### PR TITLE
Skip redirects for paths starting with double slashes

### DIFF
--- a/src/stario/http/router.py
+++ b/src/stario/http/router.py
@@ -423,7 +423,7 @@ app.assets("/static", "./static", name="static")""",
         method = c.req.method
 
         # Strip trailing slash (redirect)
-        if path != "/" and path.endswith("/"):
+        if path != "/" and path.endswith("/") and (not path.startswith("//")):
             w.redirect(path.rstrip("/"), 301)
             return
 


### PR DESCRIPTION
It seems stario is open to open redirects of the form: `GET https://my-stario-website.com//aftra.io/`. 
This would redirect the user to `aftra.io` or whatever you put in the url.

This is just the simplest fix but open to other suggestions since I am not familiar with the codebase.

Great project, btw!