### PR TITLE
Benchmark suite: Stario Cython baseline + native/ASGI servers + upload cases

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,2 +1,4 @@
 .venvs/
 results/
+fixtures/*.bin
+fixtures/*.json

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -88,8 +88,11 @@ server cannot be reused by accident.
 ### Benchmark shape
 
 - One worker/process per target.
-- Same paths: `/plaintext`, `/json`, `/user/42`, and `POST /validate`.
-- Same `wrk` settings for every run.
+- Same read paths: `/plaintext`, `/json`, `/user/42`.
+- Same upload/body paths (see **Endpoint tiers** below).
+- Same `wrk` settings per tier; large uploads use fewer connections
+  (`UPLOAD_CONNECTIONS`, default 32) than read-heavy cases (`CONNECTIONS`,
+  default 128).
 - Each endpoint is measured multiple times (`RUNS`, default 7). The first
   `WARMUP` samples are discarded, then IQR outlier trimming is applied before
   reporting median requests/sec ± sample stdev.
@@ -100,6 +103,32 @@ server cannot be reused by accident.
 FastAPI uses Pydantic validation, matching the referenced benchmark. Stario,
 BlackSheep, Sanic, Socketify, Robyn, and Granian RSGI validate the JSON body
 manually. Django-Bolt uses msgspec structs.
+
+### Endpoint tiers
+
+| Tier | Endpoints | Paths |
+| --- | --- | --- |
+| **read** | `plaintext`, `json`, `params` | `GET /plaintext`, `GET /json`, `GET /user/42` |
+| **upload** | see below | POST body / multipart cases |
+| **all** | read + upload | default |
+
+Upload endpoints (all targets implement the same semantics):
+
+| Endpoint key | Path | Client payload | Server behavior |
+| --- | --- | --- | --- |
+| `validate` | `POST /validate` | JSON `{"name":"Ada","age":42}` | Validate fields, return JSON |
+| `post-form` | `POST /form` | urlencoded form | Read body, `204 No Content` |
+| `post-json-1k` | `POST /echo/json` | 1 KB JSON | Buffered read, return `{"bytes": N}` |
+| `post-octet-64k` | `POST /ingest/64k` | 64 KB octet stream | Buffered read |
+| `post-octet-2m` | `POST /ingest/2m` | 2 MB octet stream | Buffered read |
+| `post-stream-2m` | `POST /ingest/stream/2m` | 2 MB octet stream | Streaming read (where supported) |
+| `multipart-2m` | `POST /upload` | 2 MB multipart file | Read multipart/raw body |
+
+Binary fixtures live under `benchmarks/server/fixtures/` (generated on demand,
+gitignored). Lua scripts under `benchmarks/server/scripts/` load those fixtures.
+
+Robyn and Django-Bolt buffer the full body on stream routes (no native streaming
+API).
 
 ### Requirements
 
@@ -129,8 +158,10 @@ The default run benchmarks every target above.
 
 - `DURATION=10s`
 - `THREADS=2`
-- `CONNECTIONS=128`
+- `CONNECTIONS=128` (read-heavy and small upload cases)
+- `UPLOAD_CONNECTIONS=32` (64 KB / 2 MB upload cases)
 - `RUNS=7` measured samples per endpoint (plus `WARMUP=2` discarded warmup runs)
+- `ENDPOINT_TIER=all|read|upload` (default `all`)
 - `PORT=3000` as the base port
 - one process or worker per target
 
@@ -144,6 +175,8 @@ Common options:
 ```bash
 DURATION=30s THREADS=2 CONNECTIONS=128 RUNS=9 WARMUP=2 benchmarks/server/run.sh
 benchmarks/server/run.sh stario stario-cython socketify robyn granian-rsgi
+ENDPOINT_TIER=upload benchmarks/server/run.sh
+ENDPOINTS=validate,post-form,post-json-1k benchmarks/server/run.sh stario
 PORT=3999 benchmarks/server/run.sh
 REFRESH_ENVS=1 benchmarks/server/run.sh
 KEEP_RAW=1 benchmarks/server/run.sh
@@ -165,13 +198,14 @@ Successful runs keep only `summary.md` and `config.txt` by default. Use
 `KEEP_RAW=1` to keep the per-endpoint `wrk` output and server logs. Failed
 runs leave the logs in place so startup issues can be inspected.
 
-The `POST /validate` benchmark uses `benchmarks/server/validate.lua` so every
-endpoint runs through `wrk`.
-
-The Lua file is intentionally small:
+POST endpoints use small Lua scripts under `benchmarks/server/` so every case runs
+through `wrk`. `validate.lua` is the simplest example:
 
 ```lua
 wrk.method = "POST"
 wrk.body = '{"name":"Ada","age":42}'
 wrk.headers["Content-Type"] = "application/json"
 ```
+
+Larger payloads load binary fixtures from `benchmarks/server/fixtures/` (see
+`scripts/post-octet-2m.lua`, `scripts/multipart-2m.lua`, etc.).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,8 +4,8 @@ Two suites, one per layer we care about:
 
 - `html/` — HTML generation speed: stario against other Python renderers, plus
   microbenchmarks for stario's own hot paths.
-- `server/` — end-to-end HTTP throughput: the current Stario checkout against a
-  few Python framework/server combinations under `wrk`.
+- `server/` — end-to-end HTTP throughput: Stario against native Python HTTP
+  servers and ASGI framework stacks under `wrk`.
 
 The goal is repeatable local signal, not lab-grade numbers. Run on a quiet
 machine and compare repeated runs before drawing conclusions.
@@ -47,53 +47,74 @@ uv run benchmarks/html/micro.py
 
 ## HTTP server (`server/`)
 
-Compares the current Stario checkout with a few Python web framework/server
-combinations. The route mix follows Cemrehan Çavdar's framework comparison:
+Compares Stario with native HTTP servers and ASGI framework stacks. The route
+mix follows Cemrehan Çavdar's framework comparison:
 https://cemrehancavdar.com/2026/02/10/framework-benchmark/
+
+Each target runs its **own** server process — not as an ASGI backend for another
+app (except the explicit ASGI stack rows below).
 
 The runner keeps the setup explicit: one process per target, one load
 generator, dedicated virtual environments, and separate ports so a stale
 server cannot be reused by accident.
 
-Targets:
+### Targets
 
-- `stario` — this checkout with no-op tracing (Python httptools protocol)
-- `stario-cython` — same app on the Cython/llhttp protocol stack (`cython-core`)
-- `fastapi` — FastAPI on one Uvicorn worker
-- `blacksheep-uvicorn` — BlackSheep on one Uvicorn worker
-- `blacksheep-granian` — BlackSheep on one Granian worker
-- `sanic` — Sanic in one process
+**Stario (this checkout)**
+
+| Target | Server |
+| --- | --- |
+| `stario` | Python httptools protocol |
+| `stario-cython` | Cython llhttp protocol (`cython-core`) |
+
+**Native HTTP servers**
+
+| Target | Server |
+| --- | --- |
+| `socketify` | [Socketify.py](https://github.com/cirospaciari/socketify.py) (uWebSockets + libuv) |
+| `robyn` | [Robyn](https://github.com/sparckles/Robyn) (Rust/Actix) |
+| `granian-rsgi` | [Granian](https://github.com/emmett-framework/granian) RSGI (Rust, no framework) |
+| `sanic` | [Sanic](https://sanic.dev/) (uvloop) |
+| `django-bolt` | [Django-Bolt](https://bolt.farhana.li/) (Actix/Tokio) |
+
+**ASGI framework stacks**
+
+| Target | Stack |
+| --- | --- |
+| `blacksheep-granian` | BlackSheep + Granian ASGI |
+| `blacksheep-uvicorn` | BlackSheep + Uvicorn |
+| `fastapi` | FastAPI + Uvicorn + Pydantic |
 
 ### Benchmark shape
 
-- One worker/process per framework.
+- One worker/process per target.
 - Same paths: `/plaintext`, `/json`, `/user/42`, and `POST /validate`.
 - Same `wrk` settings for every run.
 - Each endpoint is measured multiple times (`RUNS`, default 7). The first
   `WARMUP` samples are discarded, then IQR outlier trimming is applied before
   reporting median requests/sec ± sample stdev.
 - Stario response compression disabled with negative codec levels.
-- JSON response bodies use `ujson` for Stario and FastAPI to match Sanic's
-  `ujson` dependency more closely.
-- Stario runs with `STARIO_TRACER=noop`; FastAPI, BlackSheep/Uvicorn,
-  BlackSheep/Granian, and Sanic run with access logging disabled.
+- JSON response bodies use `ujson` where the stack allows it.
+- Access logging and OpenAPI docs disabled for competitors where configurable.
 
 FastAPI uses Pydantic validation, matching the referenced benchmark. Stario,
-BlackSheep, and Sanic validate the JSON body manually because they do not
-bundle a Pydantic-style request validation layer.
+BlackSheep, Sanic, Socketify, Robyn, and Granian RSGI validate the JSON body
+manually. Django-Bolt uses msgspec structs.
 
 ### Requirements
 
 - `uv`
 - `wrk`
 - Python compatible with Stario (3.14+)
+- `libbrotli-dev` (or set `BROTLI_PKG_CONFIG`) for `stario-cython`
 
-All targets run on `uvloop`: Stario uses `STARIO_LOOP=uvloop`, FastAPI/Uvicorn
-uses `--loop uvloop`, and Sanic uses its uvloop-backed default when installed.
+Targets that support uvloop use it where applicable (Stario, Sanic, Granian
+RSGI, ASGI stacks). Socketify, Robyn, and Django-Bolt use their own native
+runtimes (libuv, Rust, Tokio).
 
 The runner creates dedicated virtual environments under
 `benchmarks/server/.venvs/` with `uv venv` and `uv pip install`, then starts
-each server from its own environment. The Stario target installs this checkout
+each server from its own environment. The Stario targets install this checkout
 as `stario @ file://...`. Use `REFRESH_ENVS=1` after changing dependencies or
 upgrading framework versions.
 
@@ -104,7 +125,7 @@ cd projects/stario
 benchmarks/server/run.sh
 ```
 
-The default run is the standard comparison shape:
+The default run benchmarks every target above.
 
 - `DURATION=10s`
 - `THREADS=2`
@@ -115,13 +136,14 @@ The default run is the standard comparison shape:
 
 Use those defaults when you want numbers that are easiest to compare with
 other local runs. The generated `config.txt` records the exact settings for
-that run.
+that run. The summary groups results into **Stario**, **Native HTTP servers**,
+and **ASGI framework stacks**.
 
 Common options:
 
 ```bash
 DURATION=30s THREADS=2 CONNECTIONS=128 RUNS=9 WARMUP=2 benchmarks/server/run.sh
-benchmarks/server/run.sh stario stario-cython blacksheep-granian
+benchmarks/server/run.sh stario stario-cython socketify robyn granian-rsgi
 PORT=3999 benchmarks/server/run.sh
 REFRESH_ENVS=1 benchmarks/server/run.sh
 KEEP_RAW=1 benchmarks/server/run.sh
@@ -130,12 +152,13 @@ BROTLI_PKG_CONFIG=/opt/brotli/lib/pkgconfig benchmarks/server/run.sh stario-cyth
 ```
 
 `PORT` is a base port, not a shared port. The runner assigns fixed offsets per
-target (`stario` on `PORT`, `stario-cython` on `PORT+1`, and so on) and checks each
-port before starting a server.
+target in `TARGETS` order (`stario` on `PORT`, `stario-cython` on `PORT+1`,
+`socketify` on `PORT+2`, and so on) and checks each port before starting a
+server.
 
 Each run writes a timestamped directory under `benchmarks/server/results/`:
 
-- `summary.md` — markdown tables suitable for copying into notes or docs.
+- `summary.md` — grouped markdown tables.
 - `config.txt` — run settings.
 
 Successful runs keep only `summary.md` and `config.txt` by default. Use

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -127,8 +127,29 @@ Upload endpoints (all targets implement the same semantics):
 Binary fixtures live under `benchmarks/server/fixtures/` (generated on demand,
 gitignored). Lua scripts under `benchmarks/server/scripts/` load those fixtures.
 
-Robyn and Django-Bolt buffer the full body on stream routes (no native streaming
-API).
+Robyn and Django-Bolt buffer the full body on the stream route (no request
+streaming API). All other targets use chunked streaming reads on
+`POST /ingest/stream/2m`.
+
+### Route parity
+
+Every app exposes the same paths and response shapes:
+
+| Route | Method | Response |
+| --- | --- | --- |
+| `/plaintext` | GET | `Hello, World!` |
+| `/json` | GET | `{"message":"Hello, World!"}` |
+| `/user/{id}` | GET | `{"id":"…","name":"User …"}` |
+| `/validate` | POST | `validate_fields()` → JSON + status |
+| `/form` | POST | read body → `204` |
+| `/echo/json` | POST | read body → `{"bytes":N}` |
+| `/ingest/64k`, `/ingest/2m` | POST | buffered read → `{"bytes":N}` |
+| `/ingest/stream/2m` | POST | stream read → `{"bytes":N}` (buffered on Robyn/Django-Bolt) |
+| `/upload` | POST | read raw body → `{"bytes":N}` |
+
+Validation uses `apps.common.validate_fields()` everywhere except Django-Bolt,
+which uses msgspec struct parsing then calls the same helper. JSON responses
+use `ujson` where the stack allows it.
 
 ### Requirements
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -215,6 +215,10 @@ Each run writes a timestamped directory under `benchmarks/server/results/`:
 - `summary.md` — grouped markdown tables.
 - `config.txt` — run settings.
 
+A committed reference baseline (hardware, methodology, tables) lives at
+`benchmarks/server/baseline-20260824.md`. Timestamped `results/` dirs remain
+gitignored.
+
 Successful runs keep only `summary.md` and `config.txt` by default. Use
 `KEEP_RAW=1` to keep the per-endpoint `wrk` output and server logs. Failed
 runs leave the logs in place so startup issues can be inspected.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -147,9 +147,22 @@ Every app exposes the same paths and response shapes:
 | `/ingest/stream/2m` | POST | stream read → `{"bytes":N}` (buffered on Robyn/Django-Bolt) |
 | `/upload` | POST | read raw body → `{"bytes":N}` |
 
-Validation uses `apps.common.validate_fields()` everywhere except Django-Bolt,
-which uses msgspec struct parsing then calls the same helper. JSON responses
+Validation uses `apps.common.validate_fields()` on every target. JSON responses
 use `ujson` where the stack allows it.
+
+### Handler policy (no static responses)
+
+Benchmark handlers must **compute every response on each request**: build dicts,
+run `validate_fields`, call `ujson.dumps` / framework JSON helpers, and construct
+`Response` objects per call. Do **not**:
+
+- Reuse a single `Response` / `PlainTextResponse` instance across requests
+- Pre-serialize JSON at import time and return cached bytes
+- Skip validation or serialization because the wrk payload is fixed
+
+Framework-specific routing or server tuning is fine when output bytes and status
+codes stay identical. The goal is to measure handler + serialization work, not
+wire throughput of prebuilt buffers.
 
 ### Requirements
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -57,7 +57,8 @@ server cannot be reused by accident.
 
 Targets:
 
-- `stario` — this checkout with no-op tracing
+- `stario` — this checkout with no-op tracing (Python httptools protocol)
+- `stario-cython` — same app on the Cython/llhttp protocol stack (`cython-core`)
 - `fastapi` — FastAPI on one Uvicorn worker
 - `blacksheep-uvicorn` — BlackSheep on one Uvicorn worker
 - `blacksheep-granian` — BlackSheep on one Granian worker
@@ -68,6 +69,9 @@ Targets:
 - One worker/process per framework.
 - Same paths: `/plaintext`, `/json`, `/user/42`, and `POST /validate`.
 - Same `wrk` settings for every run.
+- Each endpoint is measured multiple times (`RUNS`, default 7). The first
+  `WARMUP` samples are discarded, then IQR outlier trimming is applied before
+  reporting median requests/sec ± sample stdev.
 - Stario response compression disabled with negative codec levels.
 - JSON response bodies use `ujson` for Stario and FastAPI to match Sanic's
   `ujson` dependency more closely.
@@ -105,6 +109,7 @@ The default run is the standard comparison shape:
 - `DURATION=10s`
 - `THREADS=2`
 - `CONNECTIONS=128`
+- `RUNS=7` measured samples per endpoint (plus `WARMUP=2` discarded warmup runs)
 - `PORT=3000` as the base port
 - one process or worker per target
 
@@ -115,15 +120,17 @@ that run.
 Common options:
 
 ```bash
-DURATION=30s THREADS=2 CONNECTIONS=128 benchmarks/server/run.sh
-benchmarks/server/run.sh stario blacksheep-granian
+DURATION=30s THREADS=2 CONNECTIONS=128 RUNS=9 WARMUP=2 benchmarks/server/run.sh
+benchmarks/server/run.sh stario stario-cython blacksheep-granian
 PORT=3999 benchmarks/server/run.sh
 REFRESH_ENVS=1 benchmarks/server/run.sh
 KEEP_RAW=1 benchmarks/server/run.sh
+WRK=/path/to/wrk benchmarks/server/run.sh
+BROTLI_PKG_CONFIG=/opt/brotli/lib/pkgconfig benchmarks/server/run.sh stario-cython
 ```
 
 `PORT` is a base port, not a shared port. The runner assigns fixed offsets per
-target (`stario` on `PORT`, `fastapi` on `PORT+1`, and so on) and checks each
+target (`stario` on `PORT`, `stario-cython` on `PORT+1`, and so on) and checks each
 port before starting a server.
 
 Each run writes a timestamped directory under `benchmarks/server/results/`:

--- a/benchmarks/server/apps/blacksheep_app.py
+++ b/benchmarks/server/apps/blacksheep_app.py
@@ -4,6 +4,8 @@ import ujson
 from blacksheep import Application, Content, Request, Response
 from blacksheep.server.responses import text as text_response
 
+from apps.common import validate_fields
+
 HELLO = "Hello, World!"
 JSON_CONTENT_TYPE = b"application/json"
 
@@ -34,16 +36,38 @@ async def get_user(user_id: str) -> Response:
 
 @app.router.post("/validate")
 async def validate(request: Request) -> Response:
-    body = ujson.loads(await request.read())
-    name = body.get("name")
-    age = body.get("age")
+    payload, status = validate_fields(ujson.loads(await request.read()))
+    return json_response(payload, status)
 
-    if not isinstance(name, str) or not name:
-        return json_response({"error": "name must be a non-empty string"}, 400)
-    if not isinstance(age, int) or age < 0 or age > 150:
-        return json_response(
-            {"error": "age must be an integer between 0 and 150"},
-            400,
-        )
 
-    return json_response({"name": name, "age": age, "valid": True})
+@app.router.post("/form")
+async def post_form(request: Request) -> Response:
+    await request.read()
+    return Response(204)
+
+
+@app.router.post("/echo/json")
+async def post_echo_json(request: Request) -> Response:
+    body = await request.read()
+    return json_response({"bytes": len(body)})
+
+
+@app.router.post("/ingest/64k")
+@app.router.post("/ingest/2m")
+async def ingest_buffer(request: Request) -> Response:
+    body = await request.read()
+    return json_response({"bytes": len(body)})
+
+
+@app.router.post("/ingest/stream/2m")
+async def ingest_stream(request: Request) -> Response:
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+    return json_response({"bytes": total})
+
+
+@app.router.post("/upload")
+async def upload(request: Request) -> Response:
+    body = await request.read()
+    return json_response({"bytes": len(body)})

--- a/benchmarks/server/apps/blacksheep_app.py
+++ b/benchmarks/server/apps/blacksheep_app.py
@@ -1,62 +1,61 @@
 # pyright: reportMissingImports=false
 
 import ujson
-from blacksheep import Application, Content, Request, Response
-from blacksheep.server.responses import text as text_response
+from blacksheep import Application, Request, Response
+from blacksheep.server.responses import json as bs_json
+from blacksheep.server.responses import no_content, text as text_response
+from blacksheep.server.routing import Router
+from blacksheep.settings.json import json_settings
 
 from apps.common import validate_fields
 
 HELLO = "Hello, World!"
 JSON_CONTENT_TYPE = b"application/json"
 
-app = Application(show_error_details=False)
+json_settings.use(loads=ujson.loads, dumps=ujson.dumps)
 
-
-def json_response(value: object, status: int = 200) -> Response:
-    return Response(
-        status,
-        content=Content(JSON_CONTENT_TYPE, ujson.dumps(value).encode("utf-8")),
-    )
+app = Application(router=Router(), show_error_details=False)
 
 
 @app.router.get("/plaintext")
-async def plaintext():
+async def plaintext(request: Request) -> Response:
     return text_response(HELLO)
 
 
 @app.router.get("/json")
-async def json_endpoint() -> Response:
-    return json_response({"message": HELLO})
+async def json_endpoint(request: Request) -> Response:
+    return bs_json({"message": HELLO})
 
 
 @app.router.get("/user/{user_id}")
-async def get_user(user_id: str) -> Response:
-    return json_response({"id": user_id, "name": f"User {user_id}"})
+async def get_user(request: Request) -> Response:
+    user_id = request.route_values["user_id"]
+    return bs_json({"id": user_id, "name": f"User {user_id}"})
 
 
 @app.router.post("/validate")
 async def validate(request: Request) -> Response:
     payload, status = validate_fields(ujson.loads(await request.read()))
-    return json_response(payload, status)
+    return bs_json(payload, status)
 
 
 @app.router.post("/form")
 async def post_form(request: Request) -> Response:
     await request.read()
-    return Response(204)
+    return no_content()
 
 
 @app.router.post("/echo/json")
 async def post_echo_json(request: Request) -> Response:
     body = await request.read()
-    return json_response({"bytes": len(body)})
+    return bs_json({"bytes": len(body)})
 
 
 @app.router.post("/ingest/64k")
 @app.router.post("/ingest/2m")
 async def ingest_buffer(request: Request) -> Response:
     body = await request.read()
-    return json_response({"bytes": len(body)})
+    return bs_json({"bytes": len(body)})
 
 
 @app.router.post("/ingest/stream/2m")
@@ -64,10 +63,10 @@ async def ingest_stream(request: Request) -> Response:
     total = 0
     async for chunk in request.stream():
         total += len(chunk)
-    return json_response({"bytes": total})
+    return bs_json({"bytes": total})
 
 
 @app.router.post("/upload")
 async def upload(request: Request) -> Response:
     body = await request.read()
-    return json_response({"bytes": len(body)})
+    return bs_json({"bytes": len(body)})

--- a/benchmarks/server/apps/common.py
+++ b/benchmarks/server/apps/common.py
@@ -1,0 +1,27 @@
+# pyright: reportMissingImports=false
+
+"""Shared constants and helpers for benchmark apps."""
+
+from __future__ import annotations
+
+HELLO = "Hello, World!"
+JSON_CONTENT_TYPE = b"application/json"
+FORM_BODY = b"name=Ada&age=42&source=benchmark"
+
+PAYLOAD_1K = 1024
+PAYLOAD_64K = 64 * 1024
+PAYLOAD_2M = 2 * 1024 * 1024
+
+
+def validate_fields(data: dict) -> tuple[dict, int]:
+    name = data.get("name")
+    age = data.get("age")
+    if not isinstance(name, str) or not name:
+        return {"error": "name must be a non-empty string"}, 400
+    if not isinstance(age, int) or age < 0 or age > 150:
+        return {"error": "age must be an integer between 0 and 150"}, 400
+    return {"name": name, "age": age, "valid": True}, 200
+
+
+def byte_count(value: int) -> dict[str, int]:
+    return {"bytes": value}

--- a/benchmarks/server/apps/django_bolt/api.py
+++ b/benchmarks/server/apps/django_bolt/api.py
@@ -2,6 +2,8 @@ import msgspec
 from django_bolt import BoltAPI
 from django_bolt.responses import PlainText
 
+from apps.common import validate_fields
+
 HELLO = "Hello, World!"
 api = BoltAPI()
 
@@ -28,8 +30,30 @@ class UserInput(msgspec.Struct):
 
 @api.post("/validate")
 async def validate(body: UserInput):
-    if not body.name:
-        return {"error": "name must be a non-empty string"}, 400
-    if body.age < 0 or body.age > 150:
-        return {"error": "age must be an integer between 0 and 150"}, 400
-    return {"name": body.name, "age": body.age, "valid": True}
+    payload, status = validate_fields({"name": body.name, "age": body.age})
+    if status != 200:
+        return payload, status
+    return payload
+
+
+@api.post("/form")
+async def post_form(request):
+    _ = request.body
+    return PlainText("", status_code=204)
+
+
+@api.post("/echo/json")
+async def post_echo_json(request):
+    return {"bytes": len(request.body)}
+
+
+@api.post("/ingest/64k")
+@api.post("/ingest/2m")
+@api.post("/ingest/stream/2m")
+async def ingest_buffer(request):
+    return {"bytes": len(request.body)}
+
+
+@api.post("/upload")
+async def upload(request):
+    return {"bytes": len(request.body)}

--- a/benchmarks/server/apps/django_bolt/api.py
+++ b/benchmarks/server/apps/django_bolt/api.py
@@ -1,0 +1,35 @@
+import msgspec
+from django_bolt import BoltAPI
+from django_bolt.responses import PlainText
+
+HELLO = "Hello, World!"
+api = BoltAPI()
+
+
+@api.get("/plaintext")
+async def plaintext():
+    return PlainText(HELLO)
+
+
+@api.get("/json")
+async def json_endpoint():
+    return {"message": HELLO}
+
+
+@api.get("/user/{user_id}")
+async def get_user(user_id: str):
+    return {"id": user_id, "name": f"User {user_id}"}
+
+
+class UserInput(msgspec.Struct):
+    name: str
+    age: int
+
+
+@api.post("/validate")
+async def validate(body: UserInput):
+    if not body.name:
+        return {"error": "name must be a non-empty string"}, 400
+    if body.age < 0 or body.age > 150:
+        return {"error": "age must be an integer between 0 and 150"}, 400
+    return {"name": body.name, "age": body.age, "valid": True}

--- a/benchmarks/server/apps/django_bolt/api.py
+++ b/benchmarks/server/apps/django_bolt/api.py
@@ -1,11 +1,11 @@
-import msgspec
+import ujson
 from django_bolt import BoltAPI
 from django_bolt.responses import PlainText
 
 from apps.common import validate_fields
 
 HELLO = "Hello, World!"
-api = BoltAPI()
+api = BoltAPI(validate_response=False)
 
 
 @api.get("/plaintext")
@@ -23,14 +23,9 @@ async def get_user(user_id: str):
     return {"id": user_id, "name": f"User {user_id}"}
 
 
-class UserInput(msgspec.Struct):
-    name: str
-    age: int
-
-
 @api.post("/validate")
-async def validate(body: UserInput):
-    payload, status = validate_fields({"name": body.name, "age": body.age})
+async def validate(request):
+    payload, status = validate_fields(ujson.loads(request.body))
     if status != 200:
         return payload, status
     return payload

--- a/benchmarks/server/apps/django_bolt/api.py
+++ b/benchmarks/server/apps/django_bolt/api.py
@@ -49,8 +49,12 @@ async def post_echo_json(request):
 
 @api.post("/ingest/64k")
 @api.post("/ingest/2m")
-@api.post("/ingest/stream/2m")
 async def ingest_buffer(request):
+    return {"bytes": len(request.body)}
+
+
+@api.post("/ingest/stream/2m")
+async def ingest_stream(request):
     return {"bytes": len(request.body)}
 
 

--- a/benchmarks/server/apps/django_bolt/manage.py
+++ b/benchmarks/server/apps/django_bolt/manage.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "apps.django_bolt.settings")
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/benchmarks/server/apps/django_bolt/settings.py
+++ b/benchmarks/server/apps/django_bolt/settings.py
@@ -1,0 +1,28 @@
+"""Minimal Django project for django-bolt benchmarks."""
+
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = "benchmark-only-not-for-production"
+DEBUG = False
+ALLOWED_HOSTS = ["*"]
+
+INSTALLED_APPS = [
+    "django_bolt.apps.DjangoBoltConfig",
+]
+
+MIDDLEWARE = []
+
+ROOT_URLCONF = "apps.django_bolt.urls"
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}
+
+USE_TZ = True
+
+BOLT_API = ["apps.django_bolt.api:api"]

--- a/benchmarks/server/apps/django_bolt/settings.py
+++ b/benchmarks/server/apps/django_bolt/settings.py
@@ -26,3 +26,5 @@ DATABASES = {
 USE_TZ = True
 
 BOLT_API = ["apps.django_bolt.api:api"]
+BOLT_MAX_UPLOAD_SIZE = 3 * 1024 * 1024
+BOLT_COMPRESSION = None

--- a/benchmarks/server/apps/django_bolt/urls.py
+++ b/benchmarks/server/apps/django_bolt/urls.py
@@ -1,0 +1,1 @@
+urlpatterns = []

--- a/benchmarks/server/apps/fastapi_app.py
+++ b/benchmarks/server/apps/fastapi_app.py
@@ -1,19 +1,15 @@
 # pyright: reportMissingImports=false
 
 import ujson
-from fastapi import FastAPI
-from fastapi.responses import PlainTextResponse, Response
-from pydantic import BaseModel, Field
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import PlainTextResponse
+
+from apps.common import validate_fields
 
 HELLO = "Hello, World!"
 JSON_MEDIA_TYPE = "application/json"
 
 app = FastAPI()
-
-
-class UserInput(BaseModel):
-    name: str = Field(min_length=1)
-    age: int = Field(ge=0, le=150)
 
 
 def json_response(value: object, status_code: int = 200) -> Response:
@@ -40,5 +36,39 @@ async def get_user(user_id: str) -> Response:
 
 
 @app.post("/validate")
-async def validate(body: UserInput) -> Response:
-    return json_response({"name": body.name, "age": body.age, "valid": True})
+async def validate(request: Request) -> Response:
+    payload, status = validate_fields(ujson.loads(await request.body()))
+    return json_response(payload, status)
+
+
+@app.post("/form")
+async def post_form(request: Request) -> Response:
+    await request.body()
+    return Response(status_code=204)
+
+
+@app.post("/echo/json")
+async def post_echo_json(request: Request) -> Response:
+    body = await request.body()
+    return json_response({"bytes": len(body)})
+
+
+@app.post("/ingest/64k")
+@app.post("/ingest/2m")
+async def ingest_buffer(request: Request) -> Response:
+    body = await request.body()
+    return json_response({"bytes": len(body)})
+
+
+@app.post("/ingest/stream/2m")
+async def ingest_stream(request: Request) -> Response:
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+    return json_response({"bytes": total})
+
+
+@app.post("/upload")
+async def upload(request: Request) -> Response:
+    body = await request.body()
+    return json_response({"bytes": len(body)})

--- a/benchmarks/server/apps/fastapi_app.py
+++ b/benchmarks/server/apps/fastapi_app.py
@@ -3,13 +3,14 @@
 import ujson
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import PlainTextResponse
+from starlette.routing import Route
 
 from apps.common import validate_fields
 
 HELLO = "Hello, World!"
 JSON_MEDIA_TYPE = "application/json"
 
-app = FastAPI()
+app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
 
 
 def json_response(value: object, status_code: int = 200) -> Response:
@@ -20,47 +21,39 @@ def json_response(value: object, status_code: int = 200) -> Response:
     )
 
 
-@app.get("/plaintext")
-async def plaintext() -> PlainTextResponse:
+async def plaintext(_request: Request) -> PlainTextResponse:
     return PlainTextResponse(HELLO)
 
 
-@app.get("/json")
-async def json_endpoint() -> Response:
+async def json_endpoint(_request: Request) -> Response:
     return json_response({"message": HELLO})
 
 
-@app.get("/user/{user_id}")
-async def get_user(user_id: str) -> Response:
+async def get_user(request: Request) -> Response:
+    user_id = request.path_params["user_id"]
     return json_response({"id": user_id, "name": f"User {user_id}"})
 
 
-@app.post("/validate")
 async def validate(request: Request) -> Response:
     payload, status = validate_fields(ujson.loads(await request.body()))
     return json_response(payload, status)
 
 
-@app.post("/form")
 async def post_form(request: Request) -> Response:
     await request.body()
     return Response(status_code=204)
 
 
-@app.post("/echo/json")
 async def post_echo_json(request: Request) -> Response:
     body = await request.body()
     return json_response({"bytes": len(body)})
 
 
-@app.post("/ingest/64k")
-@app.post("/ingest/2m")
 async def ingest_buffer(request: Request) -> Response:
     body = await request.body()
     return json_response({"bytes": len(body)})
 
 
-@app.post("/ingest/stream/2m")
 async def ingest_stream(request: Request) -> Response:
     total = 0
     async for chunk in request.stream():
@@ -68,7 +61,20 @@ async def ingest_stream(request: Request) -> Response:
     return json_response({"bytes": total})
 
 
-@app.post("/upload")
 async def upload(request: Request) -> Response:
     body = await request.body()
     return json_response({"bytes": len(body)})
+
+
+app.router.routes = [
+    Route("/plaintext", plaintext, methods=["GET"]),
+    Route("/json", json_endpoint, methods=["GET"]),
+    Route("/user/{user_id}", get_user, methods=["GET"]),
+    Route("/validate", validate, methods=["POST"]),
+    Route("/form", post_form, methods=["POST"]),
+    Route("/echo/json", post_echo_json, methods=["POST"]),
+    Route("/ingest/64k", ingest_buffer, methods=["POST"]),
+    Route("/ingest/2m", ingest_buffer, methods=["POST"]),
+    Route("/ingest/stream/2m", ingest_stream, methods=["POST"]),
+    Route("/upload", upload, methods=["POST"]),
+]

--- a/benchmarks/server/apps/granian_rsgi_app.py
+++ b/benchmarks/server/apps/granian_rsgi_app.py
@@ -2,8 +2,25 @@
 
 import ujson
 
+from apps.common import validate_fields
+
 HELLO = "Hello, World!"
 JSON_HEADERS = [("content-type", "application/json")]
+
+
+def _json_bytes(value: object) -> bytes:
+    return ujson.dumps(value).encode()
+
+
+async def _read_buffer(proto) -> bytes:
+    return await proto()
+
+
+async def _read_stream(proto) -> int:
+    total = 0
+    async for chunk in proto:
+        total += len(chunk)
+    return total
 
 
 async def app(scope, proto):
@@ -22,37 +39,33 @@ async def app(scope, proto):
         proto.response_bytes(
             200,
             JSON_HEADERS,
-            ujson.dumps({"message": HELLO}).encode(),
+            _json_bytes({"message": HELLO}),
         )
     elif method == "GET" and path.startswith("/user/"):
         user_id = path.rsplit("/", 1)[-1]
-        body = ujson.dumps({"id": user_id, "name": f"User {user_id}"})
-        proto.response_bytes(200, JSON_HEADERS, body.encode())
-    elif method == "POST" and path == "/validate":
-        raw = await proto()
-        data = ujson.loads(raw)
-        name = data.get("name")
-        age = data.get("age")
-        if not isinstance(name, str) or not name:
-            proto.response_bytes(
-                400,
-                JSON_HEADERS,
-                ujson.dumps({"error": "name must be a non-empty string"}).encode(),
-            )
-            return
-        if not isinstance(age, int) or age < 0 or age > 150:
-            proto.response_bytes(
-                400,
-                JSON_HEADERS,
-                ujson.dumps(
-                    {"error": "age must be an integer between 0 and 150"}
-                ).encode(),
-            )
-            return
         proto.response_bytes(
             200,
             JSON_HEADERS,
-            ujson.dumps({"name": name, "age": age, "valid": True}).encode(),
+            _json_bytes({"id": user_id, "name": f"User {user_id}"}),
         )
+    elif method == "POST" and path == "/validate":
+        raw = await _read_buffer(proto)
+        payload, status = validate_fields(ujson.loads(raw))
+        proto.response_bytes(status, JSON_HEADERS, _json_bytes(payload))
+    elif method == "POST" and path == "/form":
+        await _read_buffer(proto)
+        proto.response_empty(204, [])
+    elif method == "POST" and path == "/echo/json":
+        raw = await _read_buffer(proto)
+        proto.response_bytes(200, JSON_HEADERS, _json_bytes({"bytes": len(raw)}))
+    elif method == "POST" and path in {"/ingest/64k", "/ingest/2m"}:
+        raw = await _read_buffer(proto)
+        proto.response_bytes(200, JSON_HEADERS, _json_bytes({"bytes": len(raw)}))
+    elif method == "POST" and path == "/ingest/stream/2m":
+        total = await _read_stream(proto)
+        proto.response_bytes(200, JSON_HEADERS, _json_bytes({"bytes": total}))
+    elif method == "POST" and path == "/upload":
+        raw = await _read_buffer(proto)
+        proto.response_bytes(200, JSON_HEADERS, _json_bytes({"bytes": len(raw)}))
     else:
         proto.response_str(404, [], "Not Found")

--- a/benchmarks/server/apps/granian_rsgi_app.py
+++ b/benchmarks/server/apps/granian_rsgi_app.py
@@ -1,0 +1,58 @@
+# pyright: reportMissingImports=false
+
+import ujson
+
+HELLO = "Hello, World!"
+JSON_HEADERS = [("content-type", "application/json")]
+
+
+async def app(scope, proto):
+    if scope.proto != "http":
+        return
+
+    path, method = scope.path, scope.method
+
+    if method == "GET" and path == "/plaintext":
+        proto.response_str(
+            200,
+            [("content-type", "text/plain; charset=utf-8")],
+            HELLO,
+        )
+    elif method == "GET" and path == "/json":
+        proto.response_bytes(
+            200,
+            JSON_HEADERS,
+            ujson.dumps({"message": HELLO}).encode(),
+        )
+    elif method == "GET" and path.startswith("/user/"):
+        user_id = path.rsplit("/", 1)[-1]
+        body = ujson.dumps({"id": user_id, "name": f"User {user_id}"})
+        proto.response_bytes(200, JSON_HEADERS, body.encode())
+    elif method == "POST" and path == "/validate":
+        raw = await proto()
+        data = ujson.loads(raw)
+        name = data.get("name")
+        age = data.get("age")
+        if not isinstance(name, str) or not name:
+            proto.response_bytes(
+                400,
+                JSON_HEADERS,
+                ujson.dumps({"error": "name must be a non-empty string"}).encode(),
+            )
+            return
+        if not isinstance(age, int) or age < 0 or age > 150:
+            proto.response_bytes(
+                400,
+                JSON_HEADERS,
+                ujson.dumps(
+                    {"error": "age must be an integer between 0 and 150"}
+                ).encode(),
+            )
+            return
+        proto.response_bytes(
+            200,
+            JSON_HEADERS,
+            ujson.dumps({"name": name, "age": age, "valid": True}).encode(),
+        )
+    else:
+        proto.response_str(404, [], "Not Found")

--- a/benchmarks/server/apps/robyn_app.py
+++ b/benchmarks/server/apps/robyn_app.py
@@ -1,0 +1,44 @@
+# pyright: reportMissingImports=false
+
+import os
+
+from robyn import Config, Robyn
+
+config = Config()
+app = Robyn(__file__, config=config)
+
+HELLO = "Hello, World!"
+
+
+@app.get("/plaintext")
+async def plaintext():
+    return HELLO
+
+
+@app.get("/json")
+async def json_endpoint():
+    return {"message": HELLO}
+
+
+@app.get("/user/:user_id")
+async def get_user(request):
+    user_id = request.path_params["user_id"]
+    return {"id": user_id, "name": f"User {user_id}"}
+
+
+@app.post("/validate")
+async def validate(request):
+    body = request.json() or {}
+    name = body.get("name")
+    age = body.get("age")
+    if not isinstance(name, str) or not name:
+        return {"error": "name must be a non-empty string"}, 400
+    if not isinstance(age, int) or age < 0 or age > 150:
+        return {"error": "age must be an integer between 0 and 150"}, 400
+    return {"name": name, "age": age, "valid": True}
+
+
+if __name__ == "__main__":
+    host = os.environ.get("BENCH_HOST", "127.0.0.1")
+    port = int(os.environ.get("BENCH_PORT", "8080"))
+    app.start(host=host, port=port, _check_port=False)

--- a/benchmarks/server/apps/robyn_app.py
+++ b/benchmarks/server/apps/robyn_app.py
@@ -2,7 +2,10 @@
 
 import os
 
+import ujson
 from robyn import Config, Robyn
+from robyn.jsonify import jsonify
+from robyn.robyn import Headers, Response
 
 from apps.common import validate_fields
 
@@ -37,8 +40,15 @@ async def get_user(request):
 
 @app.post("/validate")
 async def validate(request):
-    payload, status = validate_fields(request.json() or {})
-    return payload, status
+    raw = _body_bytes(request)
+    payload, status = validate_fields(ujson.loads(raw) if raw else {})
+    if status != 200:
+        return Response(
+            status_code=status,
+            headers=Headers({"Content-Type": "application/json"}),
+            description=jsonify(payload),
+        )
+    return payload
 
 
 @app.post("/form")

--- a/benchmarks/server/apps/robyn_app.py
+++ b/benchmarks/server/apps/robyn_app.py
@@ -4,10 +4,19 @@ import os
 
 from robyn import Config, Robyn
 
+from apps.common import validate_fields
+
 config = Config()
 app = Robyn(__file__, config=config)
 
 HELLO = "Hello, World!"
+
+
+def _body_bytes(request) -> bytes:
+    body = request.body
+    if isinstance(body, str):
+        return body.encode("utf-8")
+    return body or b""
 
 
 @app.get("/plaintext")
@@ -28,14 +37,36 @@ async def get_user(request):
 
 @app.post("/validate")
 async def validate(request):
-    body = request.json() or {}
-    name = body.get("name")
-    age = body.get("age")
-    if not isinstance(name, str) or not name:
-        return {"error": "name must be a non-empty string"}, 400
-    if not isinstance(age, int) or age < 0 or age > 150:
-        return {"error": "age must be an integer between 0 and 150"}, 400
-    return {"name": name, "age": age, "valid": True}
+    payload, status = validate_fields(request.json() or {})
+    return payload, status
+
+
+@app.post("/form")
+async def post_form(request):
+    _body_bytes(request)
+    return "", 204
+
+
+@app.post("/echo/json")
+async def post_echo_json(request):
+    body = _body_bytes(request)
+    return {"bytes": len(body)}
+
+
+@app.post("/ingest/64k")
+@app.post("/ingest/2m")
+@app.post("/ingest/stream/2m")
+async def ingest_buffer(request):
+    body = _body_bytes(request)
+    return {"bytes": len(body)}
+
+
+@app.post("/upload")
+async def upload(request):
+    total = sum(len(data) for data in request.files.values())
+    if total == 0:
+        total = len(_body_bytes(request))
+    return {"bytes": total}
 
 
 if __name__ == "__main__":

--- a/benchmarks/server/apps/robyn_app.py
+++ b/benchmarks/server/apps/robyn_app.py
@@ -55,18 +55,21 @@ async def post_echo_json(request):
 
 @app.post("/ingest/64k")
 @app.post("/ingest/2m")
-@app.post("/ingest/stream/2m")
 async def ingest_buffer(request):
+    body = _body_bytes(request)
+    return {"bytes": len(body)}
+
+
+@app.post("/ingest/stream/2m")
+async def ingest_stream(request):
     body = _body_bytes(request)
     return {"bytes": len(body)}
 
 
 @app.post("/upload")
 async def upload(request):
-    total = sum(len(data) for data in request.files.values())
-    if total == 0:
-        total = len(_body_bytes(request))
-    return {"bytes": total}
+    body = _body_bytes(request)
+    return {"bytes": len(body)}
 
 
 if __name__ == "__main__":

--- a/benchmarks/server/apps/sanic_app.py
+++ b/benchmarks/server/apps/sanic_app.py
@@ -2,14 +2,17 @@
 
 import argparse
 
-from sanic import Sanic, json, text
+from sanic import Sanic, empty, json, text
+
+from apps.common import validate_fields
 
 HELLO = "Hello, World!"
 
 app = Sanic("stario_benchmark_sanic")
 app.config.ACCESS_LOG = False
-app.config.RESPONSE_TIMEOUT = 60
-app.config.REQUEST_TIMEOUT = 60
+app.config.RESPONSE_TIMEOUT = 120
+app.config.REQUEST_TIMEOUT = 120
+app.config.REQUEST_MAX_SIZE = 4 * 1024 * 1024
 
 
 @app.get("/plaintext")
@@ -29,19 +32,41 @@ async def get_user(request, user_id: str):
 
 @app.post("/validate")
 async def validate(request):
-    body = request.json or {}
-    name = body.get("name")
-    age = body.get("age")
+    payload, status = validate_fields(request.json or {})
+    return json(payload, status=status)
 
-    if not isinstance(name, str) or not name:
-        return json({"error": "name must be a non-empty string"}, status=400)
-    if not isinstance(age, int) or age < 0 or age > 150:
-        return json(
-            {"error": "age must be an integer between 0 and 150"},
-            status=400,
-        )
 
-    return json({"name": name, "age": age, "valid": True})
+@app.post("/form")
+async def post_form(request):
+    await request.read()
+    return empty()
+
+
+@app.post("/echo/json")
+async def post_echo_json(request):
+    body = await request.read()
+    return json({"bytes": len(body)})
+
+
+@app.post("/ingest/64k", name="ingest_64k")
+@app.post("/ingest/2m", name="ingest_2m")
+async def ingest_buffer(request):
+    body = await request.read()
+    return json({"bytes": len(body)})
+
+
+@app.post("/ingest/stream/2m", name="ingest_stream_2m")
+async def ingest_stream(request):
+    total = 0
+    async for chunk in request.stream:
+        total += len(chunk)
+    return json({"bytes": total})
+
+
+@app.post("/upload")
+async def upload(request):
+    body = await request.read()
+    return json({"bytes": len(body)})
 
 
 if __name__ == "__main__":

--- a/benchmarks/server/apps/sanic_app.py
+++ b/benchmarks/server/apps/sanic_app.py
@@ -2,7 +2,9 @@
 
 import argparse
 
+import ujson
 from sanic import Sanic, empty, json, text
+from sanic.views import stream
 
 from apps.common import validate_fields
 
@@ -10,6 +12,7 @@ HELLO = "Hello, World!"
 
 app = Sanic("stario_benchmark_sanic")
 app.config.ACCESS_LOG = False
+app.config.MOTD = False
 app.config.RESPONSE_TIMEOUT = 120
 app.config.REQUEST_TIMEOUT = 120
 app.config.REQUEST_MAX_SIZE = 4 * 1024 * 1024
@@ -32,30 +35,29 @@ async def get_user(request, user_id: str):
 
 @app.post("/validate")
 async def validate(request):
-    payload, status = validate_fields(request.json or {})
+    payload, status = validate_fields(ujson.loads(request.body))
     return json(payload, status=status)
 
 
 @app.post("/form")
 async def post_form(request):
-    await request.read()
+    _ = request.body
     return empty()
 
 
 @app.post("/echo/json")
 async def post_echo_json(request):
-    body = await request.read()
-    return json({"bytes": len(body)})
+    return json({"bytes": len(request.body)})
 
 
 @app.post("/ingest/64k", name="ingest_64k")
 @app.post("/ingest/2m", name="ingest_2m")
 async def ingest_buffer(request):
-    body = await request.read()
-    return json({"bytes": len(body)})
+    return json({"bytes": len(request.body)})
 
 
 @app.post("/ingest/stream/2m", name="ingest_stream_2m")
+@stream
 async def ingest_stream(request):
     total = 0
     async for chunk in request.stream:
@@ -65,8 +67,7 @@ async def ingest_stream(request):
 
 @app.post("/upload")
 async def upload(request):
-    body = await request.read()
-    return json({"bytes": len(body)})
+    return json({"bytes": len(request.body)})
 
 
 if __name__ == "__main__":
@@ -80,4 +81,5 @@ if __name__ == "__main__":
         single_process=True,
         access_log=False,
         debug=False,
+        motd=False,
     )

--- a/benchmarks/server/apps/socketify_app.py
+++ b/benchmarks/server/apps/socketify_app.py
@@ -1,11 +1,48 @@
 # pyright: reportMissingImports=false
 
 import os
+from io import BytesIO
 
+from apps.common import validate_fields
 from socketify import App, AppListenOptions
 
 HELLO = "Hello, World!"
 app = App()
+
+# Pin response wrappers while C callbacks are in flight (Py3.14 + socketify ffi GC bug).
+_INFLIGHT: dict[int, object] = {}
+
+
+def _pin(res):
+    _INFLIGHT[id(res)] = res
+    return res
+
+
+def _unpin(res):
+    _INFLIGHT.pop(id(res), None)
+
+
+async def _read_body(res) -> bytes:
+    res = _pin(res)
+    done = res.app.loop.create_future()
+    buffer = BytesIO()
+
+    def on_chunk(_response, chunk, is_end):
+        if chunk is not None:
+            buffer.write(chunk)
+        if is_end and not done.done():
+            done.set_result(buffer.getvalue())
+
+    def on_aborted(_response):
+        if not done.done():
+            done.set_result(b"")
+
+    try:
+        res.on_aborted(on_aborted)
+        res.on_data(on_chunk)
+        return await done
+    finally:
+        _unpin(res)
 
 
 def plaintext(res, req):
@@ -23,23 +60,47 @@ def get_user(res, req):
 
 async def validate(res, req):
     body = await res.get_json() or {}
-    name = body.get("name")
-    age = body.get("age")
-    if not isinstance(name, str) or not name:
-        return res.write_status(400).end(
-            {"error": "name must be a non-empty string"}
-        )
-    if not isinstance(age, int) or age < 0 or age > 150:
-        return res.write_status(400).end(
-            {"error": "age must be an integer between 0 and 150"}
-        )
-    res.end({"name": name, "age": age, "valid": True})
+    payload, status = validate_fields(body)
+    if status != 200:
+        return res.write_status(status).end(payload)
+    res.end(payload)
+
+
+async def post_form(res, req):
+    await _read_body(res)
+    res.write_status(204).end_without_body()
+
+
+async def post_echo_json(res, req):
+    data = await _read_body(res)
+    res.end({"bytes": len(data)})
+
+
+async def ingest_buffer(res, req):
+    data = await _read_body(res)
+    res.end({"bytes": len(data)})
+
+
+async def ingest_stream(res, req):
+    data = await _read_body(res)
+    res.end({"bytes": len(data)})
+
+
+async def upload(res, req):
+    data = await _read_body(res)
+    res.end({"bytes": len(data)})
 
 
 app.get("/plaintext", plaintext)
 app.get("/json", json_endpoint)
 app.get("/user/:user_id", get_user)
 app.post("/validate", validate)
+app.post("/form", post_form)
+app.post("/echo/json", post_echo_json)
+app.post("/ingest/64k", ingest_buffer)
+app.post("/ingest/2m", ingest_buffer)
+app.post("/ingest/stream/2m", ingest_stream)
+app.post("/upload", upload)
 
 host = os.environ.get("BENCH_HOST", "127.0.0.1")
 port = int(os.environ.get("BENCH_PORT", "3000"))

--- a/benchmarks/server/apps/socketify_app.py
+++ b/benchmarks/server/apps/socketify_app.py
@@ -3,11 +3,14 @@
 import os
 from io import BytesIO
 
+import ujson
+
 from apps.common import validate_fields
 from socketify import App, AppListenOptions
 
 HELLO = "Hello, World!"
 app = App()
+app.json_serializer(ujson)
 
 # Pin response wrappers while C callbacks are in flight (Py3.14 + socketify ffi GC bug).
 _INFLIGHT: dict[int, object] = {}
@@ -59,7 +62,8 @@ def get_user(res, req):
 
 
 async def validate(res, req):
-    body = await res.get_json() or {}
+    raw = await _read_body(res)
+    body = ujson.loads(raw) if raw else {}
     payload, status = validate_fields(body)
     if status != 200:
         return res.write_status(status).end(payload)

--- a/benchmarks/server/apps/socketify_app.py
+++ b/benchmarks/server/apps/socketify_app.py
@@ -1,0 +1,47 @@
+# pyright: reportMissingImports=false
+
+import os
+
+from socketify import App, AppListenOptions
+
+HELLO = "Hello, World!"
+app = App()
+
+
+def plaintext(res, req):
+    res.end(HELLO)
+
+
+def json_endpoint(res, req):
+    res.end({"message": HELLO})
+
+
+def get_user(res, req):
+    user_id = req.get_parameter(0)
+    res.end({"id": user_id, "name": f"User {user_id}"})
+
+
+async def validate(res, req):
+    body = await res.get_json() or {}
+    name = body.get("name")
+    age = body.get("age")
+    if not isinstance(name, str) or not name:
+        return res.write_status(400).end(
+            {"error": "name must be a non-empty string"}
+        )
+    if not isinstance(age, int) or age < 0 or age > 150:
+        return res.write_status(400).end(
+            {"error": "age must be an integer between 0 and 150"}
+        )
+    res.end({"name": name, "age": age, "valid": True})
+
+
+app.get("/plaintext", plaintext)
+app.get("/json", json_endpoint)
+app.get("/user/:user_id", get_user)
+app.post("/validate", validate)
+
+host = os.environ.get("BENCH_HOST", "127.0.0.1")
+port = int(os.environ.get("BENCH_PORT", "3000"))
+app.listen(AppListenOptions(port=port, host=host), lambda _cfg: None)
+app.run()

--- a/benchmarks/server/apps/socketify_app.py
+++ b/benchmarks/server/apps/socketify_app.py
@@ -81,9 +81,33 @@ async def ingest_buffer(res, req):
     res.end({"bytes": len(data)})
 
 
+async def _read_stream(res) -> int:
+    res = _pin(res)
+    done = res.app.loop.create_future()
+    total = 0
+
+    def on_chunk(_response, chunk, is_end):
+        nonlocal total
+        if chunk is not None:
+            total += len(chunk)
+        if is_end and not done.done():
+            done.set_result(total)
+
+    def on_aborted(_response):
+        if not done.done():
+            done.set_result(0)
+
+    try:
+        res.on_aborted(on_aborted)
+        res.on_data(on_chunk)
+        return await done
+    finally:
+        _unpin(res)
+
+
 async def ingest_stream(res, req):
-    data = await _read_body(res)
-    res.end({"bytes": len(data)})
+    total = await _read_stream(res)
+    res.end({"bytes": total})
 
 
 async def upload(res, req):

--- a/benchmarks/server/apps/stario_app.py
+++ b/benchmarks/server/apps/stario_app.py
@@ -3,10 +3,10 @@
 import ujson
 
 import stario.responses as responses
+from apps.common import JSON_CONTENT_TYPE, validate_fields
 from stario import App, Span
 
 HELLO = "Hello, World!"
-JSON_CONTENT_TYPE = b"application/json"
 
 
 def json_response(w, value, status: int = 200) -> None:
@@ -28,17 +28,35 @@ async def get_user(c, w):
 
 async def validate(c, w):
     body = ujson.loads(await c.req.body())
-    name = body.get("name")
-    age = body.get("age")
+    payload, status = validate_fields(body)
+    json_response(w, payload, status)
 
-    if not isinstance(name, str) or not name:
-        json_response(w, {"error": "name must be a non-empty string"}, 400)
-        return
-    if not isinstance(age, int) or age < 0 or age > 150:
-        json_response(w, {"error": "age must be an integer between 0 and 150"}, 400)
-        return
 
-    json_response(w, {"name": name, "age": age, "valid": True})
+async def post_form(c, w):
+    await c.req.body()
+    responses.empty(w)
+
+
+async def post_echo_json(c, w):
+    body = await c.req.body()
+    json_response(w, {"bytes": len(body)})
+
+
+async def ingest_buffer(c, w):
+    body = await c.req.body()
+    json_response(w, {"bytes": len(body)})
+
+
+async def ingest_stream(c, w):
+    total = 0
+    async for chunk in c.req.stream():
+        total += len(chunk)
+    json_response(w, {"bytes": total})
+
+
+async def upload(c, w):
+    body = await c.req.body()
+    json_response(w, {"bytes": len(body)})
 
 
 async def bootstrap(app: App, span: Span) -> None:
@@ -46,4 +64,10 @@ async def bootstrap(app: App, span: Span) -> None:
     app.get("/json", json_endpoint)
     app.get("/user/{user_id}", get_user)
     app.post("/validate", validate)
+    app.post("/form", post_form)
+    app.post("/echo/json", post_echo_json)
+    app.post("/ingest/64k", ingest_buffer)
+    app.post("/ingest/2m", ingest_buffer)
+    app.post("/ingest/stream/2m", ingest_stream)
+    app.post("/upload", upload)
     yield

--- a/benchmarks/server/baseline-20260824.md
+++ b/benchmarks/server/baseline-20260824.md
@@ -1,0 +1,77 @@
+# Server benchmark baseline (2026-08-24)
+
+Reference run for PR comparing Stario (Python + Cython), native HTTP servers,
+and ASGI stacks. **Relative comparisons on one machine** — not lab-grade absolutes.
+
+## Reproduce
+
+```bash
+cd projects/stario   # or repo root
+WRK=wrk BROTLI_PKG_CONFIG=/path/to/brotli/pkgconfig \
+  RUNS=5 WARMUP=1 DURATION=10s THREADS=2 \
+  CONNECTIONS=128 UPLOAD_CONNECTIONS=32 \
+  ENDPOINT_TIER=all \
+  benchmarks/server/run.sh
+```
+
+Recorded commit: `3bb24f1` on branch `cursor/cython-benchmarks-e27e`.
+
+## Environment
+
+| | |
+|---|---|
+| CPU | Intel Xeon (KVM), 4 vCPUs, x86_64, AVX-512 |
+| RAM | 15 GiB, no swap |
+| OS | Linux 6.12.94+ |
+| Python | 3.14.7 |
+| Client | wrk 4.2.0, `-t2 -c128` (read/small upload), `-c32` (64KB/2MB) |
+| Topology | wrk and servers on same host, `127.0.0.1` loopback |
+
+## Methodology
+
+- One worker/process per target.
+- 10 endpoints: read (`plaintext`, `json`, `params`) + upload (`validate`,
+  `post-form`, `post-json-1k`, `post-octet-64k`, `post-octet-2m`,
+  `post-stream-2m`, `multipart-2m`).
+- 5 measured runs + 1 warmup per endpoint; IQR outlier trimming.
+- Median requests/sec ± sample stdev reported below.
+
+## Results — read-heavy
+
+| Server | Plaintext | JSON | Params |
+| --- | ---: | ---: | ---: |
+| Stario (Cython llhttp) | 120,378 ± 24,710 | 117,556 ± 10,384 | 104,519 ± 7,598 |
+| Socketify | 120,992 ± 1,098 | 95,237 ± 1,121 | 75,609 ± 603 |
+| Granian RSGI | 86,164 ± 29,130 | 118,099 ± 7,727 | 133,193 ± 19,391 |
+| BlackSheep + Granian | 111,574 ± 2,003 | 107,530 ± 903 | 99,344 ± 12,083 |
+| Stario (Python httptools) | 63,268 ± 1,006 | 68,999 ± 565 | 59,443 ± 3,394 |
+| BlackSheep + Uvicorn | 59,195 ± 98 | 58,258 ± 195 | 52,311 ± 2,156 |
+| Sanic | 53,032 ± 307 | 47,943 ± 168 | 46,673 ± 364 |
+| Django-Bolt | 30,670 ± 180 | 31,665 ± 167 | 30,432 ± 68 |
+| Robyn | 25,735 ± 166 | 25,241 ± 173 | 19,436 ± 24 |
+| FastAPI + Uvicorn | 23,803 ± 37 | 23,108 ± 64 | 18,355 ± 26 |
+
+## Results — upload / body
+
+| Server | Validate | Form | JSON 1K | 64KB | 2MB buf | 2MB stream | Multipart 2MB |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Granian RSGI | 106,976 ± 1,384 | 117,994 ± 140 | 110,114 ± 1,463 | 30,740 ± 9 | 1,434 ± 15 | 3,153 ± 38 | 3,089 ± 35 |
+| Stario (Cython) | 82,402 ± 1,389 | 94,288 ± 1,018 | 87,420 ± 3,343 | 30,842 ± 533 | 2,037 ± 47 | 2,619 ± 133 | 1,971 ± 106 |
+| Stario (Python) | 50,417 ± 2,599 | 54,616 ± 815 | 52,212 ± 2,789 | 18,151 ± 591 | 1,729 ± 138 | 2,900 ± 138 | 2,050 ± 62 |
+| BlackSheep + Uvicorn | 50,554 ± 382 | 56,769 ± 635 | 50,824 ± 153 | 17,244 ± 452 | 767 ± 15 | 2,027 ± 4 | 736 ± 15 |
+| BlackSheep + Granian | 43,031 ± 64 | 45,683 ± 5,485 | 34,101 ± 1,635 | 14,912 ± 2,597 | 1,057 ± 21 | 2,256 ± 289 | 977 ± 115 |
+| Django-Bolt | 30,181 ± 423 | 26,281 ± 108 | 23,276 ± 1,948 | 25,146 ± 2,307 | 27,590 ± 270 | 27,139 ± 160 | 27,097 ± 619 |
+| Sanic | 34,843 ± 53 | 3,654 ± 11 | 3,736 ± 3 | 3,128 ± 36 | 943 ± 20 | 1,235 ± 36 | 935 ± 33 |
+| FastAPI + Uvicorn | 19,190 ± 172 | 21,458 ± 181 | 19,017 ± 86 | 12,872 ± 367 | 1,468 ± 33 | 1,876 ± 22 | 1,482 ± 36 |
+| Socketify | 13,314 ± 99 | 20,080 ± 740 | 13,562 ± 622 | 12,502 ± 850 | 668 ± 19 | 4,244 ± 19 | 682 ± 6 |
+| Robyn | 4,730 ± 8 | 4,798 ± 8 | 18,307 ± 14 | 15,518 ± 104 | 664 ± 54 | 887 ± 18 | 492 ± 43 |
+
+## Notes
+
+- Stario Cython ~1.9× Python on read paths; ~1.6× on validate.
+- Stario Cython ties Granian RSGI on 64KB ingest (~30.8k vs ~30.7k).
+- 2MB cases: Stario/Granian/Robyn/Socketify sit in a bandwidth-limited band
+  (~0.6–3k RPS). Django-Bolt reports ~27k — likely different body-handling
+  semantics (Rust buffer, O(1) length in Python), not higher loopback throughput.
+- Robyn and Django-Bolt buffer the full body on `/ingest/stream/2m` (no streaming API).
+- Route parity documented in `benchmarks/README.md`.

--- a/benchmarks/server/baseline-20260824.md
+++ b/benchmarks/server/baseline-20260824.md
@@ -1,20 +1,20 @@
-# Server benchmark baseline (2026-08-24)
+# Server benchmark baseline (2026-08-24 / refreshed 2026-08-25)
 
-Reference run for PR comparing Stario (Python + Cython), native HTTP servers,
-and ASGI stacks. **Relative comparisons on one machine** — not lab-grade absolutes.
+Reference for comparing **Stario Cython** (and Python) against native HTTP servers
+and ASGI stacks. Relative comparisons on one machine — not lab-grade absolutes.
+
+**Going forward:** treat the Stario Cython row as the baseline for Cython protocol
+work. Re-run the same suite after changes and compare median ± stdev to these numbers.
 
 ## Reproduce
 
 ```bash
-cd projects/stario   # or repo root
 WRK=wrk BROTLI_PKG_CONFIG=/path/to/brotli/pkgconfig \
   RUNS=5 WARMUP=1 DURATION=10s THREADS=2 \
   CONNECTIONS=128 UPLOAD_CONNECTIONS=32 \
   ENDPOINT_TIER=all \
   benchmarks/server/run.sh
 ```
-
-Recorded commit: `3bb24f1` on branch `cursor/cython-benchmarks-e27e`.
 
 ## Environment
 
@@ -33,45 +33,93 @@ Recorded commit: `3bb24f1` on branch `cursor/cython-benchmarks-e27e`.
 - 10 endpoints: read (`plaintext`, `json`, `params`) + upload (`validate`,
   `post-form`, `post-json-1k`, `post-octet-64k`, `post-octet-2m`,
   `post-stream-2m`, `multipart-2m`).
-- 5 measured runs + 1 warmup per endpoint; IQR outlier trimming.
-- Median requests/sec ± sample stdev reported below.
+- Primary full suite: **5 measured + 1 warmup**, `DURATION=10s`, IQR trimming
+  (run `20260824T171421Z`, commit `3bb24f1`).
+- Corrected apps (Sanic body API, Robyn validate Response, Django-Bolt upload
+  limit, FastAPI Starlette routes): confirmatory refresh **3 measured + 1 warmup**,
+  `DURATION=5s` (run `20260825T083949Z`, commit `dd57bdc`).
+- Handlers **compute responses per request** (no reused/static `Response` objects,
+  no pre-serialized JSON bytes). See `benchmarks/README.md` handler policy.
 
-## Results — read-heavy
+## Stario Cython baseline (comparison anchor)
 
-| Server | Plaintext | JSON | Params |
-| --- | ---: | ---: | ---: |
-| Stario (Cython llhttp) | 120,378 ± 24,710 | 117,556 ± 10,384 | 104,519 ± 7,598 |
-| Socketify | 120,992 ± 1,098 | 95,237 ± 1,121 | 75,609 ± 603 |
-| Granian RSGI | 86,164 ± 29,130 | 118,099 ± 7,727 | 133,193 ± 19,391 |
-| BlackSheep + Granian | 111,574 ± 2,003 | 107,530 ± 903 | 99,344 ± 12,083 |
-| Stario (Python httptools) | 63,268 ± 1,006 | 68,999 ± 565 | 59,443 ± 3,394 |
-| BlackSheep + Uvicorn | 59,195 ± 98 | 58,258 ± 195 | 52,311 ± 2,156 |
-| Sanic | 53,032 ± 307 | 47,943 ± 168 | 46,673 ± 364 |
-| Django-Bolt | 30,670 ± 180 | 31,665 ± 167 | 30,432 ± 68 |
-| Robyn | 25,735 ± 166 | 25,241 ± 173 | 19,436 ± 24 |
-| FastAPI + Uvicorn | 23,803 ± 37 | 23,108 ± 64 | 18,355 ± 26 |
+Primary full suite (`10s` × 5 runs):
 
-## Results — upload / body
+| Endpoint | Median req/s ± stdev |
+| --- | ---: |
+| Plaintext | 120,378 ± 24,710 |
+| JSON | 117,556 ± 10,384 |
+| Params | 104,519 ± 7,598 |
+| Validate | 82,402 ± 1,389 |
+| Form POST | 94,288 ± 1,018 |
+| JSON 1KB | 87,420 ± 3,343 |
+| Octet 64KB | 30,842 ± 533 |
+| Octet 2MB (buffer) | 2,037 ± 47 |
+| Octet 2MB (stream) | 2,619 ± 133 |
+| Multipart 2MB | 1,971 ± 106 |
 
-| Server | Validate | Form | JSON 1K | 64KB | 2MB buf | 2MB stream | Multipart 2MB |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| Granian RSGI | 106,976 ± 1,384 | 117,994 ± 140 | 110,114 ± 1,463 | 30,740 ± 9 | 1,434 ± 15 | 3,153 ± 38 | 3,089 ± 35 |
-| Stario (Cython) | 82,402 ± 1,389 | 94,288 ± 1,018 | 87,420 ± 3,343 | 30,842 ± 533 | 2,037 ± 47 | 2,619 ± 133 | 1,971 ± 106 |
-| Stario (Python) | 50,417 ± 2,599 | 54,616 ± 815 | 52,212 ± 2,789 | 18,151 ± 591 | 1,729 ± 138 | 2,900 ± 138 | 2,050 ± 62 |
-| BlackSheep + Uvicorn | 50,554 ± 382 | 56,769 ± 635 | 50,824 ± 153 | 17,244 ± 452 | 767 ± 15 | 2,027 ± 4 | 736 ± 15 |
-| BlackSheep + Granian | 43,031 ± 64 | 45,683 ± 5,485 | 34,101 ± 1,635 | 14,912 ± 2,597 | 1,057 ± 21 | 2,256 ± 289 | 977 ± 115 |
-| Django-Bolt | 30,181 ± 423 | 26,281 ± 108 | 23,276 ± 1,948 | 25,146 ± 2,307 | 27,590 ± 270 | 27,139 ± 160 | 27,097 ± 619 |
-| Sanic | 34,843 ± 53 | 3,654 ± 11 | 3,736 ± 3 | 3,128 ± 36 | 943 ± 20 | 1,235 ± 36 | 935 ± 33 |
-| FastAPI + Uvicorn | 19,190 ± 172 | 21,458 ± 181 | 19,017 ± 86 | 12,872 ± 367 | 1,468 ± 33 | 1,876 ± 22 | 1,482 ± 36 |
-| Socketify | 13,314 ± 99 | 20,080 ± 740 | 13,562 ± 622 | 12,502 ± 850 | 668 ± 19 | 4,244 ± 19 | 682 ± 6 |
-| Robyn | 4,730 ± 8 | 4,798 ± 8 | 18,307 ± 14 | 15,518 ± 104 | 664 ± 54 | 887 ± 18 | 492 ± 43 |
+Confirmatory refresh (`5s` × 3 runs) — same machine, shows run-to-run noise:
+
+| Endpoint | Median req/s ± stdev |
+| --- | ---: |
+| Plaintext | 125,436 ± 4,971 |
+| JSON | 119,054 ± 6,789 |
+| Params | 121,619 ± 4,259 |
+| Validate | 110,118 ± 408 |
+| Form POST | 124,616 ± 4,699 |
+| JSON 1KB | 108,319 ± 453 |
+| Octet 64KB | 33,300 ± 475 |
+| Octet 2MB (buffer) | 2,125 ± 44 |
+| Octet 2MB (stream) | 3,063 ± 26 |
+| Multipart 2MB | 2,121 ± 32 |
+
+Stario Cython vs Stario Python (primary suite): ~**1.9×** on read paths, ~**1.6×** on validate.
+
+## Full comparison — read-heavy
+
+| Server | Plaintext | JSON | Params | Source |
+| --- | ---: | ---: | ---: | --- |
+| Stario (Cython llhttp) | 120,378 ± 24,710 | 117,556 ± 10,384 | 104,519 ± 7,598 | primary |
+| Socketify | 120,992 ± 1,098 | 95,237 ± 1,121 | 75,609 ± 603 | primary |
+| Granian RSGI | 86,164 ± 29,130 | 118,099 ± 7,727 | 133,193 ± 19,391 | primary |
+| BlackSheep + Granian | 111,574 ± 2,003 | 107,530 ± 903 | 99,344 ± 12,083 | primary |
+| Stario (Python httptools) | 63,268 ± 1,006 | 68,999 ± 565 | 59,443 ± 3,394 | primary |
+| BlackSheep + Uvicorn | 59,195 ± 98 | 58,258 ± 195 | 52,311 ± 2,156 | primary |
+| Sanic | 52,746 ± 765 | 47,592 ± 366 | 46,434 ± 337 | refresh |
+| FastAPI + Uvicorn | 47,533 ± 441 | 45,285 ± 586 | 42,607 ± 92 | refresh† |
+| Django-Bolt | 28,084 ± 1,559 | 29,002 ± 242 | 27,795 ± 124 | refresh |
+| Robyn | 25,416 ± 109 | 25,149 ± 121 | 19,187 ± 67 | refresh |
+
+† FastAPI uses Starlette `Route` registration (not `@app.get` APIRoute) with
+**per-request** `PlainTextResponse` / `ujson` serialization — no static responses.
+
+## Full comparison — upload / body
+
+| Server | Validate | Form | JSON 1K | 64KB | 2MB buf | 2MB stream | Multipart | Source |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| Granian RSGI | 106,976 ± 1,384 | 117,994 ± 140 | 110,114 ± 1,463 | 30,740 ± 9 | 1,434 ± 15 | 3,153 ± 38 | 3,089 ± 35 | primary |
+| Stario (Cython) | 82,402 ± 1,389 | 94,288 ± 1,018 | 87,420 ± 3,343 | 30,842 ± 533 | 2,037 ± 47 | 2,619 ± 133 | 1,971 ± 106 | primary |
+| Stario (Python) | 50,417 ± 2,599 | 54,616 ± 815 | 52,212 ± 2,789 | 18,151 ± 591 | 1,729 ± 138 | 2,900 ± 138 | 2,050 ± 62 | primary |
+| BlackSheep + Uvicorn | 50,554 ± 382 | 56,769 ± 635 | 50,824 ± 153 | 17,244 ± 452 | 767 ± 15 | 2,027 ± 4 | 736 ± 15 | primary |
+| Sanic | 34,731 ± 127 | 45,072 ± 676 | 35,235 ± 318 | 15,110 ± 143 | 1,360 ± 52 | 1,628 ± 471 | 1,363 ± 25 | refresh‡ |
+| FastAPI + Uvicorn | 34,263 ± 563 | 40,166 ± 633 | 34,453 ± 104 | 15,019 ± 75 | 1,460 ± 20 | 1,927 ± 531 | 1,507 ± 15 | refresh† |
+| BlackSheep + Granian | 43,031 ± 64 | 45,683 ± 5,485 | 34,101 ± 1,635 | 14,912 ± 2,597 | 1,057 ± 21 | 2,256 ± 289 | 977 ± 115 | primary |
+| Django-Bolt | 23,067 ± 69 | 24,937 ± 42 | 21,103 ± 4,946 | 25,639 ± 362 | 1,446 ± 15 | 1,454 ± 9 | 1,484 ± 9 | refresh§ |
+| Robyn | 18,070 ± 47 | 4,714 ± 50 | 17,861 ± 86 | 15,324 ± 50 | 692 ± 58 | 770 ± 89 | 386 ± 75 | refresh¶ |
+| Socketify | 13,314 ± 99 | 20,080 ± 740 | 13,562 ± 622 | 12,502 ± 850 | 668 ± 19 | 4,244 ± 19 | 682 ± 6 | primary |
+
+‡ Sanic: primary suite used invalid `request.read()` (Sanic 25.x) — form/json-1k
+columns were ~3.7k error throughput. Refresh uses `request.body`.
+
+§ Django-Bolt: primary 2MB columns (~27k) were **413 Payload too large** (1MB default
+limit). Refresh sets `BOLT_MAX_UPLOAD_SIZE=3MB` — real ingest ~1.5k.
+
+¶ Robyn: primary validate (~4.7k) was **HTTP 500** (bad return tuple). Refresh
+returns a proper Response / dict.
 
 ## Notes
 
-- Stario Cython ~1.9× Python on read paths; ~1.6× on validate.
-- Stario Cython ties Granian RSGI on 64KB ingest (~30.8k vs ~30.7k).
-- 2MB cases: Stario/Granian/Robyn/Socketify sit in a bandwidth-limited band
-  (~0.6–3k RPS). Django-Bolt reports ~27k — likely different body-handling
-  semantics (Rust buffer, O(1) length in Python), not higher loopback throughput.
+- Stario Cython ties Granian RSGI on 64KB ingest (~30.8k vs ~30.7k, primary).
+- 2MB cases for honest full-body handlers sit in a bandwidth-limited band (~0.6–3k RPS).
 - Robyn and Django-Bolt buffer the full body on `/ingest/stream/2m` (no streaming API).
-- Route parity documented in `benchmarks/README.md`.
+- Route parity and handler policy: `benchmarks/README.md`.

--- a/benchmarks/server/fixtures/generate.py
+++ b/benchmarks/server/fixtures/generate.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Generate binary and JSON payload fixtures for upload benchmarks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURES = Path(__file__).resolve().parent
+
+
+def _pattern(size: int) -> bytes:
+    return bytes(i % 256 for i in range(size))
+
+
+def main() -> None:
+    FIXTURES.mkdir(parents=True, exist_ok=True)
+    for name, size in (
+        ("payload-1k.bin", 1024),
+        ("payload-64k.bin", 64 * 1024),
+        ("payload-2m.bin", 2 * 1024 * 1024),
+    ):
+        path = FIXTURES / name
+        if not path.exists() or path.stat().st_size != size:
+            path.write_bytes(_pattern(size))
+
+    json_path = FIXTURES / "payload-1k.json"
+    payload = {"marker": "benchmark", "data": "x" * 980}
+    encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    if len(encoded) < 1024:
+        payload["pad"] = "y" * (1024 - len(encoded) - 20)
+        encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    json_path.write_bytes(encoded[:1024].ljust(1024, b"x"))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/server/run.sh
+++ b/benchmarks/server/run.sh
@@ -11,9 +11,13 @@ PORT="${PORT:-3000}"
 DURATION="${DURATION:-10s}"
 THREADS="${THREADS:-2}"
 CONNECTIONS="${CONNECTIONS:-${CONCURRENCY:-128}}"
+RUNS="${RUNS:-7}"
+WARMUP="${WARMUP:-2}"
 PYTHON="${PYTHON:-3.14}"
 KEEP_RAW="${KEEP_RAW:-0}"
-TARGETS=(stario fastapi blacksheep-uvicorn blacksheep-granian sanic)
+WRK="${WRK:-wrk}"
+BROTLI_PKG_CONFIG="${BROTLI_PKG_CONFIG:-}"
+TARGETS=(stario stario-cython fastapi blacksheep-uvicorn blacksheep-granian sanic)
 ENDPOINTS=(plaintext json params validate)
 
 RUN_DIR=""
@@ -23,12 +27,16 @@ SERVER_CMD=()
 
 usage() {
   cat <<'EOF'
-Usage: benchmarks/server/run.sh [stario|fastapi|blacksheep-uvicorn|blacksheep-granian|sanic ...]
+Usage: benchmarks/server/run.sh [stario|stario-cython|fastapi|blacksheep-uvicorn|blacksheep-granian|sanic ...]
 
-Environment: DURATION=10s THREADS=2 CONNECTIONS=128 HOST=127.0.0.1 PORT=3000 PYTHON=3.14 REFRESH_ENVS=1 KEEP_RAW=1
+Environment: DURATION=10s THREADS=2 CONNECTIONS=128 RUNS=7 WARMUP=2 HOST=127.0.0.1
+             PORT=3000 PYTHON=3.14 REFRESH_ENVS=1 KEEP_RAW=1 WRK=wrk
 
-PORT is the base port. Targets use fixed offsets: stario=PORT, fastapi=PORT+1,
-blacksheep-uvicorn=PORT+2, blacksheep-granian=PORT+3, sanic=PORT+4.
+Each endpoint is measured RUNS times; the first WARMUP samples are discarded,
+then IQR outlier trimming is applied before reporting median RPS ± stdev.
+
+PORT is the base port. Targets use fixed offsets: stario=PORT, stario-cython=PORT+1,
+fastapi=PORT+2, blacksheep-uvicorn=PORT+3, blacksheep-granian=PORT+4, sanic=PORT+5.
 EOF
 }
 
@@ -119,9 +127,36 @@ ensure_env() {
   fi
 }
 
+build_stario_cython() {
+  local python="$1"
+  local pkg_config_path="$BROTLI_PKG_CONFIG"
+  if [[ -z "$pkg_config_path" ]]; then
+    for candidate in \
+      /tmp/brotli-install/lib/pkgconfig \
+      /usr/lib/x86_64-linux-gnu/pkgconfig \
+      /usr/local/lib/pkgconfig; do
+      if [[ -f "$candidate/libbrotlienc.pc" ]]; then
+        pkg_config_path="$candidate"
+        break
+      fi
+    done
+  fi
+  if [[ -z "$pkg_config_path" ]] || ! PKG_CONFIG_PATH="$pkg_config_path" pkg-config --exists libbrotlienc libbrotlicommon; then
+    echo "Missing Brotli development libraries for stario-cython." >&2
+    echo "Install libbrotli-dev or set BROTLI_PKG_CONFIG to a directory with libbrotlienc.pc." >&2
+    exit 1
+  fi
+  echo "  building stario_cython extensions (PKG_CONFIG_PATH=$pkg_config_path)"
+  (cd "$ROOT" && PKG_CONFIG_PATH="$pkg_config_path" "$python" setup.py)
+}
+
 ensure_target() {
   case "$1" in
     stario) ensure_env stario "stario @ file://$ROOT" uvloop ujson ;;
+    stario-cython)
+      ensure_env stario-cython "stario @ file://$ROOT" uvloop ujson cython setuptools wheel
+      build_stario_cython "$(python_for stario-cython)"
+      ;;
     fastapi) ensure_env fastapi fastapi 'uvicorn[standard]' ujson ;;
     blacksheep-uvicorn) ensure_env blacksheep-uvicorn blacksheep 'uvicorn[standard]' ujson ;;
     blacksheep-granian) ensure_env blacksheep-granian blacksheep granian uvloop ujson ;;
@@ -144,7 +179,7 @@ uvicorn_cmd() {
 
 command_for() {
   case "$1" in
-    stario)
+    stario|stario-cython)
       export STARIO_HOST="$HOST"
       export STARIO_PORT="$SERVER_PORT"
       export STARIO_LOOP=uvloop
@@ -152,9 +187,16 @@ command_for() {
       export STARIO_COMPRESS_ZSTD_LEVEL=-1
       export STARIO_COMPRESS_BROTLI_LEVEL=-1
       export STARIO_COMPRESS_GZIP_LEVEL=-1
-      SERVER_CMD=(
-        "$(python_for stario)" -m stario.cli serve apps.stario_app:bootstrap
-      )
+      if [[ "$1" == stario-cython ]]; then
+        SERVER_CMD=(
+          env PYTHONPATH="$ROOT/src:$BENCHMARK_DIR"
+          "$(python_for stario-cython)" -m stario_cython apps.stario_app:bootstrap
+        )
+      else
+        SERVER_CMD=(
+          "$(python_for stario)" -m stario.cli serve apps.stario_app:bootstrap
+        )
+      fi
       ;;
     fastapi)
       uvicorn_cmd fastapi apps.fastapi_app:app
@@ -223,13 +265,39 @@ start_server() {
   wait_ready "$log"
 }
 
+aggregate_samples() {
+  local stats_file="$1" python="$2"
+  "$python" "$BENCHMARK_DIR/stats.py" >"$stats_file"
+}
+
 run_endpoint() {
-  local target="$1" endpoint="$2" out="$RUN_DIR/$target.$endpoint.txt"
-  local cmd=(wrk -t "$THREADS" -c "$CONNECTIONS" -d "$DURATION")
+  local target="$1" endpoint="$2" venv_python samples_file stats_file sample raw_out run_idx total
+  local url="http://$HOST:$SERVER_PORT$(path_for "$endpoint")"
+  local cmd=("$WRK" -t "$THREADS" -c "$CONNECTIONS" -d "$DURATION")
   [[ "$endpoint" == validate ]] && cmd+=(-s "$BENCHMARK_DIR/validate.lua")
-  echo "  $endpoint"
-  "${cmd[@]}" "http://$HOST:$SERVER_PORT$(path_for "$endpoint")" >"$out"
-  awk '/Requests\/sec:/ {print $2}' "$out" >"$RUN_DIR/$target.$endpoint.rps"
+
+  samples_file="$RUN_DIR/$target.$endpoint.samples"
+  stats_file="$RUN_DIR/$target.$endpoint.stats.json"
+  : >"$samples_file"
+  venv_python="$(python_for "$target")"
+
+  total=$((RUNS + WARMUP))
+  echo "  $endpoint ($RUNS measured runs, $WARMUP warmup discarded)"
+  for ((run_idx = 1; run_idx <= total; run_idx++)); do
+    raw_out="$RUN_DIR/$target.$endpoint.run${run_idx}.txt"
+    "${cmd[@]}" "$url" >"$raw_out"
+    sample="$(awk '/Requests\/sec:/ {print $2; exit}' "$raw_out")"
+    [[ -n "$sample" ]] || { echo "Failed to parse wrk output: $raw_out" >&2; exit 1; }
+    if ((run_idx > WARMUP)); then
+      echo "$sample" >>"$samples_file"
+    fi
+    if [[ "$KEEP_RAW" != 1 ]]; then
+      rm -f "$raw_out"
+    fi
+  done
+
+  aggregate_samples "$stats_file" "$venv_python" <"$samples_file"
+  "$venv_python" -c 'import json,sys; print(f"{json.load(sys.stdin)["median"]:.2f}")' <"$stats_file" >"$RUN_DIR/$target.$endpoint.rps"
 }
 
 run_target() {
@@ -244,24 +312,55 @@ run_target() {
   stop_server
 }
 
+format_cell() {
+  local stats_file="$1" python="$2"
+  "$python" - "$stats_file" <<'PY'
+import json
+import pathlib
+import sys
+
+stats = json.loads(pathlib.Path(sys.argv[1]).read_text())
+
+def fmt(value: float) -> str:
+    return f"{value:,.0f}"
+
+median = fmt(stats["median"])
+stdev = fmt(stats["stdev"])
+outliers = stats["outliers_removed"]
+cell = f"{median} ± {stdev}"
+if outliers:
+    cell += f" ({outliers} outlier{'s' if outliers != 1 else ''} removed)"
+print(cell)
+PY
+}
+
 print_summary() {
-  local target endpoint value rps_file table="$RUN_DIR/summary.md"
+  local target endpoint stats_file table="$RUN_DIR/summary.md" venv_python
   : >"$table"
   {
-    echo "## Single-worker framework comparison"; echo
+    echo "## Single-worker framework comparison"
+    echo
+    echo "Median requests/sec ± sample stdev after discarding $WARMUP warmup run(s)"
+    echo "and applying IQR outlier trimming across $RUNS measured samples per endpoint."
+    echo
     echo "| Target | Plaintext | JSON | Params | Validate |"
     echo "| --- | ---: | ---: | ---: | ---: |"
     for target in "$@"; do
+      venv_python="$(python_for "$target")"
       printf '| %s ' "$target"
       for endpoint in "${ENDPOINTS[@]}"; do
-        value="-"; rps_file="$RUN_DIR/$target.$endpoint.rps"
-        [[ -f "$rps_file" ]] && value="$(format_int "$(printf '%.0f' "$(cat "$rps_file")")")"
-        printf '| %s ' "$value"
+        stats_file="$RUN_DIR/$target.$endpoint.stats.json"
+        if [[ -f "$stats_file" ]]; then
+          cell="$(format_cell "$stats_file" "$venv_python")"
+          printf '| %s ' "$cell"
+        else
+          printf '| - '
+        fi
       done
       echo "|"
     done
   } | tee "$table"
-  rm -f "$RUN_DIR"/*.rps
+  rm -f "$RUN_DIR"/*.rps "$RUN_DIR"/*.samples
 }
 
 cleanup_raw_outputs() {
@@ -271,13 +370,19 @@ cleanup_raw_outputs() {
   for target in "$@"; do
     rm -f "$RUN_DIR/$target.server.log"
     for endpoint in "${ENDPOINTS[@]}"; do
-      rm -f "$RUN_DIR/$target.$endpoint.txt"
+      rm -f "$RUN_DIR/$target.$endpoint.txt" "$RUN_DIR/$target.$endpoint.run"*.txt
+      rm -f "$RUN_DIR/$target.$endpoint.stats.json"
     done
   done
 }
 
 main() {
-  need uv; need wrk; need curl
+  need uv; need curl
+  if ! command -v "$WRK" >/dev/null 2>&1; then
+    echo "Missing wrk executable: $WRK" >&2
+    echo "Install wrk or set WRK=/path/to/wrk." >&2
+    exit 1
+  fi
   trap stop_server EXIT INT TERM
 
   local selected=("$@") target
@@ -293,9 +398,13 @@ base_port=$PORT
 duration=$DURATION
 threads=$THREADS
 connections=$CONNECTIONS
+runs=$RUNS
+warmup=$WARMUP
 python=$PYTHON
-client=wrk
+client=$WRK
 keep_raw=$KEEP_RAW
+git_sha=$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)
+git_branch=$(git -C "$ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
 payload_file=benchmarks/server/validate.lua
 ports=$(port_list)
 EOF

--- a/benchmarks/server/run.sh
+++ b/benchmarks/server/run.sh
@@ -39,7 +39,28 @@ SUMMARY_GROUPS=(
   "Native HTTP servers|socketify robyn granian-rsgi sanic django-bolt"
   "ASGI framework stacks|blacksheep-granian blacksheep-uvicorn fastapi"
 )
-ENDPOINTS=(plaintext json params validate)
+READ_ENDPOINTS=(plaintext json params)
+UPLOAD_ENDPOINTS=(validate post-form post-json-1k post-octet-64k post-octet-2m post-stream-2m multipart-2m)
+DEFAULT_ENDPOINTS=( "${READ_ENDPOINTS[@]}" "${UPLOAD_ENDPOINTS[@]}" )
+if [[ -n "${ENDPOINTS:-}" ]]; then
+  ENDPOINTS_CSV="$ENDPOINTS"
+else
+  ENDPOINTS_CSV=""
+fi
+ENDPOINTS=()
+UPLOAD_CONNECTIONS="${UPLOAD_CONNECTIONS:-32}"
+ENDPOINT_LABELS=(
+  "plaintext|Plaintext"
+  "json|JSON"
+  "params|Params"
+  "validate|Validate JSON"
+  "post-form|Form POST"
+  "post-json-1k|JSON 1KB"
+  "post-octet-64k|Octet 64KB"
+  "post-octet-2m|Octet 2MB (buffer)"
+  "post-stream-2m|Octet 2MB (stream)"
+  "multipart-2m|Multipart 2MB"
+)
 
 RUN_DIR=""
 SERVER_PID=""
@@ -56,11 +77,17 @@ Targets (default: all):
   Native HTTP servers: socketify, robyn, granian-rsgi, sanic, django-bolt
   ASGI stacks:         blacksheep-granian, blacksheep-uvicorn, fastapi
 
-Environment: DURATION=10s THREADS=2 CONNECTIONS=128 RUNS=7 WARMUP=2 HOST=127.0.0.1
-             PORT=3000 PYTHON=3.14 REFRESH_ENVS=1 KEEP_RAW=1 WRK=wrk
+Environment: DURATION=10s THREADS=2 CONNECTIONS=128 UPLOAD_CONNECTIONS=32
+             RUNS=7 WARMUP=2 HOST=127.0.0.1 PORT=3000 PYTHON=3.14
+             ENDPOINT_TIER=all|read|upload  ENDPOINTS=csv  REFRESH_ENVS=1 KEEP_RAW=1
 
-Each endpoint is measured RUNS times; the first WARMUP samples are discarded,
-then IQR outlier trimming is applied before reporting median RPS ± stdev.
+Endpoint tiers:
+  read   — plaintext, json, params
+  upload — validate, post-form, post-json-1k, post-octet-64k, post-octet-2m,
+           post-stream-2m, multipart-2m
+  all    — every endpoint (default)
+
+Large upload cases use UPLOAD_CONNECTIONS (default 32) instead of CONNECTIONS.
 
 PORT is the base port. Targets use fixed offsets in TARGETS order (stario=PORT,
 stario-cython=PORT+1, socketify=PORT+2, ...).
@@ -95,7 +122,86 @@ path_for() {
     json) echo /json ;;
     params) echo /user/42 ;;
     validate) echo /validate ;;
+    post-form) echo /form ;;
+    post-json-1k) echo /echo/json ;;
+    post-octet-64k) echo /ingest/64k ;;
+    post-octet-2m) echo /ingest/2m ;;
+    post-stream-2m) echo /ingest/stream/2m ;;
+    multipart-2m) echo /upload ;;
+    *)
+      echo "Unknown endpoint: $1" >&2
+      return 1
+      ;;
   esac
+}
+
+script_for() {
+  case "$1" in
+    validate) echo "$BENCHMARK_DIR/validate.lua" ;;
+    post-form) echo "$BENCHMARK_DIR/scripts/post-form.lua" ;;
+    post-json-1k) echo "$BENCHMARK_DIR/scripts/post-json-1k.lua" ;;
+    post-octet-64k) echo "$BENCHMARK_DIR/scripts/post-octet-64k.lua" ;;
+    post-octet-2m) echo "$BENCHMARK_DIR/scripts/post-octet-2m.lua" ;;
+    post-stream-2m) echo "$BENCHMARK_DIR/scripts/post-stream-2m.lua" ;;
+    multipart-2m) echo "$BENCHMARK_DIR/scripts/multipart-2m.lua" ;;
+    *) echo "" ;;
+  esac
+}
+
+endpoint_label() {
+  local endpoint="$1" entry label
+  for entry in "${ENDPOINT_LABELS[@]}"; do
+    label="${entry#*|}"
+    if [[ "${entry%%|*}" == "$endpoint" ]]; then
+      echo "$label"
+      return 0
+    fi
+  done
+  echo "$endpoint"
+}
+
+endpoint_selected() {
+  local endpoint="$1" item
+  for item in "${ENDPOINTS[@]}"; do
+    [[ "$item" == "$endpoint" ]] && return 0
+  done
+  return 1
+}
+
+connections_for() {
+  case "$1" in
+    post-octet-64k|post-octet-2m|post-stream-2m|multipart-2m)
+      echo "$UPLOAD_CONNECTIONS"
+      ;;
+    *)
+      echo "$CONNECTIONS"
+      ;;
+  esac
+}
+
+parse_endpoints() {
+  if [[ -n "${ENDPOINTS_CSV:-}" ]]; then
+    IFS=',' read -ra ENDPOINTS <<< "$ENDPOINTS_CSV"
+    return
+  fi
+  if [[ -n "${ENDPOINT_TIER:-}" ]]; then
+    case "$ENDPOINT_TIER" in
+      read|core) ENDPOINTS=("${READ_ENDPOINTS[@]}") ;;
+      upload) ENDPOINTS=("${UPLOAD_ENDPOINTS[@]}") ;;
+      all) ENDPOINTS=("${DEFAULT_ENDPOINTS[@]}") ;;
+      *)
+        echo "Unknown ENDPOINT_TIER: $ENDPOINT_TIER (use read, upload, or all)" >&2
+        exit 1
+        ;;
+    esac
+    return
+  fi
+  ENDPOINTS=("${DEFAULT_ENDPOINTS[@]}")
+}
+
+ensure_fixtures() {
+  local python="$1"
+  "$python" "$BENCHMARK_DIR/fixtures/generate.py"
 }
 
 port_for() {
@@ -304,6 +410,14 @@ command_for() {
 stop_server() {
   if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
     kill "$SERVER_PID" >/dev/null 2>&1 || true
+    local deadline=$((SECONDS + 5))
+    while kill -0 "$SERVER_PID" >/dev/null 2>&1; do
+      if ((SECONDS >= deadline)); then
+        kill -9 "$SERVER_PID" >/dev/null 2>&1 || true
+        break
+      fi
+      sleep 0.1
+    done
     wait "$SERVER_PID" >/dev/null 2>&1 || true
   fi
   SERVER_PID=""
@@ -347,21 +461,24 @@ aggregate_samples() {
 }
 
 run_endpoint() {
-  local target="$1" endpoint="$2" venv_python samples_file stats_file sample raw_out run_idx total
+  local target="$1" endpoint="$2" venv_python samples_file stats_file sample raw_out run_idx total script connections
   local url="http://$HOST:$SERVER_PORT$(path_for "$endpoint")"
-  local cmd=("$WRK" -t "$THREADS" -c "$CONNECTIONS" -d "$DURATION")
-  [[ "$endpoint" == validate ]] && cmd+=(-s "$BENCHMARK_DIR/validate.lua")
+  local cmd=("$WRK" -t "$THREADS" -c "$(connections_for "$endpoint")" -d "$DURATION")
+  script="$(script_for "$endpoint")"
+  [[ -z "$script" || -f "$script" ]] || { echo "Missing wrk script for $endpoint: $script" >&2; exit 1; }
+  [[ -n "$script" ]] && cmd+=(-s "$script")
 
   samples_file="$RUN_DIR/$target.$endpoint.samples"
   stats_file="$RUN_DIR/$target.$endpoint.stats.json"
   : >"$samples_file"
   venv_python="$(python_for "$target")"
+  connections="$(connections_for "$endpoint")"
 
   total=$((RUNS + WARMUP))
-  echo "  $endpoint ($RUNS measured runs, $WARMUP warmup discarded)"
+  echo "  $endpoint ($(endpoint_label "$endpoint"), ${connections} conn, $RUNS measured + $WARMUP warmup)"
   for ((run_idx = 1; run_idx <= total; run_idx++)); do
     raw_out="$RUN_DIR/$target.$endpoint.run${run_idx}.txt"
-    "${cmd[@]}" "$url" >"$raw_out"
+    (cd "$ROOT" && "${cmd[@]}" "$url") >"$raw_out"
     sample="$(awk '/Requests\/sec:/ {print $2; exit}' "$raw_out")"
     [[ -n "$sample" ]] || { echo "Failed to parse wrk output: $raw_out" >&2; exit 1; }
     if ((run_idx > WARMUP)); then
@@ -411,10 +528,11 @@ PY
 }
 
 print_summary_row() {
-  local target="$1" venv_python="$2"
+  local target="$1" venv_python="$2" section_endpoints=("${@:3}")
   local endpoint stats_file cell
   printf '| %s ' "$(target_label "$target")"
-  for endpoint in "${ENDPOINTS[@]}"; do
+  for endpoint in "${section_endpoints[@]}"; do
+    endpoint_selected "$endpoint" || continue
     stats_file="$RUN_DIR/$target.$endpoint.stats.json"
     if [[ -f "$stats_file" ]]; then
       cell="$(format_cell "$stats_file" "$venv_python")"
@@ -426,17 +544,59 @@ print_summary_row() {
   echo "|"
 }
 
-target_selected() {
-  local target="$1" selected
-  for selected in "${SELECTED_TARGETS[@]}"; do
-    [[ "$selected" == "$target" ]] && return 0
+print_section_table() {
+  local section_name="$1" section_endpoints=("${@:2}")
+  local endpoint printed=0 label header=()
+  for endpoint in "${section_endpoints[@]}"; do
+    endpoint_selected "$endpoint" || continue
+    printed=1
+    header+=("$(endpoint_label "$endpoint")")
   done
-  return 1
+  [[ "$printed" == 1 ]] || return 0
+  echo
+  echo "### $section_name"
+  echo
+  printf '| Server '
+  for label in "${header[@]}"; do
+    printf '| %s ' "$label"
+  done
+  echo "|"
+  printf '| --- '
+  for _label in "${header[@]}"; do
+    printf '| ---: '
+  done
+  echo "|"
+}
+
+print_summary_section() {
+  local group_name="$1" group_printed_ref="$2" group_targets="$3"
+  local section_name="$4"
+  shift 4
+  local section_endpoints=("$@")
+  local has_rows=0 target_in_group endpoint
+  for target_in_group in $group_targets; do
+    target_selected "$target_in_group" || continue
+    for endpoint in "${section_endpoints[@]}"; do
+      endpoint_selected "$endpoint" || continue
+      [[ -f "$RUN_DIR/$target_in_group.$endpoint.stats.json" ]] && has_rows=1
+    done
+  done
+  [[ "$has_rows" == 1 ]] || return 0
+  if [[ "${!group_printed_ref}" == 0 ]]; then
+    echo
+    echo "## $group_name"
+    printf -v "$group_printed_ref" 1
+  fi
+  print_section_table "$section_name" "${section_endpoints[@]}"
+  for target_in_group in $group_targets; do
+    target_selected "$target_in_group" || continue
+    print_summary_row "$target_in_group" "$(python_for "$target_in_group")" "${section_endpoints[@]}"
+  done
 }
 
 print_summary() {
-  local group_entry group_name group_targets target table="$RUN_DIR/summary.md" venv_python
-  local printed_header target_in_group printed_any=0
+  local group_entry group_name group_targets table="$RUN_DIR/summary.md"
+  local printed_any=0 group_printed=0
   SELECTED_TARGETS=("$@")
   : >"$table"
   {
@@ -444,24 +604,16 @@ print_summary() {
     echo
     echo "Median requests/sec ± sample stdev after discarding $WARMUP warmup run(s)"
     echo "and applying IQR outlier trimming across $RUNS measured samples per endpoint."
+    echo "Large uploads use $UPLOAD_CONNECTIONS connections; other cases use $CONNECTIONS."
     for group_entry in "${SUMMARY_GROUPS[@]}"; do
       group_name="${group_entry%%|*}"
       group_targets="${group_entry#*|}"
-      printed_header=0
-      for target_in_group in $group_targets; do
-        target_selected "$target_in_group" || continue
-        if [[ "$printed_header" == 0 ]]; then
-          echo
-          echo "### $group_name"
-          echo
-          echo "| Server | Plaintext | JSON | Params | Validate |"
-          echo "| --- | ---: | ---: | ---: | ---: |"
-          printed_header=1
-          printed_any=1
-        fi
-        venv_python="$(python_for "$target_in_group")"
-        print_summary_row "$target_in_group" "$venv_python"
-      done
+      group_printed=0
+      print_summary_section "$group_name" group_printed "$group_targets" "Read-heavy" "${READ_ENDPOINTS[@]}"
+      print_summary_section "$group_name" group_printed "$group_targets" "Upload / body" "${UPLOAD_ENDPOINTS[@]}"
+      if [[ "$group_printed" == 1 ]]; then
+        printed_any=1
+      fi
     done
     if [[ "$printed_any" == 0 ]]; then
       echo
@@ -484,6 +636,14 @@ cleanup_raw_outputs() {
   done
 }
 
+target_selected() {
+  local target="$1" selected
+  for selected in "${SELECTED_TARGETS[@]}"; do
+    [[ "$selected" == "$target" ]] && return 0
+  done
+  return 1
+}
+
 main() {
   need uv; need curl
   if ! command -v "$WRK" >/dev/null 2>&1; then
@@ -491,12 +651,20 @@ main() {
     echo "Install wrk or set WRK=/path/to/wrk." >&2
     exit 1
   fi
+  parse_endpoints
   trap stop_server EXIT INT TERM
 
-  local selected=("$@") target
+  local selected=("$@") target endpoint
   if ((${#selected[@]} == 0)); then selected=("${TARGETS[@]}"); fi
   case "${selected[0]}" in -h|--help|help) usage; exit 0 ;; esac
   for target in "${selected[@]}"; do known_target "$target" || { echo "Unknown target: $target" >&2; usage >&2; exit 1; }; done
+  for endpoint in "${ENDPOINTS[@]}"; do path_for "$endpoint" >/dev/null || exit 1; done
+
+  ensure_fixtures "$(python_for "${selected[0]}")"
+  if [[ ! -x "$(python_for "${selected[0]}")" ]]; then
+    ensure_target "${selected[0]}"
+    ensure_fixtures "$(python_for "${selected[0]}")"
+  fi
 
   RUN_DIR="$RESULTS_DIR/$(date -u +%Y%m%dT%H%M%SZ)"
   mkdir -p "$RUN_DIR"
@@ -506,14 +674,15 @@ base_port=$PORT
 duration=$DURATION
 threads=$THREADS
 connections=$CONNECTIONS
+upload_connections=$UPLOAD_CONNECTIONS
 runs=$RUNS
 warmup=$WARMUP
 python=$PYTHON
 client=$WRK
 keep_raw=$KEEP_RAW
+endpoints=${ENDPOINTS[*]}
 git_sha=$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)
 git_branch=$(git -C "$ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
-payload_file=benchmarks/server/validate.lua
 ports=$(port_list)
 EOF
 

--- a/benchmarks/server/run.sh
+++ b/benchmarks/server/run.sh
@@ -17,17 +17,44 @@ PYTHON="${PYTHON:-3.14}"
 KEEP_RAW="${KEEP_RAW:-0}"
 WRK="${WRK:-wrk}"
 BROTLI_PKG_CONFIG="${BROTLI_PKG_CONFIG:-}"
-TARGETS=(stario stario-cython fastapi blacksheep-uvicorn blacksheep-granian sanic)
+TARGETS=(
+  stario stario-cython
+  socketify robyn granian-rsgi sanic django-bolt
+  blacksheep-granian blacksheep-uvicorn fastapi
+)
+TARGET_LABELS=(
+  "stario|Stario (Python httptools)"
+  "stario-cython|Stario (Cython llhttp)"
+  "socketify|Socketify (uWebSockets/libuv)"
+  "robyn|Robyn (Rust/Actix)"
+  "granian-rsgi|Granian RSGI (Rust, no framework)"
+  "sanic|Sanic (uvloop)"
+  "django-bolt|Django-Bolt (Actix/Tokio)"
+  "blacksheep-granian|BlackSheep + Granian ASGI"
+  "blacksheep-uvicorn|BlackSheep + Uvicorn ASGI"
+  "fastapi|FastAPI + Uvicorn ASGI"
+)
+SUMMARY_GROUPS=(
+  "Stario (this checkout)|stario stario-cython"
+  "Native HTTP servers|socketify robyn granian-rsgi sanic django-bolt"
+  "ASGI framework stacks|blacksheep-granian blacksheep-uvicorn fastapi"
+)
 ENDPOINTS=(plaintext json params validate)
 
 RUN_DIR=""
 SERVER_PID=""
 SERVER_PORT=""
 SERVER_CMD=()
+SELECTED_TARGETS=()
 
 usage() {
   cat <<'EOF'
-Usage: benchmarks/server/run.sh [stario|stario-cython|fastapi|blacksheep-uvicorn|blacksheep-granian|sanic ...]
+Usage: benchmarks/server/run.sh [target ...]
+
+Targets (default: all):
+  Stario:              stario, stario-cython
+  Native HTTP servers: socketify, robyn, granian-rsgi, sanic, django-bolt
+  ASGI stacks:         blacksheep-granian, blacksheep-uvicorn, fastapi
 
 Environment: DURATION=10s THREADS=2 CONNECTIONS=128 RUNS=7 WARMUP=2 HOST=127.0.0.1
              PORT=3000 PYTHON=3.14 REFRESH_ENVS=1 KEEP_RAW=1 WRK=wrk
@@ -35,8 +62,8 @@ Environment: DURATION=10s THREADS=2 CONNECTIONS=128 RUNS=7 WARMUP=2 HOST=127.0.0
 Each endpoint is measured RUNS times; the first WARMUP samples are discarded,
 then IQR outlier trimming is applied before reporting median RPS ± stdev.
 
-PORT is the base port. Targets use fixed offsets: stario=PORT, stario-cython=PORT+1,
-fastapi=PORT+2, blacksheep-uvicorn=PORT+3, blacksheep-granian=PORT+4, sanic=PORT+5.
+PORT is the base port. Targets use fixed offsets in TARGETS order (stario=PORT,
+stario-cython=PORT+1, socketify=PORT+2, ...).
 EOF
 }
 
@@ -150,6 +177,18 @@ build_stario_cython() {
   (cd "$ROOT" && PKG_CONFIG_PATH="$pkg_config_path" "$python" setup.py)
 }
 
+target_label() {
+  local target="$1" entry label
+  for entry in "${TARGET_LABELS[@]}"; do
+    label="${entry#*|}"
+    if [[ "${entry%%|*}" == "$target" ]]; then
+      echo "$label"
+      return 0
+    fi
+  done
+  echo "$target"
+}
+
 ensure_target() {
   case "$1" in
     stario) ensure_env stario "stario @ file://$ROOT" uvloop ujson ;;
@@ -157,10 +196,14 @@ ensure_target() {
       ensure_env stario-cython "stario @ file://$ROOT" uvloop ujson cython setuptools wheel
       build_stario_cython "$(python_for stario-cython)"
       ;;
+    socketify) ensure_env socketify socketify ujson ;;
+    robyn) ensure_env robyn robyn ujson ;;
+    granian-rsgi) ensure_env granian-rsgi granian uvloop ujson ;;
+    sanic) ensure_env sanic sanic uvloop ujson ;;
+    django-bolt) ensure_env django-bolt django django-bolt msgspec ujson ;;
     fastapi) ensure_env fastapi fastapi 'uvicorn[standard]' ujson ;;
     blacksheep-uvicorn) ensure_env blacksheep-uvicorn blacksheep 'uvicorn[standard]' ujson ;;
     blacksheep-granian) ensure_env blacksheep-granian blacksheep granian uvloop ujson ;;
-    sanic) ensure_env sanic sanic uvloop ujson ;;
   esac
 }
 
@@ -222,6 +265,39 @@ command_for() {
         --host "$HOST" --port "$SERVER_PORT"
       )
       ;;
+    socketify)
+      export BENCH_HOST="$HOST"
+      export BENCH_PORT="$SERVER_PORT"
+      SERVER_CMD=(
+        "$(python_for socketify)" "$BENCHMARK_DIR/apps/socketify_app.py"
+      )
+      ;;
+    robyn)
+      export BENCH_HOST="$HOST"
+      export BENCH_PORT="$SERVER_PORT"
+      SERVER_CMD=(
+        "$(python_for robyn)" "$BENCHMARK_DIR/apps/robyn_app.py"
+        --log-level=WARN --disable-openapi --processes 1 --workers 1
+      )
+      ;;
+    granian-rsgi)
+      SERVER_CMD=(
+        "$(python_for granian-rsgi)" -m granian apps.granian_rsgi_app:app
+        --interface rsgi
+        --host "$HOST" --port "$SERVER_PORT"
+        --workers 1
+        --runtime-threads 1
+        --loop uvloop
+        --no-access-log
+        --log-level warning
+      )
+      ;;
+    django-bolt)
+      SERVER_CMD=(
+        "$(python_for django-bolt)" "$BENCHMARK_DIR/apps/django_bolt/manage.py"
+        runbolt --host "$HOST" --port "$SERVER_PORT" --processes 1
+      )
+      ;;
   esac
 }
 
@@ -241,7 +317,7 @@ fail_with_log() {
 }
 
 wait_ready() {
-  local url="http://$HOST:$SERVER_PORT/plaintext" deadline=$((SECONDS + 10)) log="$1"
+  local url="http://$HOST:$SERVER_PORT/plaintext" deadline=$((SECONDS + 30)) log="$1"
   until curl -fsS --max-time 1 "$url" >/dev/null 2>&1; do
     if [[ -n "$SERVER_PID" ]] && ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
       fail_with_log "Server exited before it was ready." "$log"
@@ -334,31 +410,63 @@ print(cell)
 PY
 }
 
+print_summary_row() {
+  local target="$1" venv_python="$2"
+  local endpoint stats_file cell
+  printf '| %s ' "$(target_label "$target")"
+  for endpoint in "${ENDPOINTS[@]}"; do
+    stats_file="$RUN_DIR/$target.$endpoint.stats.json"
+    if [[ -f "$stats_file" ]]; then
+      cell="$(format_cell "$stats_file" "$venv_python")"
+      printf '| %s ' "$cell"
+    else
+      printf '| - '
+    fi
+  done
+  echo "|"
+}
+
+target_selected() {
+  local target="$1" selected
+  for selected in "${SELECTED_TARGETS[@]}"; do
+    [[ "$selected" == "$target" ]] && return 0
+  done
+  return 1
+}
+
 print_summary() {
-  local target endpoint stats_file table="$RUN_DIR/summary.md" venv_python
+  local group_entry group_name group_targets target table="$RUN_DIR/summary.md" venv_python
+  local printed_header target_in_group printed_any=0
+  SELECTED_TARGETS=("$@")
   : >"$table"
   {
-    echo "## Single-worker framework comparison"
+    echo "## Single-worker HTTP server comparison"
     echo
     echo "Median requests/sec ± sample stdev after discarding $WARMUP warmup run(s)"
     echo "and applying IQR outlier trimming across $RUNS measured samples per endpoint."
-    echo
-    echo "| Target | Plaintext | JSON | Params | Validate |"
-    echo "| --- | ---: | ---: | ---: | ---: |"
-    for target in "$@"; do
-      venv_python="$(python_for "$target")"
-      printf '| %s ' "$target"
-      for endpoint in "${ENDPOINTS[@]}"; do
-        stats_file="$RUN_DIR/$target.$endpoint.stats.json"
-        if [[ -f "$stats_file" ]]; then
-          cell="$(format_cell "$stats_file" "$venv_python")"
-          printf '| %s ' "$cell"
-        else
-          printf '| - '
+    for group_entry in "${SUMMARY_GROUPS[@]}"; do
+      group_name="${group_entry%%|*}"
+      group_targets="${group_entry#*|}"
+      printed_header=0
+      for target_in_group in $group_targets; do
+        target_selected "$target_in_group" || continue
+        if [[ "$printed_header" == 0 ]]; then
+          echo
+          echo "### $group_name"
+          echo
+          echo "| Server | Plaintext | JSON | Params | Validate |"
+          echo "| --- | ---: | ---: | ---: | ---: |"
+          printed_header=1
+          printed_any=1
         fi
+        venv_python="$(python_for "$target_in_group")"
+        print_summary_row "$target_in_group" "$venv_python"
       done
-      echo "|"
     done
+    if [[ "$printed_any" == 0 ]]; then
+      echo
+      echo "_No results recorded._"
+    fi
   } | tee "$table"
   rm -f "$RUN_DIR"/*.rps "$RUN_DIR"/*.samples
 }

--- a/benchmarks/server/scripts/multipart-2m.lua
+++ b/benchmarks/server/scripts/multipart-2m.lua
@@ -1,0 +1,16 @@
+local fixture = "benchmarks/server/fixtures/payload-2m.bin"
+local file = assert(io.open(fixture, "rb"))
+local content = file:read("*a")
+file:close()
+
+local boundary = "----WebKitFormBoundaryBenchUpload"
+local crlf = "\r\n"
+local body = "--" .. boundary .. crlf
+    .. 'Content-Disposition: form-data; name="file"; filename="payload-2m.bin"' .. crlf
+    .. "Content-Type: application/octet-stream" .. crlf .. crlf
+    .. content .. crlf
+    .. "--" .. boundary .. "--"
+
+wrk.method = "POST"
+wrk.body = body
+wrk.headers["Content-Type"] = "multipart/form-data; boundary=" .. boundary

--- a/benchmarks/server/scripts/post-form.lua
+++ b/benchmarks/server/scripts/post-form.lua
@@ -1,0 +1,3 @@
+wrk.method = "POST"
+wrk.body = "name=Ada&age=42&source=benchmark"
+wrk.headers["Content-Type"] = "application/x-www-form-urlencoded"

--- a/benchmarks/server/scripts/post-json-1k.lua
+++ b/benchmarks/server/scripts/post-json-1k.lua
@@ -1,0 +1,6 @@
+local fixture = "benchmarks/server/fixtures/payload-1k.json"
+local file = assert(io.open(fixture, "rb"))
+wrk.method = "POST"
+wrk.body = file:read("*a")
+file:close()
+wrk.headers["Content-Type"] = "application/json"

--- a/benchmarks/server/scripts/post-octet-2m.lua
+++ b/benchmarks/server/scripts/post-octet-2m.lua
@@ -1,0 +1,6 @@
+local fixture = "benchmarks/server/fixtures/payload-2m.bin"
+local file = assert(io.open(fixture, "rb"))
+wrk.method = "POST"
+wrk.body = file:read("*a")
+file:close()
+wrk.headers["Content-Type"] = "application/octet-stream"

--- a/benchmarks/server/scripts/post-octet-64k.lua
+++ b/benchmarks/server/scripts/post-octet-64k.lua
@@ -1,0 +1,6 @@
+local fixture = "benchmarks/server/fixtures/payload-64k.bin"
+local file = assert(io.open(fixture, "rb"))
+wrk.method = "POST"
+wrk.body = file:read("*a")
+file:close()
+wrk.headers["Content-Type"] = "application/octet-stream"

--- a/benchmarks/server/scripts/post-stream-2m.lua
+++ b/benchmarks/server/scripts/post-stream-2m.lua
@@ -1,0 +1,7 @@
+-- Same payload as buffered 2MB ingest; server route uses streaming read API.
+local fixture = "benchmarks/server/fixtures/payload-2m.bin"
+local file = assert(io.open(fixture, "rb"))
+wrk.method = "POST"
+wrk.body = file:read("*a")
+file:close()
+wrk.headers["Content-Type"] = "application/octet-stream"

--- a/benchmarks/server/stats.py
+++ b/benchmarks/server/stats.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Aggregate repeated wrk samples with warmup discard and IQR outlier trimming."""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+
+
+def _quartile(sorted_vals: list[float], q: float) -> float:
+    if not sorted_vals:
+        return float("nan")
+    pos = (len(sorted_vals) - 1) * q
+    lo = int(math.floor(pos))
+    hi = int(math.ceil(pos))
+    if lo == hi:
+        return sorted_vals[lo]
+    weight = pos - lo
+    return sorted_vals[lo] * (1 - weight) + sorted_vals[hi] * weight
+
+
+def aggregate(values: list[float]) -> dict[str, float | int]:
+    if not values:
+        raise ValueError("no samples")
+
+    raw = sorted(values)
+    q1 = _quartile(raw, 0.25)
+    q3 = _quartile(raw, 0.75)
+    iqr = q3 - q1
+    if iqr > 0 and len(raw) >= 4:
+        lower = q1 - 1.5 * iqr
+        upper = q3 + 1.5 * iqr
+        kept = [v for v in raw if lower <= v <= upper]
+        if kept:
+            used = kept
+        else:
+            used = raw
+    else:
+        used = raw
+
+    n = len(used)
+    median = _quartile(used, 0.5)
+    mean = sum(used) / n
+    if n > 1:
+        variance = sum((v - mean) ** 2 for v in used) / (n - 1)
+        stdev = math.sqrt(variance)
+    else:
+        stdev = 0.0
+
+    return {
+        "median": median,
+        "mean": mean,
+        "stdev": stdev,
+        "min": min(used),
+        "max": max(used),
+        "n_raw": len(raw),
+        "n_used": n,
+        "outliers_removed": len(raw) - len(used),
+    }
+
+
+def main() -> int:
+    values = [float(line.strip()) for line in sys.stdin if line.strip()]
+    result = aggregate(values)
+    json.dump(result, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ready to merge into `cython-core`

This PR lands the **benchmark suite + baseline numbers** for Stario Cython. Future Cython protocol work can compare against these numbers instead of re-deriving a full multi-framework suite every time.

### What’s included

- `stario-cython` target + multi-run stats (IQR trimming)
- Native servers: Socketify, Robyn, Granian RSGI, Sanic, Django-Bolt
- ASGI stacks: BlackSheep (Granian/Uvicorn), FastAPI
- Upload/body endpoints across all targets (validate, form, JSON 1K, 64KB/2MB, stream, multipart)
- Shared route semantics + **no static/cached response** policy
- Correctness fixes so competitor numbers are honest (Sanic `request.body`, Robyn validate Response, Django-Bolt upload limit)

### Stario Cython baseline (comparison anchor)

Primary full suite — `10s` × 5 runs, IQR trimmed (`20260824T171421Z`):

| Endpoint | Median req/s ± stdev |
| --- | ---: |
| Plaintext | 120,378 ± 24,710 |
| JSON | 117,556 ± 10,384 |
| Params | 104,519 ± 7,598 |
| Validate | 82,402 ± 1,389 |
| Form | 94,288 ± 1,018 |
| JSON 1KB | 87,420 ± 3,343 |
| 64KB | 30,842 ± 533 |
| 2MB buffer | 2,037 ± 47 |
| 2MB stream | 2,619 ± 133 |
| Multipart 2MB | 1,971 ± 106 |

~**1.9×** Stario Python on read · ~**1.6×** on validate · ties Granian RSGI on 64KB (~30.8k).

Full tables + corrected competitor columns: [`benchmarks/server/baseline-20260824.md`](benchmarks/server/baseline-20260824.md)

### After merge

1. Compare Cython protocol changes to the Stario Cython row above (`ENDPOINT_TIER=all` or targeted endpoints).
2. Large-upload work (batch `_acc` through `body()`, buffer-before-dispatch for ingest routes) can land in follow-up PRs.

### Merge

- **Base:** `cython-core`
- Benchmark-only under `benchmarks/` (+ runner docs)
- No runtime API changes to published Stario surface beyond what’s already on `cython-core`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abb1a665-aab6-4b40-8c33-0656179ae27e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abb1a665-aab6-4b40-8c33-0656179ae27e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

