### PR TITLE
feat(router): add URL parameterized routes

### DIFF
--- a/examples/params/app/static/css/style.css
+++ b/examples/params/app/static/css/style.css
@@ -1,0 +1,125 @@
+* {
+    box-sizing: border-box;
+}
+
+body {
+    font-family: system-ui, -apple-system, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 20px;
+    background: #f5f5f5;
+    color: #333;
+}
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    background: white;
+    padding: 30px;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+h1 {
+    color: #2563eb;
+    border-bottom: 2px solid #2563eb;
+    padding-bottom: 10px;
+}
+
+h2 {
+    color: #475569;
+    margin-top: 30px;
+}
+
+h3 {
+    color: #64748b;
+    margin-top: 20px;
+}
+
+p {
+    margin: 15px 0;
+}
+
+a {
+    color: #2563eb;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+ul {
+    padding-left: 25px;
+}
+
+li {
+    margin: 8px 0;
+}
+
+.code-block {
+    background: #1e293b;
+    color: #e2e8f0;
+    padding: 15px;
+    border-radius: 5px;
+    overflow-x: auto;
+    font-size: 14px;
+}
+
+pre {
+    margin: 0;
+}
+
+code {
+    font-family: 'Monaco', 'Menlo', monospace;
+}
+
+.route-demo {
+    background: #f0f9ff;
+    padding: 20px;
+    border-radius: 5px;
+    border-left: 4px solid #2563eb;
+    margin: 20px 0;
+}
+
+.route-demo.item {
+    background: #eff6ff;
+    border-left-color: #3b82f6;
+}
+
+.route-demo.category {
+    background: #f0fdf4;
+    border-left-color: #22c55e;
+}
+
+.route-demo.comment {
+    background: #fef3c7;
+    border-left-color: #f59e0b;
+}
+
+.params-box {
+    background: #f8fafc;
+    padding: 15px;
+    border-radius: 5px;
+    margin: 15px 0;
+}
+
+.nav-links {
+    display: flex;
+    gap: 15px;
+    margin: 20px 0;
+    flex-wrap: wrap;
+}
+
+.nav-links a {
+    background: #2563eb;
+    color: white;
+    padding: 8px 16px;
+    border-radius: 5px;
+    transition: background 0.2s;
+}
+
+.nav-links a:hover {
+    background: #1d4ed8;
+    text-decoration: none;
+}

--- a/examples/params/app/static/js/datastar.js
+++ b/examples/params/app/static/js/datastar.js
@@ -1,0 +1,2037 @@
+// Datastar v1.0.0-RC.8
+var ut = /🖕JS_DS🚀/.source,
+  Ge = ut.slice(0, 5),
+  je = ut.slice(4),
+  j = "datastar-fetch",
+  ee = "datastar-signal-patch";
+var P = Object.hasOwn ?? Object.prototype.hasOwnProperty.call;
+var J = (e) =>
+    e !== null &&
+    typeof e == "object" &&
+    (Object.getPrototypeOf(e) === Object.prototype ||
+      Object.getPrototypeOf(e) === null),
+  ft = (e) => {
+    for (let t in e) if (P(e, t)) return !1;
+    return !0;
+  },
+  te = (e, t) => {
+    for (let n in e) {
+      let r = e[n];
+      J(r) || Array.isArray(r) ? te(r, t) : (e[n] = t(r));
+    }
+  },
+  Re = (e) => {
+    let t = {};
+    for (let [n, r] of e) {
+      let s = n.split("."),
+        i = s.pop(),
+        o = s.reduce((a, c) => (a[c] ??= {}), t);
+      o[i] = r;
+    }
+    return t;
+  };
+var Me = [],
+  We = [],
+  Oe = 0,
+  xe = 0,
+  Be = 0,
+  Ue,
+  W,
+  Le = 0,
+  M = () => {
+    Oe++;
+  },
+  x = () => {
+    --Oe || (pt(), K());
+  },
+  k = (e) => {
+    ((Ue = W), (W = e));
+  },
+  H = () => {
+    ((W = Ue), (Ue = void 0));
+  },
+  pe = (e) => Zt.bind(0, { previousValue: e, t: e, e: 1 }),
+  Je = Symbol("computed"),
+  Pe = (e) => {
+    let t = Yt.bind(0, { e: 17, getter: e });
+    return ((t[Je] = 1), t);
+  },
+  T = (e) => {
+    let t = { d: e, e: 2 };
+    (W && ze(t, W), k(t), M());
+    try {
+      t.d();
+    } finally {
+      (x(), H());
+    }
+    return bt.bind(0, t);
+  },
+  pt = () => {
+    for (; xe < Be; ) {
+      let e = We[xe];
+      ((We[xe++] = void 0), yt(e, (e.e &= -65)));
+    }
+    ((xe = 0), (Be = 0));
+  },
+  dt = (e) => ("getter" in e ? gt(e) : ht(e, e.t)),
+  gt = (e) => {
+    (k(e), vt(e));
+    try {
+      let t = e.t;
+      return t !== (e.t = e.getter(t));
+    } finally {
+      (H(), Et(e));
+    }
+  },
+  ht = (e, t) => ((e.e = 1), e.previousValue !== (e.previousValue = t)),
+  Ke = (e) => {
+    let t = e.e;
+    if (!(t & 64)) {
+      e.e = t | 64;
+      let n = e.r;
+      n ? Ke(n.o) : (We[Be++] = e);
+    }
+  },
+  yt = (e, t) => {
+    if (t & 16 || (t & 32 && St(e.s, e))) {
+      (k(e), vt(e), M());
+      try {
+        e.d();
+      } finally {
+        (x(), H(), Et(e));
+      }
+      return;
+    }
+    t & 32 && (e.e = t & -33);
+    let n = e.s;
+    for (; n; ) {
+      let r = n.c,
+        s = r.e;
+      (s & 64 && yt(r, (r.e = s & -65)), (n = n.i));
+    }
+  },
+  Zt = (e, ...t) => {
+    if (t.length) {
+      if (e.t !== (e.t = t[0])) {
+        e.e = 17;
+        let r = e.r;
+        return (r && (Xt(r), Oe || pt()), !0);
+      }
+      return !1;
+    }
+    let n = e.t;
+    if (e.e & 16 && ht(e, n)) {
+      let r = e.r;
+      r && Ce(r);
+    }
+    return (W && ze(e, W), n);
+  },
+  Yt = (e) => {
+    let t = e.e;
+    if (t & 16 || (t & 32 && St(e.s, e))) {
+      if (gt(e)) {
+        let n = e.r;
+        n && Ce(n);
+      }
+    } else t & 32 && (e.e = t & -33);
+    return (W && ze(e, W), e.t);
+  },
+  bt = (e) => {
+    let t = e.s;
+    for (; t; ) t = Fe(t, e);
+    let n = e.r;
+    (n && Fe(n), (e.e = 0));
+  },
+  ze = (e, t) => {
+    let n = t.a;
+    if (n && n.c === e) return;
+    let r = n ? n.i : t.s;
+    if (r && r.c === e) {
+      ((r.m = Le), (t.a = r));
+      return;
+    }
+    let s = e.p;
+    if (s && s.m === Le && s.o === t) return;
+    let i = (t.a = e.p = { m: Le, c: e, o: t, l: n, i: r, u: s });
+    (r && (r.l = i), n ? (n.i = i) : (t.s = i), s ? (s.n = i) : (e.r = i));
+  },
+  Fe = (e, t = e.o) => {
+    let n = e.c,
+      r = e.l,
+      s = e.i,
+      i = e.n,
+      o = e.u;
+    if (
+      (s ? (s.l = r) : (t.a = r),
+      r ? (r.i = s) : (t.s = s),
+      i ? (i.u = o) : (n.p = o),
+      o)
+    )
+      o.n = i;
+    else if (!(n.r = i))
+      if ("getter" in n) {
+        let a = n.s;
+        if (a) {
+          n.e = 17;
+          do a = Fe(a, n);
+          while (a);
+        }
+      } else "previousValue" in n || bt(n);
+    return s;
+  },
+  Xt = (e) => {
+    let t = e.n,
+      n;
+    e: for (;;) {
+      let r = e.o,
+        s = r.e;
+      if (
+        (s & 60
+          ? s & 12
+            ? s & 4
+              ? !(s & 48) && en(e, r)
+                ? ((r.e = s | 40), (s &= 1))
+                : (s = 0)
+              : (r.e = (s & -9) | 32)
+            : (s = 0)
+          : (r.e = s | 32),
+        s & 2 && Ke(r),
+        s & 1)
+      ) {
+        let i = r.r;
+        if (i) {
+          let o = (e = i).n;
+          o && ((n = { t, f: n }), (t = o));
+          continue;
+        }
+      }
+      if ((e = t)) {
+        t = e.n;
+        continue;
+      }
+      for (; n; )
+        if (((e = n.t), (n = n.f), e)) {
+          t = e.n;
+          continue e;
+        }
+      break;
+    }
+  },
+  vt = (e) => {
+    (Le++, (e.a = void 0), (e.e = (e.e & -57) | 4));
+  },
+  Et = (e) => {
+    let t = e.a,
+      n = t ? t.i : e.s;
+    for (; n; ) n = Fe(n, e);
+    e.e &= -5;
+  },
+  St = (e, t) => {
+    let n,
+      r = 0,
+      s = !1;
+    e: for (;;) {
+      let i = e.c,
+        o = i.e;
+      if (t.e & 16) s = !0;
+      else if ((o & 17) === 17) {
+        if (dt(i)) {
+          let a = i.r;
+          (a.n && Ce(a), (s = !0));
+        }
+      } else if ((o & 33) === 33) {
+        ((e.n || e.u) && (n = { t: e, f: n }), (e = i.s), (t = i), ++r);
+        continue;
+      }
+      if (!s) {
+        let a = e.i;
+        if (a) {
+          e = a;
+          continue;
+        }
+      }
+      for (; r--; ) {
+        let a = t.r,
+          c = a.n;
+        if ((c ? ((e = n.t), (n = n.f)) : (e = a), s)) {
+          if (dt(t)) {
+            (c && Ce(a), (t = e.o));
+            continue;
+          }
+          s = !1;
+        } else t.e &= -33;
+        if (((t = e.o), e.i)) {
+          e = e.i;
+          continue e;
+        }
+      }
+      return s;
+    }
+  },
+  Ce = (e) => {
+    do {
+      let t = e.o,
+        n = t.e;
+      (n & 48) === 32 && ((t.e = n | 16), n & 2 && Ke(t));
+    } while ((e = e.n));
+  },
+  en = (e, t) => {
+    let n = t.a;
+    for (; n; ) {
+      if (n === e) return !0;
+      n = n.l;
+    }
+    return !1;
+  },
+  ie = (e) => {
+    let t = ne,
+      n = e.split(".");
+    for (let r of n) {
+      if (t == null || !P(t, r)) return;
+      t = t[r];
+    }
+    return t;
+  },
+  Ne = (e, t = "") => {
+    let n = Array.isArray(e);
+    if (n || J(e)) {
+      let r = n ? [] : {};
+      for (let i in e) r[i] = pe(Ne(e[i], `${t + i}.`));
+      let s = pe(0);
+      return new Proxy(r, {
+        get(i, o) {
+          if (!(o === "toJSON" && !P(r, o)))
+            return n && o in Array.prototype
+              ? (s(), r[o])
+              : typeof o == "symbol"
+                ? r[o]
+                : ((!P(r, o) || r[o]() == null) &&
+                    ((r[o] = pe("")), K(t + o, ""), s(s() + 1)),
+                  r[o]());
+        },
+        set(i, o, a) {
+          let c = t + o;
+          if (n && o === "length") {
+            let l = r[o] - a;
+            if (((r[o] = a), l > 0)) {
+              let u = {};
+              for (let d = a; d < r[o]; d++) u[d] = null;
+              (K(t.slice(0, -1), u), s(s() + 1));
+            }
+          } else if (P(r, o))
+            if (a == null) delete r[o];
+            else if (P(a, Je)) ((r[o] = a), K(c, ""));
+            else {
+              let l = r[o](),
+                u = `${c}.`;
+              if (J(l) && J(a)) {
+                for (let d in l) P(a, d) || (delete l[d], K(u + d, null));
+                for (let d in a) {
+                  let h = a[d];
+                  l[d] !== h && (l[d] = h);
+                }
+              } else r[o](Ne(a, u)) && K(c, a);
+            }
+          else
+            a != null &&
+              (P(a, Je)
+                ? ((r[o] = a), K(c, ""))
+                : ((r[o] = pe(Ne(a, `${c}.`))), K(c, a)),
+              s(s() + 1));
+          return !0;
+        },
+        deleteProperty(i, o) {
+          return (delete r[o], s(s() + 1), !0);
+        },
+        ownKeys() {
+          return (s(), Reflect.ownKeys(r));
+        },
+        has(i, o) {
+          return (s(), o in r);
+        },
+      });
+    }
+    return e;
+  },
+  K = (e, t) => {
+    if ((e !== void 0 && t !== void 0 && Me.push([e, t]), !Oe && Me.length)) {
+      let n = Re(Me);
+      ((Me.length = 0),
+        document.dispatchEvent(new CustomEvent(ee, { detail: n })));
+    }
+  },
+  _ = (e, { ifMissing: t } = {}) => {
+    M();
+    for (let n in e) e[n] == null ? t || delete ne[n] : Tt(e[n], n, ne, "", t);
+    x();
+  },
+  A = (e, t) => _(Re(e), t),
+  Tt = (e, t, n, r, s) => {
+    if (J(e)) {
+      (P(n, t) && (J(n[t]) || Array.isArray(n[t]))) || (n[t] = {});
+      for (let i in e)
+        e[i] == null ? s || delete n[t][i] : Tt(e[i], i, n[t], `${r + t}.`, s);
+    } else (s && P(n, t)) || (n[t] = e);
+  },
+  mt = (e) => (typeof e == "string" ? RegExp(e.replace(/^\/|\/$/g, "")) : e),
+  $ = ({ include: e = /.*/, exclude: t = /(?!)/ } = {}, n = ne) => {
+    let r = mt(e),
+      s = mt(t),
+      i = [],
+      o = [[n, ""]];
+    for (; o.length; ) {
+      let [a, c] = o.pop();
+      for (let l in a) {
+        let u = c + l;
+        J(a[l])
+          ? o.push([a[l], `${u}.`])
+          : r.test(u) && !s.test(u) && i.push([u, ie(u)]);
+      }
+    }
+    return Re(i);
+  },
+  ne = Ne({});
+var z = (e) =>
+  e instanceof HTMLElement ||
+  e instanceof SVGElement ||
+  e instanceof MathMLElement;
+var ge = (e) =>
+  e
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/([a-z])([0-9]+)/gi, "$1-$2")
+    .replace(/([0-9]+)([a-z])/gi, "$1-$2")
+    .replace(/[\s_]+/g, "-")
+    .toLowerCase();
+var At = (e) => ge(e).replace(/-/g, "_");
+var tn =
+    /^(?:(?:async\s+)?function\b|(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>)/,
+  oe = (e, t = {}) => {
+    let { reviveFunctionStrings: n = !1 } = t;
+    try {
+      return n
+        ? JSON.parse(e, (r, s) => {
+            if (typeof s != "string") return s;
+            let i = s.trim();
+            if (!tn.test(i)) return s;
+            try {
+              let o = Function(`return (${i})`)();
+              return typeof o == "function" ? o : s;
+            } catch {
+              return s;
+            }
+          })
+        : JSON.parse(e);
+    } catch {
+      return Function(`return (${e})`)();
+    }
+  },
+  wt = {
+    camel: (e) => e.replace(/-[a-z]/g, (t) => t[1].toUpperCase()),
+    snake: (e) => e.replace(/-/g, "_"),
+    pascal: (e) => e[0].toUpperCase() + wt.camel(e.slice(1)),
+  },
+  L = (e, t, n = "camel") => {
+    for (let r of t.get("case") || [n]) e = wt[r]?.(e) || e;
+    return e;
+  },
+  B = (e) => `data-${e}`,
+  Qe = (e) => e;
+var nn = "https://data-star.dev/errors",
+  he = (e, t, n = {}) => {
+    Object.assign(n, e);
+    let r = new Error(),
+      s = At(t),
+      i = new URLSearchParams({ metadata: JSON.stringify(n) }).toString(),
+      o = JSON.stringify(n, null, 2);
+    return (
+      (r.message = `${t}
+More info: ${nn}/${s}?${i}
+Context: ${o}`),
+      r
+    );
+  },
+  ye = new Map(),
+  Ze = new Map(),
+  Mt = new Map(),
+  xt = new Proxy(
+    {},
+    {
+      get: (e, t) => ye.get(t)?.apply,
+      has: (e, t) => ye.has(t),
+      ownKeys: () => Reflect.ownKeys(ye),
+      set: () => !1,
+      deleteProperty: () => !1,
+    },
+  ),
+  be = new Map(),
+  ke = [],
+  Ye = new Set(),
+  rn = new WeakSet(),
+  g = (e) => {
+    (ke.push(e),
+      ke.length === 1 &&
+        setTimeout(() => {
+          for (let t of ke) (Ye.add(t.name), Ze.set(t.name, t));
+          ((ke.length = 0), ln(), Ye.clear());
+        }));
+  },
+  V = (e) => {
+    ye.set(e.name, e);
+  };
+document.addEventListener(j, (e) => {
+  let t = Mt.get(e.detail.type);
+  t &&
+    t.apply(
+      {
+        error: he.bind(0, {
+          plugin: { type: "watcher", name: t.name },
+          element: { id: e.target.id, tag: e.target.tagName },
+        }),
+      },
+      e.detail.argsRaw,
+    );
+});
+var ve = (e) => {
+    Mt.set(e.name, e);
+  },
+  Rt = (e) => {
+    for (let t of e) {
+      let n = be.get(t);
+      if (n && be.delete(t))
+        for (let r of n.values()) for (let s of r.values()) s();
+    }
+  },
+  Lt = B("ignore"),
+  sn = `[${Lt}]`,
+  Nt = (e) => e.hasAttribute(`${Lt}__self`) || !!e.closest(sn),
+  He = (e, t) => {
+    for (let n of e)
+      if (!Nt(n)) {
+        let r = new Set();
+        for (let s in n.dataset) {
+          let i = s.replace(/[A-Z]/g, "-$&").toLowerCase();
+          (r.add(i), Xe(n, i, n.dataset[s], t));
+        }
+        for (let s of Array.from(n.attributes)) {
+          if (!s.name.startsWith("data-")) continue;
+          let i = s.name.slice(5);
+          r.has(i) || Xe(n, i, s.value, t);
+        }
+      }
+  },
+  on = (e) => {
+    for (let {
+      target: t,
+      type: n,
+      attributeName: r,
+      addedNodes: s,
+      removedNodes: i,
+    } of e)
+      if (n === "childList") {
+        for (let o of i) z(o) && (Rt([o]), Rt(o.querySelectorAll("*")));
+        for (let o of s) z(o) && (He([o]), He(o.querySelectorAll("*")));
+      } else if (
+        n === "attributes" &&
+        r.startsWith("data-") &&
+        z(t) &&
+        !Nt(t)
+      ) {
+        let o = r.slice(5),
+          a = Qe(o);
+        if (!a) continue;
+        let c = t.getAttribute(r);
+        if (c === null) {
+          let l = be.get(t);
+          if (l) {
+            let u = l.get(a);
+            if (u) {
+              for (let d of u.values()) d();
+              l.delete(a);
+            }
+          }
+        } else Xe(t, o, c);
+      }
+  },
+  an = new MutationObserver(on),
+  cn = (e) => {
+    let [t, ...n] = e.split("__"),
+      [r, s] = t.split(/:(.+)/),
+      i = new Map();
+    for (let o of n) {
+      let [a, ...c] = o.split(".");
+      i.set(a, new Set(c));
+    }
+    return { pluginName: r, key: s, mods: i };
+  };
+var ln = (e = document.documentElement, t = !0) => {
+  (z(e) && He([e], !0),
+    He(e.querySelectorAll("*"), !0),
+    t &&
+      (an.observe(e, { subtree: !0, childList: !0, attributes: !0 }),
+      rn.add(e)));
+};
+var Xe = (e, t, n, r) => {
+    let s = Qe(t);
+    if (!s) return;
+    let { pluginName: i, key: o, mods: a } = cn(s),
+      c = Ze.get(i);
+    if ((!r || Ye.has(i)) && !!c) {
+      let u = {
+          el: e,
+          rawKey: s,
+          mods: a,
+          error: he.bind(0, {
+            plugin: { type: "attribute", name: c.name },
+            element: { id: e.id, tag: e.tagName },
+            expression: { rawKey: s, key: o, value: n },
+          }),
+          key: o,
+          value: n,
+          loadedPluginNames: {
+            actions: new Set(ye.keys()),
+            attributes: new Set(Ze.keys()),
+          },
+          rx: void 0,
+        },
+        d =
+          (c.requirement &&
+            (typeof c.requirement == "string"
+              ? c.requirement
+              : c.requirement.key)) ||
+          "allowed",
+        h =
+          (c.requirement &&
+            (typeof c.requirement == "string"
+              ? c.requirement
+              : c.requirement.value)) ||
+          "allowed",
+        f = o != null && o !== "",
+        p = n != null && n !== "";
+      if (f) {
+        if (d === "denied") throw u.error("KeyNotAllowed");
+      } else if (d === "must") throw u.error("KeyRequired");
+      if (p) {
+        if (h === "denied") throw u.error("ValueNotAllowed");
+      } else if (h === "must") throw u.error("ValueRequired");
+      if (d === "exclusive" || h === "exclusive") {
+        if (f && p) throw u.error("KeyAndValueProvided");
+        if (!f && !p) throw u.error("KeyOrValueRequired");
+      }
+      let m = new Map();
+      if (p) {
+        let v;
+        u.rx = (...C) => (
+          v ||
+            (v = un(n, {
+              returnsValue: c.returnsValue,
+              argNames: c.argNames,
+              cleanups: m,
+            })),
+          v(e, ...C)
+        );
+      }
+      let b = c.apply(u);
+      b && m.set("attribute", b);
+      let R = be.get(e);
+      if (R) {
+        let v = R.get(s);
+        if (v) for (let C of v.values()) C();
+      } else ((R = new Map()), be.set(e, R));
+      R.set(s, m);
+    }
+  },
+  un = (
+    e,
+    { returnsValue: t = !1, argNames: n = [], cleanups: r = new Map() } = {},
+  ) => {
+    let s = "";
+    if (t) {
+      let c =
+          /(\/(\\\/|[^/])*\/|"(\\"|[^"])*"|'(\\'|[^'])*'|`(\\`|[^`])*`|\(\s*((function)\s*\(\s*\)|(\(\s*\))\s*=>)\s*(?:\{[\s\S]*?\}|[^;){]*)\s*\)\s*\(\s*\)|[^;])+/gm,
+        l = e.trim().match(c);
+      if (l) {
+        let u = l.length - 1,
+          d = l[u].trim();
+        (d.startsWith("return") || (l[u] = `return (${d});`),
+          (s = l.join(`;
+`)));
+      }
+    } else s = e.trim();
+    let i = new Map(),
+      o = RegExp(`(?:${Ge})(.*?)(?:${je})`, "gm"),
+      a = 0;
+    for (let c of s.matchAll(o)) {
+      let l = c[1],
+        u = `__escaped${a++}`;
+      (i.set(u, l), (s = s.replace(Ge + l + je, u)));
+    }
+    ((s = s.replace(
+      /("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\$]|\$(?!\{))*`)|\$\{([^{}]*)\}|\$([a-zA-Z_\d]\w*(?:[.-]\w+)*)/g,
+      (c, l, u, d) =>
+        l
+          ? c
+          : u !== void 0
+            ? `\${${u.replace(/\$([a-zA-Z_\d]\w*(?:[.-]\w+)*)/g, (h, f) => f.split(".").reduce((p, m) => `${p}['${m}']`, "$"))}}`
+            : d.split(".").reduce((h, f) => `${h}['${f}']`, "$"),
+    )),
+      (s = s.replaceAll(/@([A-Za-z_$][\w$]*)\(/g, '__action("$1",evt,')));
+    for (let [c, l] of i) s = s.replace(c, l);
+    try {
+      let c = Function("el", "$", "__action", "evt", ...n, s);
+      return (l, ...u) => {
+        let d = (h, f, ...p) => {
+          let m = he.bind(0, {
+              plugin: { type: "action", name: h },
+              element: { id: l.id, tag: l.tagName },
+              expression: { fnContent: s, value: e },
+            }),
+            b = xt[h];
+          if (b) return b({ el: l, evt: f, error: m, cleanups: r }, ...p);
+          throw m("UndefinedAction");
+        };
+        try {
+          return c(l, ne, d, void 0, ...u);
+        } catch (h) {
+          throw (
+            console.error(h),
+            he(
+              {
+                element: { id: l.id, tag: l.tagName },
+                expression: { fnContent: s, value: e },
+                error: h.message,
+              },
+              "ExecuteExpression",
+            )
+          );
+        }
+      };
+    } catch (c) {
+      throw (
+        console.error(c),
+        he(
+          { expression: { fnContent: s, value: e }, error: c.message },
+          "GenerateExpression",
+        )
+      );
+    }
+  };
+V({
+  name: "peek",
+  apply(e, t) {
+    k();
+    try {
+      return t();
+    } finally {
+      H();
+    }
+  },
+});
+V({
+  name: "setAll",
+  apply(e, t, n) {
+    k();
+    let r = $(n);
+    (te(r, () => t), _(r), H());
+  },
+});
+V({
+  name: "toggleAll",
+  apply(e, t) {
+    k();
+    let n = $(t);
+    (te(n, (r) => !r), _(n), H());
+  },
+});
+var Ft = new WeakMap(),
+  Ee = (e, t, n = !0) =>
+    V({
+      name: e,
+      apply: async (
+        { el: r, evt: s, error: i, cleanups: o },
+        a,
+        {
+          selector: c,
+          headers: l,
+          contentType: u = "json",
+          filterSignals: { include: d = /.*/, exclude: h = /(^|\.)_/ } = {},
+          openWhenHidden: f = n,
+          payload: p,
+          requestCancellation: m = "auto",
+          retry: b = "auto",
+          retryInterval: R = 1e3,
+          retryScaler: v = 2,
+          retryMaxWaitMs: C = 3e4,
+          retryMaxCount: _e = 10,
+        } = {},
+      ) => {
+        let Y = m instanceof AbortController ? m : new AbortController();
+        ((m === "auto" || m === "cleanup") &&
+          (Ft.get(r)?.abort(), Ft.set(r, Y)),
+          m === "cleanup" &&
+            (o.get(`@${e}`)?.(),
+            o.set(`@${e}`, async () => {
+              (Y.abort(), await Promise.resolve());
+            })));
+        let X = () => {};
+        try {
+          if (!a?.length) throw i("FetchNoUrlProvided", { action: V });
+          let fe = {
+            Accept: "text/event-stream, text/html, application/json",
+            "Datastar-Request": !0,
+          };
+          u === "json" && (fe["Content-Type"] = "application/json");
+          let q = Object.assign({}, fe, l),
+            N = {
+              input: "",
+              method: t,
+              headers: q,
+              openWhenHidden: f,
+              retry: b,
+              retryInterval: R,
+              retryScaler: v,
+              retryMaxWaitMs: C,
+              retryMaxCount: _e,
+              signal: Y.signal,
+              onopen: async (y) => {
+                y.status >= 400 && re(fn, r, { status: y.status.toString() });
+              },
+              onmessage: (y) => {
+                if (!y.event.startsWith("datastar")) return;
+                let U = y.event,
+                  E = {};
+                for (let F of y.data.split(`
+`)) {
+                  let S = F.indexOf(" "),
+                    O = F.slice(0, S),
+                    w = F.slice(S + 1);
+                  (E[O] ||= []).push(w);
+                }
+                let D = Object.fromEntries(
+                  Object.entries(E).map(([F, S]) => [
+                    F,
+                    S.join(`
+`),
+                  ]),
+                );
+                re(U, r, D);
+              },
+              onerror: (y) => {
+                if (Ct(y)) throw y("FetchExpectedTextEventStream", { url: a });
+                y &&
+                  (console.error(y.message), re(dn, r, { message: y.message }));
+              },
+            },
+            Ve = () => {
+              let y = new URL(a, document.baseURI),
+                U = new URLSearchParams(y.search);
+              if (u === "json") {
+                (k(),
+                  (p = p !== void 0 ? p : $({ include: d, exclude: h })),
+                  H());
+                let E = JSON.stringify(p);
+                t === "GET" ? U.set("datastar", E) : (N.body = E);
+              } else if (u === "form") {
+                let E = c ? document.querySelector(c) : r.closest("form");
+                if (!E)
+                  throw i("FetchFormNotFound", { action: V, selector: c });
+                if (!E.noValidate && !E.checkValidity()) {
+                  E.reportValidity();
+                  return;
+                }
+                let D = new FormData(E),
+                  F = r;
+                if (r === E && s instanceof SubmitEvent) F = s.submitter;
+                else {
+                  let w = (de) => de.preventDefault();
+                  (E.addEventListener("submit", w),
+                    (X = () => {
+                      E.removeEventListener("submit", w);
+                    }));
+                }
+                if (F instanceof HTMLButtonElement) {
+                  let w = F.getAttribute("name");
+                  w && D.append(w, F.value);
+                }
+                let S = E.getAttribute("enctype") === "multipart/form-data";
+                S || (q["Content-Type"] = "application/x-www-form-urlencoded");
+                let O = new URLSearchParams(D);
+                if (t === "GET") for (let [w, de] of O) U.append(w, de);
+                else S ? (N.body = D) : (N.body = O);
+              } else
+                throw i("FetchInvalidContentType", {
+                  action: V,
+                  contentType: u,
+                });
+              return ((y.search = U.toString()), (N.input = y.toString()), N);
+            };
+          re(et, r, {});
+          try {
+            await bn(r, Ve);
+          } catch (y) {
+            if (!Ct(y))
+              throw i("FetchFailed", { method: t, url: a, error: y.message });
+          }
+        } finally {
+          (re(tt, r, {}), X(), o.delete(`@${e}`));
+        }
+      },
+    });
+Ee("get", "GET", !1);
+Ee("patch", "PATCH");
+Ee("post", "POST");
+Ee("put", "PUT");
+Ee("delete", "DELETE");
+var et = "started",
+  tt = "finished",
+  fn = "error",
+  dn = "retrying",
+  mn = "retries-failed",
+  re = (e, t, n) =>
+    document.dispatchEvent(
+      new CustomEvent(j, { detail: { type: e, el: t, argsRaw: n } }),
+    ),
+  Ct = (e) => `${e}`.includes("text/event-stream"),
+  pn = async (e, t) => {
+    let n = e.getReader(),
+      r = await n.read();
+    for (; !r.done; ) (t(r.value), (r = await n.read()));
+  },
+  gn = (e) => {
+    let t,
+      n,
+      r,
+      s = !1;
+    return (i) => {
+      t ? (t = yn(t, i)) : ((t = i), (n = 0), (r = -1));
+      let o = t.length,
+        a = 0;
+      for (; n < o; ) {
+        s && (t[n] === 10 && (a = ++n), (s = !1));
+        let c = -1;
+        for (; n < o && c === -1; ++n)
+          switch (t[n]) {
+            case 58:
+              r === -1 && (r = n - a);
+              break;
+            case 13:
+              s = !0;
+            case 10:
+              c = n;
+              break;
+          }
+        if (c === -1) break;
+        (e(t.subarray(a, c), r), (a = n), (r = -1));
+      }
+      a === o ? (t = void 0) : a && ((t = t.subarray(a)), (n -= a));
+    };
+  },
+  hn = (e, t, n) => {
+    let r = Ot(),
+      s = new TextDecoder();
+    return (i, o) => {
+      if (!i.length) (n?.(r), (r = Ot()));
+      else if (o > 0) {
+        let a = s.decode(i.subarray(0, o)),
+          c = o + (i[o + 1] === 32 ? 2 : 1),
+          l = s.decode(i.subarray(c));
+        switch (a) {
+          case "data":
+            r.data = r.data
+              ? `${r.data}
+${l}`
+              : l;
+            break;
+          case "event":
+            r.event = l;
+            break;
+          case "id":
+            e((r.id = l));
+            break;
+          case "retry": {
+            let u = +l;
+            Number.isNaN(u) || t((r.retry = u));
+            break;
+          }
+        }
+      }
+    };
+  },
+  yn = (e, t) => {
+    let n = new Uint8Array(e.length + t.length);
+    return (n.set(e), n.set(t, e.length), n);
+  },
+  Ot = () => ({ data: "", event: "", id: "", retry: void 0 }),
+  bn = (e, t) =>
+    new Promise((n, r) => {
+      let s = t();
+      if (!s) return;
+      let {
+          input: i,
+          signal: o,
+          headers: a,
+          onopen: c,
+          onmessage: l,
+          onclose: u,
+          onerror: d,
+          openWhenHidden: h,
+          fetch: f,
+          retry: p = "auto",
+          retryInterval: m = 1e3,
+          retryScaler: b = 2,
+          retryMaxWaitMs: R = 3e4,
+          retryMaxCount: v = 10,
+          responseOverrides: C,
+          ..._e
+        } = s,
+        Y = { ...a },
+        X,
+        fe = () => {
+          (X.abort(), document.hidden || D());
+        };
+      h || document.addEventListener("visibilitychange", fe);
+      let q,
+        N = () => {
+          (document.removeEventListener("visibilitychange", fe),
+            clearTimeout(q),
+            X.abort());
+        };
+      o?.addEventListener("abort", () => {
+        (N(), n());
+      });
+      let Ve = f || window.fetch,
+        y = c || (() => {}),
+        U = 0,
+        E = m,
+        D = async () => {
+          X = new AbortController();
+          let F = X.signal;
+          try {
+            let S = await Ve(i, { ..._e, headers: Y, signal: F });
+            await y(S);
+            let O = async (G, me, De, Ae, ...Qt) => {
+                let lt = { [De]: await me.text() };
+                for (let $e of Qt) {
+                  let qe = me.headers.get(`datastar-${ge($e)}`);
+                  if (Ae) {
+                    let we = Ae[$e];
+                    we &&
+                      (qe = typeof we == "string" ? we : JSON.stringify(we));
+                  }
+                  qe && (lt[$e] = qe);
+                }
+                (re(G, e, lt), N(), n());
+              },
+              w = S.status,
+              de = w === 204,
+              ct = w >= 300 && w < 400,
+              zt = w >= 400 && w < 600;
+            if (w !== 200) {
+              if (
+                (u?.(),
+                p !== "never" &&
+                  !de &&
+                  !ct &&
+                  (p === "always" || (p === "error" && zt)))
+              ) {
+                (clearTimeout(q), (q = setTimeout(D, m)));
+                return;
+              }
+              (N(), n());
+              return;
+            }
+            ((U = 0), (m = E));
+            let Ie = S.headers.get("Content-Type");
+            if (Ie?.includes("text/html"))
+              return await O(
+                "datastar-patch-elements",
+                S,
+                "elements",
+                C,
+                "selector",
+                "mode",
+                "namespace",
+                "useViewTransition",
+              );
+            if (Ie?.includes("application/json"))
+              return await O(
+                "datastar-patch-signals",
+                S,
+                "signals",
+                C,
+                "onlyIfMissing",
+              );
+            if (Ie?.includes("text/javascript")) {
+              let G = document.createElement("script"),
+                me = S.headers.get("datastar-script-attributes");
+              if (me)
+                for (let [De, Ae] of Object.entries(JSON.parse(me)))
+                  G.setAttribute(De, Ae);
+              ((G.textContent = await S.text()),
+                document.head.appendChild(G),
+                N());
+              return;
+            }
+            if (
+              (await pn(
+                S.body,
+                gn(
+                  hn(
+                    (G) => {
+                      G ? (Y["last-event-id"] = G) : delete Y["last-event-id"];
+                    },
+                    (G) => {
+                      E = m = G;
+                    },
+                    l,
+                  ),
+                ),
+              ),
+              u?.(),
+              p === "always" && !ct)
+            ) {
+              (clearTimeout(q), (q = setTimeout(D, m)));
+              return;
+            }
+            (N(), n());
+          } catch (S) {
+            if (!F.aborted)
+              try {
+                let O = d?.(S) || m;
+                (clearTimeout(q),
+                  (q = setTimeout(D, O)),
+                  (m = Math.min(m * b, R)),
+                  ++U >= v
+                    ? (re(mn, e, {}), N(), r("Max retries reached."))
+                    : console.error(
+                        `Datastar failed to reach ${i.toString()} retrying in ${O}ms.`,
+                      ));
+              } catch (O) {
+                (N(), r(O));
+              }
+          }
+        };
+      D();
+    });
+g({
+  name: "attr",
+  requirement: { value: "must" },
+  returnsValue: !0,
+  apply({ el: e, key: t, rx: n }) {
+    let r = (a, c) => {
+        c === "" || c === !0
+          ? e.setAttribute(a, "")
+          : c === !1 || c == null
+            ? e.removeAttribute(a)
+            : typeof c == "string"
+              ? e.setAttribute(a, c)
+              : typeof c == "function"
+                ? e.setAttribute(a, c.toString())
+                : e.setAttribute(
+                    a,
+                    JSON.stringify(c, (l, u) =>
+                      typeof u == "function" ? u.toString() : u,
+                    ),
+                  );
+      },
+      s = t
+        ? () => {
+            i.disconnect();
+            let a = n();
+            (r(t, a), i.observe(e, { attributeFilter: [t] }));
+          }
+        : () => {
+            i.disconnect();
+            let a = n(),
+              c = Object.keys(a);
+            for (let l of c) r(l, a[l]);
+            i.observe(e, { attributeFilter: c });
+          },
+      i = new MutationObserver(s),
+      o = T(s);
+    return () => {
+      (i.disconnect(), o());
+    };
+  },
+});
+var vn = /^data:(?<mime>[^;]+);base64,(?<contents>.*)$/,
+  Pt = Symbol("empty"),
+  kt = B("bind");
+g({
+  name: "bind",
+  requirement: "exclusive",
+  apply({ el: e, key: t, mods: n, value: r, error: s }) {
+    let i = t != null ? L(t, n) : r,
+      o = (f, p) => (p === "number" ? +f.value : f.value),
+      a = (f) => {
+        e.value = `${f}`;
+      };
+    if (e instanceof HTMLInputElement)
+      switch (e.type) {
+        case "range":
+        case "number":
+          o = (f, p) => (p === "string" ? f.value : +f.value);
+          break;
+        case "checkbox":
+          ((o = (f, p) =>
+            f.value !== "on"
+              ? p === "boolean"
+                ? f.checked
+                : f.checked
+                  ? f.value
+                  : ""
+              : p === "string"
+                ? f.checked
+                  ? f.value
+                  : ""
+                : f.checked),
+            (a = (f) => {
+              e.checked = typeof f == "string" ? f === e.value : f;
+            }));
+          break;
+        case "radio":
+          (e.getAttribute("name")?.length || e.setAttribute("name", i),
+            (o = (f, p) =>
+              f.checked ? (p === "number" ? +f.value : f.value) : Pt),
+            (a = (f) => {
+              e.checked = f === (typeof f == "number" ? +e.value : e.value);
+            }));
+          break;
+        case "file": {
+          let f = () => {
+            let p = [...(e.files || [])],
+              m = [];
+            Promise.all(
+              p.map(
+                (b) =>
+                  new Promise((R) => {
+                    let v = new FileReader();
+                    ((v.onload = () => {
+                      if (typeof v.result != "string")
+                        throw s("InvalidFileResultType", {
+                          resultType: typeof v.result,
+                        });
+                      let C = v.result.match(vn);
+                      if (!C?.groups)
+                        throw s("InvalidDataUri", { result: v.result });
+                      m.push({
+                        name: b.name,
+                        contents: C.groups.contents,
+                        mime: C.groups.mime,
+                      });
+                    }),
+                      (v.onloadend = () => R()),
+                      v.readAsDataURL(b));
+                  }),
+              ),
+            ).then(() => {
+              A([[i, m]]);
+            });
+          };
+          return (
+            e.addEventListener("change", f),
+            e.addEventListener("input", f),
+            () => {
+              (e.removeEventListener("change", f),
+                e.removeEventListener("input", f));
+            }
+          );
+        }
+      }
+    else if (e instanceof HTMLSelectElement) {
+      if (e.multiple) {
+        let f = new Map();
+        ((o = (p) =>
+          [...p.selectedOptions].map((m) => {
+            let b = f.get(m.value);
+            return b === "string" || b == null ? m.value : +m.value;
+          })),
+          (a = (p) => {
+            for (let m of e.options)
+              p.includes(m.value)
+                ? (f.set(m.value, "string"), (m.selected = !0))
+                : p.includes(+m.value)
+                  ? (f.set(m.value, "number"), (m.selected = !0))
+                  : (m.selected = !1);
+          }));
+      }
+    } else
+      e instanceof HTMLTextAreaElement ||
+        ((o = (f) => ("value" in f ? f.value : f.getAttribute("value"))),
+        (a = (f) => {
+          "value" in e ? (e.value = f) : e.setAttribute("value", f);
+        }));
+    let c = ie(i),
+      l = typeof c,
+      u = i;
+    if (Array.isArray(c) && !(e instanceof HTMLSelectElement && e.multiple)) {
+      let f = t || r,
+        p = document.querySelectorAll(
+          `[${kt}\\:${CSS.escape(f)}],[${kt}="${CSS.escape(f)}"]`,
+        ),
+        m = [],
+        b = 0;
+      for (let R of p) {
+        if ((m.push([`${u}.${b}`, o(R, "none")]), e === R)) break;
+        b++;
+      }
+      (A(m, { ifMissing: !0 }), (u = `${u}.${b}`));
+    } else A([[u, o(e, l)]], { ifMissing: !0 });
+    let d = () => {
+      let f = ie(u);
+      if (f != null) {
+        let p = o(e, typeof f);
+        p !== Pt && A([[u, p]]);
+      }
+    };
+    (e.addEventListener("input", d), e.addEventListener("change", d));
+    let h = T(() => {
+      a(ie(u));
+    });
+    return () => {
+      (h(),
+        e.removeEventListener("input", d),
+        e.removeEventListener("change", d));
+    };
+  },
+});
+g({
+  name: "class",
+  requirement: { value: "must" },
+  returnsValue: !0,
+  apply({ key: e, el: t, mods: n, rx: r }) {
+    e &&= L(e, n, "kebab");
+    let s,
+      i = () => {
+        (o.disconnect(), (s = e ? { [e]: r() } : r()));
+        for (let c in s) {
+          let l = c.split(/\s+/).filter((u) => u.length > 0);
+          if (s[c])
+            for (let u of l) t.classList.contains(u) || t.classList.add(u);
+          else
+            for (let u of l) t.classList.contains(u) && t.classList.remove(u);
+        }
+        o.observe(t, { attributeFilter: ["class"] });
+      },
+      o = new MutationObserver(i),
+      a = T(i);
+    return () => {
+      (o.disconnect(), a());
+      for (let c in s) {
+        let l = c.split(/\s+/).filter((u) => u.length > 0);
+        for (let u of l) t.classList.remove(u);
+      }
+    };
+  },
+});
+g({
+  name: "computed",
+  requirement: { value: "must" },
+  returnsValue: !0,
+  apply({ key: e, mods: t, rx: n, error: r }) {
+    if (e) A([[L(e, t), Pe(n)]]);
+    else {
+      let s = Object.assign({}, n());
+      (te(s, (i) => {
+        if (typeof i == "function") return Pe(i);
+        throw r("ComputedExpectedFunction");
+      }),
+        _(s));
+    }
+  },
+});
+g({
+  name: "effect",
+  requirement: { key: "denied", value: "must" },
+  apply: ({ rx: e }) => T(e),
+});
+g({
+  name: "indicator",
+  requirement: "exclusive",
+  apply({ el: e, key: t, mods: n, value: r }) {
+    let s = t != null ? L(t, n) : r;
+    A([[s, !1]]);
+    let i = (o) => {
+      let { type: a, el: c } = o.detail;
+      if (c === e)
+        switch (a) {
+          case et:
+            A([[s, !0]]);
+            break;
+          case tt:
+            A([[s, !1]]);
+            break;
+        }
+    };
+    return (
+      document.addEventListener(j, i),
+      () => {
+        (A([[s, !1]]), document.removeEventListener(j, i));
+      }
+    );
+  },
+});
+var Q = (e) => {
+    if (!e || e.size <= 0) return 0;
+    for (let t of e) {
+      if (t.endsWith("ms")) return +t.replace("ms", "");
+      if (t.endsWith("s")) return +t.replace("s", "") * 1e3;
+      try {
+        return Number.parseFloat(t);
+      } catch {}
+    }
+    return 0;
+  },
+  se = (e, t, n = !1) => (e ? e.has(t.toLowerCase()) : n),
+  Ht = (e, t = "") => {
+    if (e && e.size > 0) for (let n of e) return n;
+    return t;
+  };
+var nt =
+    (e, t) =>
+    (...n) => {
+      setTimeout(() => {
+        e(...n);
+      }, t);
+    },
+  _t = (e, t, n = !0, r = !1, s = !1) => {
+    let i = null,
+      o = 0;
+    return (...a) => {
+      (n && !o ? (e(...a), (i = null)) : (i = a),
+        (!o || s) &&
+          (o && clearTimeout(o),
+          (o = setTimeout(() => {
+            (r && i !== null && e(...i), (i = null), (o = 0));
+          }, t))));
+    };
+  },
+  ae = (e, t) => {
+    let n = t.get("delay");
+    if (n) {
+      let i = Q(n);
+      e = nt(e, i);
+    }
+    let r = t.get("debounce");
+    if (r) {
+      let i = Q(r),
+        o = se(r, "leading", !1),
+        a = !se(r, "notrailing", !1);
+      e = _t(e, i, o, a, !0);
+    }
+    let s = t.get("throttle");
+    if (s) {
+      let i = Q(s),
+        o = !se(s, "noleading", !1),
+        a = se(s, "trailing", !1);
+      e = _t(e, i, o, a);
+    }
+    return e;
+  };
+var rt = !!document.startViewTransition,
+  Z = (e, t) => {
+    if (t.has("viewtransition") && rt) {
+      let n = e;
+      e = (...r) => document.startViewTransition(() => n(...r));
+    }
+    return e;
+  };
+g({
+  name: "init",
+  requirement: { key: "denied", value: "must" },
+  apply({ rx: e, mods: t }) {
+    let n = () => {
+      (M(), e(), x());
+    };
+    n = Z(n, t);
+    let r = 0,
+      s = t.get("delay");
+    (s && ((r = Q(s)), r > 0 && (n = nt(n, r))), n());
+  },
+});
+g({
+  name: "json-signals",
+  requirement: { key: "denied" },
+  apply({ el: e, value: t, mods: n }) {
+    let r = n.has("terse") ? 0 : 2,
+      s = {};
+    t && (s = oe(t));
+    let i = () => {
+        (o.disconnect(),
+          (e.textContent = JSON.stringify($(s), null, r)),
+          o.observe(e, { childList: !0, characterData: !0, subtree: !0 }));
+      },
+      o = new MutationObserver(i),
+      a = T(i);
+    return () => {
+      (o.disconnect(), a());
+    };
+  },
+});
+g({
+  name: "on",
+  requirement: "must",
+  argNames: ["evt"],
+  apply({ el: e, key: t, mods: n, rx: r }) {
+    let s = e;
+    n.has("window") && (s = window);
+    let i = (c) => {
+      (c &&
+        (n.has("prevent") && c.preventDefault(),
+        n.has("stop") && c.stopPropagation()),
+        M(),
+        r(c),
+        x());
+    };
+    ((i = Z(i, n)), (i = ae(i, n)));
+    let o = {
+      capture: n.has("capture"),
+      passive: n.has("passive"),
+      once: n.has("once"),
+    };
+    if (n.has("outside")) {
+      s = document;
+      let c = i;
+      i = (l) => {
+        e.contains(l?.target) || c(l);
+      };
+    }
+    let a = L(t, n, "kebab");
+    if (
+      ((a === j || a === ee) && (s = document),
+      e instanceof HTMLFormElement && a === "submit")
+    ) {
+      let c = i;
+      i = (l) => {
+        (l?.preventDefault(), c(l));
+      };
+    }
+    return (
+      s.addEventListener(a, i, o),
+      () => {
+        s.removeEventListener(a, i);
+      }
+    );
+  },
+});
+var Vt = (e, t, n) => Math.max(t, Math.min(n, e));
+var st = new WeakSet();
+g({
+  name: "on-intersect",
+  requirement: { key: "denied", value: "must" },
+  apply({ el: e, mods: t, rx: n }) {
+    let r = () => {
+      (M(), n(), x());
+    };
+    ((r = Z(r, t)), (r = ae(r, t)));
+    let s = { threshold: 0 };
+    if (t.has("full")) s.threshold = 1;
+    else if (t.has("half")) s.threshold = 0.5;
+    else {
+      let a = t.get("threshold");
+      a && (s.threshold = Vt(Number(Ht(a)), 0, 100) / 100);
+    }
+    let i = t.has("exit"),
+      o = new IntersectionObserver((a) => {
+        for (let c of a)
+          c.isIntersecting !== i && (r(), o && st.has(e) && o.disconnect());
+      }, s);
+    return (
+      o.observe(e),
+      t.has("once") && st.add(e),
+      () => {
+        (t.has("once") || st.delete(e), o && (o.disconnect(), (o = null)));
+      }
+    );
+  },
+});
+g({
+  name: "on-interval",
+  requirement: { key: "denied", value: "must" },
+  apply({ mods: e, rx: t }) {
+    let n = () => {
+      (M(), t(), x());
+    };
+    n = Z(n, e);
+    let r = 1e3,
+      s = e.get("duration");
+    s && ((r = Q(s)), se(s, "leading", !1) && n());
+    let i = setInterval(n, r);
+    return () => {
+      clearInterval(i);
+    };
+  },
+});
+g({
+  name: "on-signal-patch",
+  requirement: { value: "must" },
+  argNames: ["patch"],
+  returnsValue: !0,
+  apply({ el: e, key: t, mods: n, rx: r, error: s }) {
+    if (t && t !== "filter") throw s("KeyNotAllowed");
+    let i = B(`${this.name}-filter`),
+      o = e.getAttribute(i),
+      a = {};
+    o && (a = oe(o));
+    let c = !1,
+      l = ae((u) => {
+        if (c) return;
+        let d = $(a, u.detail);
+        if (!ft(d)) {
+          ((c = !0), M());
+          try {
+            r(d);
+          } finally {
+            (x(), (c = !1));
+          }
+        }
+      }, n);
+    return (
+      document.addEventListener(ee, l),
+      () => {
+        document.removeEventListener(ee, l);
+      }
+    );
+  },
+});
+g({
+  name: "ref",
+  requirement: "exclusive",
+  apply({ el: e, key: t, mods: n, value: r }) {
+    let s = t != null ? L(t, n) : r;
+    A([[s, e]]);
+  },
+});
+var It = "none",
+  Dt = "display";
+g({
+  name: "show",
+  requirement: { key: "denied", value: "must" },
+  returnsValue: !0,
+  apply({ el: e, rx: t }) {
+    let n = () => {
+        (r.disconnect(),
+          t()
+            ? e.style.display === It && e.style.removeProperty(Dt)
+            : e.style.setProperty(Dt, It),
+          r.observe(e, { attributeFilter: ["style"] }));
+      },
+      r = new MutationObserver(n),
+      s = T(n);
+    return () => {
+      (r.disconnect(), s());
+    };
+  },
+});
+g({
+  name: "signals",
+  returnsValue: !0,
+  apply({ key: e, mods: t, rx: n }) {
+    let r = t.has("ifmissing");
+    if (e) {
+      e = L(e, t);
+      let s = n?.();
+      A([[e, s]], { ifMissing: r });
+    } else {
+      let s = Object.assign({}, n?.());
+      _(s, { ifMissing: r });
+    }
+  },
+});
+g({
+  name: "style",
+  requirement: { value: "must" },
+  returnsValue: !0,
+  apply({ key: e, el: t, rx: n }) {
+    let { style: r } = t,
+      s = new Map(),
+      i = (l, u) => {
+        let d = s.get(l);
+        !u && u !== 0
+          ? d !== void 0 && (d ? r.setProperty(l, d) : r.removeProperty(l))
+          : (d === void 0 && s.set(l, r.getPropertyValue(l)),
+            r.setProperty(l, String(u)));
+      },
+      o = () => {
+        if ((a.disconnect(), e)) i(e, n());
+        else {
+          let l = n();
+          for (let [u, d] of s)
+            u in l || (d ? r.setProperty(u, d) : r.removeProperty(u));
+          for (let u in l) i(ge(u), l[u]);
+        }
+        a.observe(t, { attributeFilter: ["style"] });
+      },
+      a = new MutationObserver(o),
+      c = T(o);
+    return () => {
+      (a.disconnect(), c());
+      for (let [l, u] of s) u ? r.setProperty(l, u) : r.removeProperty(l);
+    };
+  },
+});
+g({
+  name: "text",
+  requirement: { key: "denied", value: "must" },
+  returnsValue: !0,
+  apply({ el: e, rx: t }) {
+    let n = () => {
+        (r.disconnect(),
+          (e.textContent = `${t()}`),
+          r.observe(e, { childList: !0, characterData: !0, subtree: !0 }));
+      },
+      r = new MutationObserver(n),
+      s = T(n);
+    return () => {
+      (r.disconnect(), s());
+    };
+  },
+});
+var $t = (e, t) => e.includes(t),
+  En = [
+    "remove",
+    "outer",
+    "inner",
+    "replace",
+    "prepend",
+    "append",
+    "before",
+    "after",
+  ],
+  Sn = ["html", "svg", "mathml"];
+ve({
+  name: "datastar-patch-elements",
+  apply(e, t) {
+    let n = typeof t.selector == "string" ? t.selector : "",
+      r = typeof t.mode == "string" ? t.mode : "outer",
+      s = typeof t.namespace == "string" ? t.namespace : "html",
+      i = typeof t.useViewTransition == "string" ? t.useViewTransition : "",
+      o = t.elements;
+    if (!$t(En, r)) throw e.error("PatchElementsInvalidMode", { mode: r });
+    if (!n && r !== "outer" && r !== "replace")
+      throw e.error("PatchElementsExpectedSelector");
+    if (!$t(Sn, s))
+      throw e.error("PatchElementsInvalidNamespace", { namespace: s });
+    let a = {
+      selector: n,
+      mode: r,
+      namespace: s,
+      useViewTransition: i.trim() === "true",
+      elements: o,
+    };
+    rt && a.useViewTransition
+      ? document.startViewTransition(() => qt(e, a))
+      : qt(e, a);
+  },
+});
+var qt = (
+    { error: e },
+    { selector: t, mode: n, namespace: r, elements: s },
+  ) => {
+    let i = document.createDocumentFragment(),
+      o = typeof s != "string" && !!s;
+    if (typeof s == "string") {
+      let a = s.replace(/<svg(\s[^>]*>|>)([\s\S]*?)<\/svg>/gim, ""),
+        c = /<\/html>/.test(a),
+        l = /<\/head>/.test(a),
+        u = /<\/body>/.test(a),
+        d = r === "svg" ? "svg" : r === "mathml" ? "math" : "",
+        h = d ? `<${d}>${s}</${d}>` : s,
+        f = new DOMParser().parseFromString(
+          c || l || u ? s : `<body><template>${h}</template></body>`,
+          "text/html",
+        );
+      if (c) i.appendChild(f.documentElement);
+      else if (l && u) (i.appendChild(f.head), i.appendChild(f.body));
+      else if (l) i.appendChild(f.head);
+      else if (u) i.appendChild(f.body);
+      else if (d) {
+        let p = f.querySelector("template").content.querySelector(d);
+        for (let m of p.childNodes) i.appendChild(m);
+      } else i = f.querySelector("template").content;
+    } else
+      s &&
+        (s instanceof DocumentFragment
+          ? (i = s)
+          : s instanceof Element && i.appendChild(s));
+    if (!t && (n === "outer" || n === "replace")) {
+      let a = Array.from(i.children);
+      for (let c of a) {
+        let l;
+        if (c instanceof HTMLHtmlElement) l = document.documentElement;
+        else if (c instanceof HTMLBodyElement) l = document.body;
+        else if (c instanceof HTMLHeadElement) l = document.head;
+        else if (((l = document.getElementById(c.id)), !l)) {
+          console.warn(e("PatchElementsNoTargetsFound"), {
+            element: { id: c.id },
+          });
+          continue;
+        }
+        jt(n, c, [l], o);
+      }
+    } else {
+      let a = document.querySelectorAll(t);
+      if (!a.length) {
+        console.warn(e("PatchElementsNoTargetsFound"), { selector: t });
+        return;
+      }
+      let c = o && n !== "remove" ? [a[0]] : a;
+      jt(n, i, c, o);
+    }
+  },
+  ot = new WeakSet();
+for (let e of document.querySelectorAll("script")) ot.add(e);
+var Ut = (e) => {
+    let t = e instanceof HTMLScriptElement ? [e] : e.querySelectorAll("script");
+    for (let n of t)
+      if (!ot.has(n)) {
+        let r = document.createElement("script");
+        for (let { name: s, value: i } of n.attributes) r.setAttribute(s, i);
+        ((r.text = n.text), n.replaceWith(r), ot.add(r));
+      }
+  },
+  Gt = (e, t, n, r) => {
+    let s = !1;
+    for (let i of e) {
+      if (r && s) break;
+      let o = r ? t : t.cloneNode(!0);
+      (Ut(o), i[n](o), (s = !0));
+    }
+  },
+  jt = (e, t, n, r) => {
+    switch (e) {
+      case "remove":
+        for (let s of n) s.remove();
+        break;
+      case "outer":
+      case "inner":
+        {
+          let s = !1;
+          for (let i of n) {
+            if (r && s) break;
+            let o = r ? t : t.cloneNode(!0);
+            (An(i, o, e), Ut(i));
+            let a = i.closest("[data-scope-children]");
+            (a &&
+              a.dispatchEvent(
+                new CustomEvent("datastar:scope-children", { bubbles: !1 }),
+              ),
+              (s = !0));
+          }
+        }
+        break;
+      case "replace":
+        Gt(n, t, "replaceWith", r);
+        break;
+      case "prepend":
+      case "append":
+      case "before":
+      case "after":
+        Gt(n, t, e, r);
+    }
+  },
+  I = new Map(),
+  le = new Set(),
+  ce = new Map(),
+  Se = new Set(),
+  ue = document.createElement("div");
+ue.hidden = !0;
+var Te = B("ignore-morph"),
+  Tn = `[${Te}]`,
+  An = (e, t, n = "outer") => {
+    if (
+      (z(e) && z(t) && e.hasAttribute(Te) && t.hasAttribute(Te)) ||
+      e.parentElement?.closest(Tn)
+    )
+      return;
+    let r = document.createElement("div");
+    (r.append(t), document.body.insertAdjacentElement("afterend", ue));
+    let s = e.querySelectorAll("[id]");
+    for (let { id: a, tagName: c } of s) ce.has(a) ? Se.add(a) : ce.set(a, c);
+    (e instanceof Element &&
+      e.id &&
+      (ce.has(e.id) ? Se.add(e.id) : ce.set(e.id, e.tagName)),
+      le.clear());
+    let i = r.querySelectorAll("[id]");
+    for (let { id: a, tagName: c } of i)
+      le.has(a) ? Se.add(a) : ce.get(a) === c && le.add(a);
+    for (let a of Se) le.delete(a);
+    (ce.clear(), Se.clear(), I.clear());
+    let o = n === "outer" ? e.parentElement : e;
+    (Bt(o, s),
+      Bt(r, i),
+      Jt(o, r, n === "outer" ? e : null, e.nextSibling),
+      ue.remove());
+  },
+  Jt = (e, t, n = null, r = null) => {
+    (e instanceof HTMLTemplateElement &&
+      t instanceof HTMLTemplateElement &&
+      ((e = e.content), (t = t.content)),
+      (n ??= e.firstChild));
+    for (let s of t.childNodes) {
+      if (n && n !== r) {
+        let i = wn(s, n, r);
+        if (i) {
+          if (i !== n) {
+            let o = n;
+            for (; o && o !== i; ) {
+              let a = o;
+              ((o = o.nextSibling), at(a));
+            }
+          }
+          (it(i, s), (n = i.nextSibling));
+          continue;
+        }
+      }
+      if (s instanceof Element && le.has(s.id)) {
+        let i = document.getElementById(s.id),
+          o = i;
+        for (; (o = o.parentNode); ) {
+          let a = I.get(o);
+          a && (a.delete(s.id), a.size || I.delete(o));
+        }
+        (Kt(e, i, n), it(i, s), (n = i.nextSibling));
+        continue;
+      }
+      if (I.has(s)) {
+        let i = s.namespaceURI,
+          o = s.tagName,
+          a =
+            i && i !== "http://www.w3.org/1999/xhtml"
+              ? document.createElementNS(i, o)
+              : document.createElement(o);
+        (e.insertBefore(a, n), it(a, s), (n = a.nextSibling));
+      } else {
+        let i = document.importNode(s, !0);
+        (e.insertBefore(i, n), (n = i.nextSibling));
+      }
+    }
+    for (; n && n !== r; ) {
+      let s = n;
+      ((n = n.nextSibling), at(s));
+    }
+  },
+  wn = (e, t, n) => {
+    let r = null,
+      s = e.nextSibling,
+      i = 0,
+      o = 0,
+      a = I.get(e)?.size || 0,
+      c = t;
+    for (; c && c !== n; ) {
+      if (Wt(c, e)) {
+        let l = !1,
+          u = I.get(c),
+          d = I.get(e);
+        if (d && u) {
+          for (let h of u)
+            if (d.has(h)) {
+              l = !0;
+              break;
+            }
+        }
+        if (l) return c;
+        if (!r && !I.has(c)) {
+          if (!a) return c;
+          r = c;
+        }
+      }
+      if (((o += I.get(c)?.size || 0), o > a)) break;
+      (r === null &&
+        s &&
+        Wt(c, s) &&
+        (i++, (s = s.nextSibling), i >= 2 && (r = void 0)),
+        (c = c.nextSibling));
+    }
+    return r || null;
+  },
+  Wt = (e, t) =>
+    e.nodeType === t.nodeType &&
+    e.tagName === t.tagName &&
+    (!e.id || e.id === t.id),
+  at = (e) => {
+    I.has(e) ? Kt(ue, e, null) : e.parentNode?.removeChild(e);
+  },
+  Kt = at.call.bind(ue.moveBefore ?? ue.insertBefore),
+  Rn = B("preserve-attr"),
+  it = (e, t) => {
+    let n = t.nodeType;
+    if (n === 1) {
+      let r = e,
+        s = t,
+        i = r.hasAttribute("data-scope-children");
+      if (r.hasAttribute(Te) && s.hasAttribute(Te)) return e;
+      r instanceof HTMLInputElement &&
+      s instanceof HTMLInputElement &&
+      s.type !== "file"
+        ? s.getAttribute("value") !== r.getAttribute("value") &&
+          (r.value = s.getAttribute("value") ?? "")
+        : r instanceof HTMLTextAreaElement &&
+          s instanceof HTMLTextAreaElement &&
+          (s.value !== r.value && (r.value = s.value),
+          r.firstChild &&
+            r.firstChild.nodeValue !== s.value &&
+            (r.firstChild.nodeValue = s.value));
+      let o = (t.getAttribute(Rn) ?? "").split(" ");
+      for (let { name: a, value: c } of s.attributes)
+        r.getAttribute(a) !== c && !o.includes(a) && r.setAttribute(a, c);
+      for (let a = r.attributes.length - 1; a >= 0; a--) {
+        let { name: c } = r.attributes[a];
+        !s.hasAttribute(c) && !o.includes(c) && r.removeAttribute(c);
+      }
+      (i &&
+        !r.hasAttribute("data-scope-children") &&
+        r.setAttribute("data-scope-children", ""),
+        r instanceof HTMLTemplateElement && s instanceof HTMLTemplateElement
+          ? (r.innerHTML = s.innerHTML)
+          : r.isEqualNode(s) || Jt(r, s),
+        i &&
+          r.dispatchEvent(
+            new CustomEvent("datastar:scope-children", { bubbles: !1 }),
+          ));
+    }
+    return (
+      (n === 8 || n === 3) &&
+        e.nodeValue !== t.nodeValue &&
+        (e.nodeValue = t.nodeValue),
+      e
+    );
+  },
+  Bt = (e, t) => {
+    for (let n of t)
+      if (le.has(n.id)) {
+        let r = n;
+        for (; r && r !== e; ) {
+          let s = I.get(r);
+          (s || ((s = new Set()), I.set(r, s)),
+            s.add(n.id),
+            (r = r.parentElement));
+        }
+      }
+  };
+ve({
+  name: "datastar-patch-signals",
+  apply({ error: e }, { signals: t, onlyIfMissing: n }) {
+    if (typeof t != "string") throw e("PatchSignalsExpectedSignals");
+    let r = typeof n == "string" && n.trim() === "true";
+    _(oe(t), { ifMissing: r });
+  },
+});
+export {
+  V as action,
+  xt as actions,
+  g as attribute,
+  M as beginBatch,
+  Pe as computed,
+  T as effect,
+  x as endBatch,
+  $ as filtered,
+  ie as getPath,
+  _ as mergePatch,
+  A as mergePaths,
+  ne as root,
+  pe as signal,
+  k as startPeeking,
+  H as stopPeeking,
+  ve as watcher,
+};
+//# sourceMappingURL=datastar.js.map

--- a/examples/params/main.py
+++ b/examples/params/main.py
@@ -1,0 +1,299 @@
+"""
+Params Demo - URL Parameter Routing with Stario
+
+Run with: uv run stario watch main:bootstrap
+      or: uv run stario serve main:bootstrap
+
+This example demonstrates:
+1. URL path parameters like /items/{id}
+2. Nested parameters like /categories/{catId}/items/{itemId}
+3. Using c.req.params to access parameter values
+4. Using c.url_for() with params dict to generate URLs
+"""
+
+from pathlib import Path
+
+from stario import Stario, Span
+from stario.http.types import Context
+from stario.http.writer import Writer
+from stario.html import (
+    A,
+    Body,
+    Code,
+    Div,
+    H1,
+    H2,
+    H3,
+    Head,
+    Html,
+    Li,
+    Link,
+    Meta,
+    P,
+    Pre,
+    Script,
+    Span,
+    Title,
+    Ul,
+)
+
+
+def page(url_for, *children):
+    """Base HTML shell with Datastar."""
+    return Html(
+        {"lang": "en"},
+        Head(
+            Meta({"charset": "UTF-8"}),
+            Meta(
+                {"name": "viewport", "content": "width=device-width, initial-scale=1"}
+            ),
+            Title("Params Demo - Stario"),
+            Link({"rel": "stylesheet", "href": url_for("static", "css/style.css")}),
+            Script(
+                {
+                    "type": "module",
+                    "src": url_for("static", "js/datastar.js"),
+                }
+            ),
+        ),
+        Body(
+            Div({"class": "container"}, *children),
+        ),
+    )
+
+
+def code_block(text):
+    """Code block."""
+    return Pre({"class": "code-block"}, Code(text))
+
+
+async def home(c: Context, w: Writer) -> None:
+    """Home page explaining URL parameters."""
+    w.html(
+        page(
+            c.url_for,
+            H1("URL Parameter Routing Demo"),
+            P("This demo shows how to use URL parameters in Stario routes."),
+            H2("What are URL Parameters?"),
+            P(
+                "URL parameters allow you to capture parts of the URL path as variables."
+            ),
+            P(
+                "Instead of creating separate routes for each item, you can use one route pattern."
+            ),
+            H2("Route Patterns"),
+            Div(
+                {"class": "route-demo"},
+                H3("Single Parameter"),
+                code_block("/items/{itemId}"),
+                P("Matches: /items/123, /items/abc, /items/hello"),
+                P("Access with: c.req.params['itemId']"),
+                H3("Multiple Parameters"),
+                code_block("/categories/{catId}/items/{itemId}"),
+                P("Matches: /categories/electronics/items/456"),
+                P("Access with: c.req.params['catId'] and c.req.params['itemId']"),
+                H3("Static Segments Mixed"),
+                code_block("/users/{userId}/posts/{postId}/comments/{commentId}"),
+                P("Three parameters with static segments between them."),
+            ),
+            H2("Try It Out"),
+            P("Click these links to see parameter routing in action:"),
+            Ul(
+                Li(
+                    A(
+                        {"href": c.url_for("item", {"itemId": "42"})},
+                        "Single param: /items/42",
+                    )
+                ),
+                Li(
+                    A(
+                        {"href": c.url_for("item", {"itemId": "hello"})},
+                        "Single param: /items/hello",
+                    )
+                ),
+                Li(
+                    A(
+                        {
+                            "href": c.url_for(
+                                "category_item",
+                                {"catId": "electronics", "itemId": "99"},
+                            )
+                        },
+                        "Two params: /categories/electronics/items/99",
+                    )
+                ),
+                Li(
+                    A(
+                        {
+                            "href": c.url_for(
+                                "comment",
+                                {
+                                    "userId": "alice",
+                                    "postId": "123",
+                                    "commentId": "456",
+                                },
+                            )
+                        },
+                        "Three params: /users/alice/posts/123/comments/456",
+                    )
+                ),
+            ),
+            H2("Backend Handler Example"),
+            code_block("""async def item_handler(c: Context, w: Writer) -> None:
+    item_id = c.req.params['itemId']  # Get the param value
+    w.json({'item_id': item_id})"""),
+            H2("Generating URLs with url_for"),
+            code_block("""# Single param
+c.url_for('item', {'itemId': '42'})
+# → '/items/42'
+
+# Multiple params
+c.url_for('category_item', {'catId': 'books', 'itemId': '77'})
+# → '/categories/books/items/77'"""),
+        )
+    )
+
+
+async def item(c: Context, w: Writer) -> None:
+    """Display a single item - single param demo."""
+    item_id = c.req.params.get("itemId", "unknown")
+    w.html(
+        page(
+            c.url_for,
+            H1("Item Detail Page"),
+            Div(
+                {"class": "route-demo item"},
+                H2(f"Viewing Item: {item_id}"),
+                P(f"This page was rendered by the /items/{item_id} route."),
+                P(f"The parameter 'itemId' has value: {item_id}"),
+                H3("What happened?"),
+                Ul(
+                    Li(f"URL: /items/{item_id}"),
+                    Li("Route pattern: /items/{itemId}"),
+                    Li("Handler accessed: c.req.params['itemId']"),
+                ),
+            ),
+            H2("Code"),
+            code_block(f"""async def item(c: Context, w: Writer) -> None:
+    item_id = c.req.params['itemId']  # = "{item_id}"
+    # ... render page ..."""),
+            H2("Navigate"),
+            Div(
+                {"class": "nav-links"},
+                A({"href": c.url_for("home")}, "Back to Home"),
+                A({"href": c.url_for("item", {"itemId": "123"})}, "Another item"),
+                A(
+                    {
+                        "href": c.url_for(
+                            "category_item", {"catId": "electronics", "itemId": item_id}
+                        )
+                    },
+                    "Category view",
+                ),
+            ),
+        )
+    )
+
+
+async def category_item(c: Context, w: Writer) -> None:
+    """Display item in category - two param demo."""
+    cat_id = c.req.params.get("catId", "unknown")
+    item_id = c.req.params.get("itemId", "unknown")
+    w.html(
+        page(
+            c.url_for,
+            H1("Category + Item Page"),
+            Div(
+                {"class": "route-demo category"},
+                H2(f"Category: {cat_id}"),
+                H3(f"Item: {item_id}"),
+                P("This page uses two URL parameters!"),
+                H3("Parameters captured:"),
+                Ul(
+                    Li(f"catId = {cat_id}"),
+                    Li(f"itemId = {item_id}"),
+                ),
+            ),
+            H2("Route Pattern"),
+            code_block("/categories/{catId}/items/{itemId}"),
+            H2("Navigate"),
+            Div(
+                {"class": "nav-links"},
+                A({"href": c.url_for("home")}, "Back to Home"),
+                A({"href": c.url_for("item", {"itemId": item_id})}, "View item only"),
+                A(
+                    {
+                        "href": c.url_for(
+                            "comment",
+                            {"userId": "bob", "postId": "1", "commentId": "1"},
+                        )
+                    },
+                    "Three params",
+                ),
+            ),
+        )
+    )
+
+
+async def comment(c: Context, w: Writer) -> None:
+    """Display comment - three param demo."""
+    user_id = c.req.params.get("userId", "unknown")
+    post_id = c.req.params.get("postId", "unknown")
+    comment_id = c.req.params.get("commentId", "unknown")
+    w.html(
+        page(
+            c.url_for,
+            H1("Comment Thread"),
+            Div(
+                {"class": "route-demo comment"},
+                H2(f"User: {user_id}"),
+                H3(f"Post: {post_id}"),
+                H3(f"Comment: {comment_id}"),
+                P("Three parameters captured from the URL path!"),
+            ),
+            H2("All Parameters"),
+            Div(
+                {"class": "params-box"},
+                code_block(f"""c.req.params = {{
+    'userId': '{user_id}',
+    'postId': '{post_id}',
+    'commentId': '{comment_id}'
+}}"""),
+            ),
+            H2("Navigate"),
+            Div(
+                {"class": "nav-links"},
+                A({"href": c.url_for("home")}, "Back to Home"),
+                A(
+                    {"href": c.url_for("item", {"itemId": post_id})},
+                    "View post as item",
+                ),
+                A(
+                    {
+                        "href": c.url_for(
+                            "category_item", {"catId": "general", "itemId": post_id}
+                        )
+                    },
+                    "View in category",
+                ),
+            ),
+        )
+    )
+
+
+async def bootstrap(app: Stario, span) -> None:
+    """Register routes with parameter patterns."""
+    static_dir = Path(__file__).parent / "app" / "static"
+    static_dir_display = (
+        static_dir.relative_to(Path.cwd())
+        if static_dir.is_relative_to(Path.cwd())
+        else static_dir
+    )
+    app.assets("/static", static_dir, name="static")
+
+    app.get("/", home, name="home")
+    app.get("/items/{itemId}", item, name="item")
+    app.get("/categories/{catId}/items/{itemId}", category_item, name="category_item")
+    app.get(
+        "/users/{userId}/posts/{postId}/comments/{commentId}", comment, name="comment"
+    )

--- a/src/stario/http/request.py
+++ b/src/stario/http/request.py
@@ -231,6 +231,7 @@ class Request:
         "path",
         "tail",
         "subhost",
+        "params",
         "headers",
         "protocol_version",
         "keep_alive",
@@ -261,6 +262,7 @@ class Request:
         self.subhost = (
             ""  # The matched wildcard portion for host routing (*.example.com)
         )
+        self.params: dict[str, str] = {}  # Extracted path parameters
         self.headers = headers
         self.protocol_version = protocol_version
         self.keep_alive = keep_alive

--- a/src/stario/http/router.py
+++ b/src/stario/http/router.py
@@ -13,6 +13,7 @@ Usage:
     router.assets("/static", "./static", name="static")
 """
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlencode
@@ -51,6 +52,44 @@ def _append_queries(url: str, queries: UrlQueryParams | None) -> str:
     if not queries:
         return url
     return f"{url}?{urlencode(queries, doseq=True)}"
+
+
+_PARAM_PATTERN = re.compile(r"\{(\w+)\}")
+
+
+def _has_param_syntax(path: str) -> bool:
+    """Check if path contains {param} style parameters."""
+    return "{" in path and "}" in path
+
+
+def _convert_param_path(path: str) -> tuple[str, list[str], re.Pattern[str]]:
+    """
+    Convert {param} style path to regex pattern.
+
+    Returns:
+        tuple of (prefix_without_params, list of param names, compiled regex pattern)
+    """
+    param_names: list[str] = []
+    regex_parts: list[str] = []
+    last_end = 0
+
+    for match in _PARAM_PATTERN.finditer(path):
+        param_names.append(match.group(1))
+        before = path[last_end : match.start()]
+        regex_parts.append(re.escape(before) + r"(?P<" + match.group(1) + r">[^/]+)")
+        last_end = match.end()
+
+    if last_end < len(path):
+        regex_parts.append(re.escape(path[last_end:]))
+
+    regex_str = "".join(regex_parts) + "$"
+    pattern = re.compile(regex_str)
+
+    prefix = path[: path.find("{")].rstrip("/") if "{" in path else path
+    if not prefix:
+        prefix = "/"
+
+    return prefix, param_names, pattern
 
 
 @dataclass(slots=True, frozen=True)
@@ -97,7 +136,43 @@ class _AssetRoute:
         return self.static.url(path)
 
 
-type _ReverseRoute = _ExactRoute | _WildcardRoute | _AssetRoute
+@dataclass(slots=True, frozen=True)
+class _ParamRoute:
+    """Reverse route for a parameterized path."""
+
+    prefix: str
+    param_names: list[str]
+    pattern: re.Pattern[str]
+    path_template: str = ""
+
+    def url(self, path: dict[str, str] | None) -> str:
+        if path is None:
+            raise StarioError(
+                "Parameterized routes require a path argument",
+                help_text="Pass a dict with param values, for example url_for('game', {'gameId': '123'}).",
+            )
+        for name in self.param_names:
+            if name not in path:
+                raise StarioError(
+                    f"Missing parameter: '{name}'",
+                    context={
+                        "route_params": self.param_names,
+                        "provided": list(path.keys()),
+                    },
+                    help_text=f"All route parameters must be provided: {self.param_names}",
+                )
+        if self.path_template:
+            result = self.path_template
+            for name in self.param_names:
+                result = result.replace("{" + name + "}", path[name])
+            return result[len(self.prefix) :]  # Return only the part after prefix
+        url = ""
+        for name in self.param_names:
+            url = f"{url}/{path[name]}"
+        return url
+
+
+type _ReverseRoute = _ExactRoute | _WildcardRoute | _AssetRoute | _ParamRoute
 
 
 class Router:
@@ -132,6 +207,7 @@ class Router:
         "_middlewares",
         "_exact",
         "_catchall",
+        "_param_routes",
         "_reverse_routes",
     )
 
@@ -139,12 +215,15 @@ class Router:
         self._middlewares: list[Middleware] = []
         self._exact: dict[str, dict[str, Handler]] = {}
         self._catchall: list[tuple[str, dict[str, Handler]]] = []
+        self._param_routes: list[
+            tuple[str, list[str], re.Pattern[str], dict[str, Handler]]
+        ] = []
         self._reverse_routes: dict[str, _ReverseRoute] = {}
 
     @property
     def empty(self) -> bool:
         """True if no routes have been registered."""
-        return not self._exact and not self._catchall
+        return not self._exact and not self._catchall and not self._param_routes
 
     # =========================================================================
     # Configuration
@@ -197,6 +276,13 @@ router.get("/", home)        # Then: routes""",
             if name is not None:
                 self._register_reverse_route(name, _WildcardRoute(prefix))
             self._add_catchall(prefix, method, wrapped)
+        elif _has_param_syntax(path):
+            prefix, param_names, pattern = _convert_param_path(path)
+            if name is not None:
+                self._register_reverse_route(
+                    name, _ParamRoute(prefix, param_names, pattern, path)
+                )
+            self._add_param_route(prefix, method, wrapped, param_names, pattern)
         else:
             if name is not None:
                 self._register_reverse_route(name, _ExactRoute(path))
@@ -229,6 +315,30 @@ router.get("/", home)        # Then: routes""",
         self._catchall.append((prefix, {method: handler}))
         # Sort by prefix length (longest first)
         self._catchall.sort(key=lambda x: len(x[0]), reverse=True)
+
+    def _add_param_route(
+        self,
+        prefix: str,
+        method: str,
+        handler: Handler,
+        param_names: list[str],
+        pattern: re.Pattern[str],
+    ) -> None:
+        """Add parameterized route."""
+        for p, _, existing_pattern, methods in self._param_routes:
+            if p == prefix and existing_pattern.pattern == pattern.pattern:
+                if method in methods:
+                    raise StarioError(
+                        f"Route already registered: {method} {pattern.pattern}",
+                        context={"method": method, "pattern": pattern.pattern},
+                        help_text="Each method + path combination can only have one handler.",
+                    )
+                methods[method] = handler
+                return
+
+        self._param_routes.append((prefix, param_names, pattern, {method: handler}))
+        # Sort by prefix length (longest first)
+        self._param_routes.sort(key=lambda x: len(x[0]), reverse=True)
 
     def _register_reverse_route(self, name: str, route: _ReverseRoute) -> None:
         """Register a reverse route in the flat name registry."""
@@ -336,12 +446,25 @@ router.get("/", home)        # Then: routes""",
                 wrapped = self._wrap_handler(handler)
                 self._add_catchall(full_prefix, method, wrapped)
 
+        # Copy param routes with prefix, applying parent middleware
+        for sub_prefix, param_names, pattern, methods in router._param_routes:
+            full_prefix = _normalize_path(prefix + sub_prefix)
+            for method, handler in methods.items():
+                wrapped = self._wrap_handler(handler)
+                self._add_param_route(
+                    full_prefix, method, wrapped, param_names, pattern
+                )
+
         for name, route in router._reverse_routes.items():
             full_path = _normalize_path(prefix + route.prefix)
             if isinstance(route, _ExactRoute):
                 mounted = _ExactRoute(full_path)
             elif isinstance(route, _WildcardRoute):
                 mounted = _WildcardRoute(full_path)
+            elif isinstance(route, _ParamRoute):
+                mounted = _ParamRoute(
+                    full_path, route.param_names, route.pattern, route.path_template
+                )
             else:
                 mounted = _AssetRoute(full_path, route.static)
             self._register_reverse_route(name, mounted)
@@ -388,7 +511,7 @@ router.get("/", home)        # Then: routes""",
     def url_for(
         self,
         name: str,
-        path: str | None = None,
+        path: str | dict[str, str] | None = None,
         queries: UrlQueryParams | None = None,
     ) -> str:
         """
@@ -397,6 +520,7 @@ router.get("/", home)        # Then: routes""",
         Exact routes ignore `path`.
         Wildcard routes append `path` to the registered prefix.
         Asset mounts fingerprint and resolve the logical asset `path`.
+        Parameterized routes require a dict of param values.
         """
         route = self._reverse_routes.get(name)
         if route is None:
@@ -411,7 +535,24 @@ router.get("/", home)        # Then: routes""",
 app.assets("/static", "./static", name="static")""",
             )
 
-        return _append_queries(_join_subpath(route.prefix, route.url(path)), queries)
+        if isinstance(route, _ParamRoute):
+            if isinstance(path, dict):
+                resolved_path = route.url(path)
+            elif path is None:
+                resolved_path = route.url(None)
+            else:
+                raise StarioError(
+                    "Parameterized routes require a dict of param values",
+                    help_text="Pass a dict, for example url_for('game', {'gameId': '123'}).",
+                )
+        else:
+            if isinstance(path, dict):
+                raise StarioError(
+                    "Non-parameterized routes do not accept dict path",
+                    help_text="Pass a string path or use parameterized routes.",
+                )
+            resolved_path = route.url(path)
+        return _append_queries(_join_subpath(route.prefix, resolved_path), queries)
 
     # =========================================================================
     # Dispatch
@@ -441,14 +582,24 @@ app.assets("/static", "./static", name="static")""",
         for prefix, methods in self._catchall:
             if path.startswith(prefix):
                 if handler := methods.get(method):
-                    # Set param to rest of path
                     c.req.tail = path[len(prefix) :].lstrip("/")
                     await handler(c, w)
                     return
-                # Method not allowed
                 w.headers.set(b"allow", ", ".join(methods.keys()))
                 w.text("Method Not Allowed", 405)
                 return
+
+        # Try parameterized routes
+        for prefix, _, pattern, methods in self._param_routes:
+            if path.startswith(prefix):
+                if match := pattern.match(path):
+                    if handler := methods.get(method):
+                        c.req.params = match.groupdict()
+                        await handler(c, w)
+                        return
+                    w.headers.set(b"allow", ", ".join(methods.keys()))
+                    w.text("Method Not Allowed", 405)
+                    return
 
         # Not found
         w.text("Not Found", 404)

--- a/src/stario/http/types.py
+++ b/src/stario/http/types.py
@@ -31,7 +31,7 @@ class UrlFor(Protocol):
     def __call__(
         self,
         name: str,
-        path: str | None = None,
+        path: str | dict[str, str] | None = None,
         queries: UrlQueryParams | None = None,
     ) -> str: ...
 
@@ -54,7 +54,7 @@ class Context:
     def url_for(
         self,
         name: str,
-        path: str | None = None,
+        path: str | dict[str, str] | None = None,
         queries: UrlQueryParams | None = None,
     ) -> str:
         """Resolve a named route or asset URL through the current app."""
@@ -69,6 +69,7 @@ class Context:
             raw = await self.req.body()
 
         return parse_signals(raw, schema)
+
 
 type Handler = Callable[[Context, Writer], Awaitable[None]]
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -192,7 +192,9 @@ class TestRouterMiddleware:
         def mw(handler: Handler) -> Handler:
             return handler
 
-        with pytest.raises(StarioError, match="Middleware must be registered before routes"):
+        with pytest.raises(
+            StarioError, match="Middleware must be registered before routes"
+        ):
             router.use(mw)
 
     def test_per_route_middleware(self):
@@ -252,7 +254,9 @@ class TestRouterUrlFor:
 
         router.get("/", home)
 
-        with pytest.raises(StarioError, match="Register the route or asset first with name='home'"):
+        with pytest.raises(
+            StarioError, match="Register the route or asset first with name='home'"
+        ):
             router.url_for("home")
 
     def test_url_for_exact_route(self):
@@ -322,7 +326,9 @@ class TestRouterUrlFor:
 
         router.get("/", home, name="home")
 
-        with pytest.raises(StarioError, match="Exact routes do not accept a path argument"):
+        with pytest.raises(
+            StarioError, match="Exact routes do not accept a path argument"
+        ):
             router.url_for("home", "extra")
 
     def test_mount_catchall(self):
@@ -360,3 +366,89 @@ class TestRouterUrlFor:
         api.get("/test", handler)
         main.mount("/api", api)
         # Parent middleware should wrap mounted routes
+
+
+class TestRouterParams:
+    """Test parameterized route registration and dispatch."""
+
+    def test_param_registration(self):
+        router = Router()
+
+        async def handler(c: Context, w: Writer) -> None:
+            pass
+
+        router.get("/games/{gameId}", handler)
+        assert len(router._param_routes) == 1
+        assert router._param_routes[0][0] == "/games"
+        assert router._param_routes[0][3] == {"GET": handler}
+
+    def test_nested_params(self):
+        router = Router()
+
+        async def handler(c: Context, w: Writer) -> None:
+            pass
+
+        router.get("/games/{gameId}/players/{playerId}", handler)
+        assert len(router._param_routes) == 1
+        assert router._param_routes[0][0] == "/games"
+
+    def test_param_sorted_by_prefix_length(self):
+        router = Router()
+
+        async def handler(c: Context, w: Writer) -> None:
+            pass
+
+        router.get("/a/{x}", handler)
+        router.get("/a/b/{x}/{y}", handler)
+        router.get("/a/c/{z}", handler)
+
+        prefixes = [p for p, _, _, _ in router._param_routes]
+        assert prefixes[0] == "/a/b"
+        assert prefixes[1] == "/a/c"
+        assert prefixes[2] == "/a"
+
+    def test_param_url_for(self):
+        router = Router()
+
+        async def handler(c: Context, w: Writer) -> None:
+            pass
+
+        router.get("/games/{gameId}", handler, name="game")
+
+        url = router.url_for("game", {"gameId": "123"})
+        assert url == "/games/123"
+
+    def test_nested_param_url_for(self):
+        router = Router()
+
+        async def handler(c: Context, w: Writer) -> None:
+            pass
+
+        router.get("/games/{gameId}/players/{playerId}", handler, name="player")
+
+        url = router.url_for("player", {"gameId": "abc", "playerId": "xyz"})
+        assert url == "/games/abc/players/xyz"
+
+    def test_param_url_for_missing_param_raises(self):
+        router = Router()
+
+        async def handler(c: Context, w: Writer) -> None:
+            pass
+
+        router.get("/games/{gameId}", handler, name="game")
+
+        with pytest.raises(StarioError, match="Missing parameter"):
+            router.url_for("game", {})
+
+    def test_param_mount_prefix(self):
+        main = Router()
+        api = Router()
+
+        async def handler(c: Context, w: Writer) -> None:
+            pass
+
+        api.get("/games/{gameId}", handler)
+        main.mount("/api", api)
+
+        prefixes = [p for p, _, _, _ in main._param_routes]
+        assert "/api/games" in prefixes


### PR DESCRIPTION
Add support for parameterized URL routes like
/users/{userId}/posts/{postId}.
- Single and multiple path parameters using {param} syntax
- Access params via c.req.params dict in handlers
- Generate URLs with c.url_for('route', {'param': 'value'})
- Mount support for prefixed param routes
- Sorted by prefix length for correct dispatch order
- Backward compatible with existing exact and catchall routes
- Dispatch order: exact -> catchall -> param (catchall wins over param)