### PR TITLE
Feature/add text color to debugger

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stario"
-version = "4.0.0"
+version = "4.0.1"
 description = "Craft realtime hypermedia apps that are a joy to write and ship."
 readme = "README.md"
 license = "MIT"

--- a/src/stario/debug.py
+++ b/src/stario/debug.py
@@ -32,6 +32,7 @@ def debug_inspector(
                 "opacity": "0.95",
                 "border": "1px solid #ccc",
                 "background": "#fff",
+                "color": "#111",
                 "padding": "0.75rem",
                 "width": "320px",
                 "z-index": "9999",
@@ -79,6 +80,7 @@ def debug_inspector(
                 {
                     "background": "#f4f4f4",
                     "border": "1px solid #eee",
+                    "color": "#111",
                     "padding": "0.5rem",
                     "margin-top": "0.5rem",
                     "margin-bottom": "0",


### PR DESCRIPTION
Add `color` option within styles of debugger. Set it to `#111` to so that the dark text will contrast against the already light background