### PR TITLE
Optimize Cython HTTP/1.1 body and writer path

### DIFF
--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -7,6 +7,14 @@ cdef class RequestExchange:
     cdef list _date_box
     cdef object _compression
     cdef object _accept
+    cdef object _req_accept_encoding
+    cdef object _req_connection
+    cdef object _req_expect
+    cdef object _req_content_type
+    cdef object _req_host
+    cdef bint _req_expect_continue
+    cdef bint _req_connection_close
+    cdef bint _resp_connection_close
     cdef public Headers headers
     cdef StarioBrotli* _brotli
     cdef StarioGzip* _gzip
@@ -73,6 +81,7 @@ cdef class RequestExchange:
     cdef void park(self)
     cdef void release_global(self)
     cdef void reset_body(self, bint expect_continue)
+    cdef void cache_hot_request_headers(self)
     cdef void prepare_body_capacity(self, Py_ssize_t expected_size)
     cdef void c_feed(self, const char* at, size_t length)
     cdef void c_complete(self)

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -8,13 +8,8 @@ cdef class RequestExchange:
     cdef object _compression
     cdef object _accept
     cdef object _req_accept_encoding
-    cdef object _req_connection
-    cdef object _req_expect
-    cdef object _req_content_type
-    cdef object _req_host
     cdef bint _req_expect_continue
     cdef bint _req_connection_close
-    cdef bint _resp_connection_close
     cdef public Headers headers
     cdef StarioBrotli* _brotli
     cdef StarioGzip* _gzip
@@ -29,7 +24,6 @@ cdef class RequestExchange:
     cdef int _brotli_window
     cdef int _gzip_level
     cdef Py_ssize_t _compress_min_size
-    cdef bint _compress_enabled
     cdef bint _completed
 
     cdef public object app
@@ -62,7 +56,6 @@ cdef class RequestExchange:
     cdef Py_ssize_t _acc_len
     cdef Py_ssize_t _acc_cap
     cdef Py_ssize_t _acc_pos
-    cdef Py_ssize_t _expected_body
     cdef Py_ssize_t _stream_max_chunk
 
     cdef void reset(
@@ -81,6 +74,7 @@ cdef class RequestExchange:
     cdef void park(self)
     cdef void release_global(self)
     cdef void reset_body(self, bint expect_continue)
+    cdef void _clear_hot_request_headers(self)
     cdef void cache_hot_request_headers(self)
     cdef void prepare_body_capacity(self, Py_ssize_t expected_size)
     cdef void c_feed(self, const char* at, size_t length)
@@ -102,7 +96,13 @@ cdef class RequestExchange:
     cdef Py_ssize_t _body_nbytes(self, object body) except -2
     cdef object _body_as_bytes(self, object body)
     cdef int _write_body_raw(self, object body) except -1
-    cdef bint _may_compress(self, object data, object content_type, bint streaming)
+    cdef bint _may_compress(
+        self,
+        object data,
+        object content_type,
+        bint streaming,
+        Py_ssize_t nbytes,
+    )
     cdef int _frame(self, object data, object encoding, const unsigned char** out, size_t* out_len) except -1
     cdef int _block(self, object data, const unsigned char** out, size_t* out_len) except -1
     cdef int _finish(self, const unsigned char** out, size_t* out_len) except -1
@@ -110,7 +110,13 @@ cdef class RequestExchange:
     cdef int _ensure_brotli(self) except -1
     cdef int _ensure_gzip(self) except -1
     cdef void _free_compressors(self)
-    cdef object _select(self, object data, object content_type, bint streaming)
+    cdef object _select(
+        self,
+        object data,
+        object content_type,
+        bint streaming,
+        Py_ssize_t nbytes,
+    )
     cdef void _raise_abort(self)
     cdef void _wake(self)
     cdef void _cancel_stall_timer(self)

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -20,6 +20,8 @@ cdef class RequestExchange:
     cdef int _brotli_level
     cdef int _brotli_window
     cdef int _gzip_level
+    cdef Py_ssize_t _compress_min_size
+    cdef bint _compress_enabled
     cdef bint _completed
 
     cdef public object app
@@ -83,8 +85,12 @@ cdef class RequestExchange:
     cdef void _apply_compression(self, object compression)
     cdef int _buf_add(self, const char* src, Py_ssize_t n) except -1
     cdef int _buf_bytes(self, object data) except -1
+    cdef int _buf_body(self, object body) except -1
     cdef int _buf_uint(self, size_t n, int base) except -1
     cdef void _flush(self)
+    cdef Py_ssize_t _body_nbytes(self, object body) except -2
+    cdef object _body_as_bytes(self, object body)
+    cdef int _write_body_raw(self, object body) except -1
     cdef bint _may_compress(self, object data, object content_type, bint streaming)
     cdef int _frame(self, object data, object encoding, const unsigned char** out, size_t* out_len) except -1
     cdef int _block(self, object data, const unsigned char** out, size_t* out_len) except -1

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -36,7 +36,6 @@ cdef class RequestExchange:
     cdef object _chunks
     cdef object _cached
     cdef object _data_ready
-    cdef object _body_fut
     cdef int _buffered
     cdef int _total_read
     cdef int _max_size
@@ -97,7 +96,6 @@ cdef class RequestExchange:
     cdef object _select(self, object data, object content_type, bint streaming)
     cdef void _raise_abort(self)
     cdef void _wake(self)
-    cdef void _resolve_body_fut(self, object value)
     cdef object _take_chunk(self, int index)
     cdef void _maybe_continue(self)
     cdef void _done(self)

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -50,6 +50,7 @@ cdef class RequestExchange:
     cdef char* _acc
     cdef Py_ssize_t _acc_len
     cdef Py_ssize_t _acc_cap
+    cdef Py_ssize_t _acc_pos
     cdef Py_ssize_t _expected_body
     cdef Py_ssize_t _stream_max_chunk
 
@@ -75,6 +76,8 @@ cdef class RequestExchange:
     cdef void c_abort(self)
     cdef int _acc_add(self, const char* at, size_t length) except -1
     cdef int _acc_reserve(self, Py_ssize_t need) except -1
+    cdef int _acc_compact(self) except -1
+    cdef Py_ssize_t _acc_unread(self) noexcept
     cdef object _acc_to_bytes(self)
     cdef void _emit_from_acc(self, Py_ssize_t n)
     cdef void reset_response(self, object accept_encoding)

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -36,6 +36,7 @@ cdef class RequestExchange:
     cdef object _chunks
     cdef object _cached
     cdef object _data_ready
+    cdef object _body_fut
     cdef int _buffered
     cdef int _total_read
     cdef int _max_size
@@ -50,6 +51,7 @@ cdef class RequestExchange:
     cdef Py_ssize_t _acc_len
     cdef Py_ssize_t _acc_cap
     cdef Py_ssize_t _expected_body
+    cdef Py_ssize_t _stream_max_chunk
 
     cdef void reset(
         self,
@@ -67,13 +69,14 @@ cdef class RequestExchange:
     cdef void park(self)
     cdef void release_global(self)
     cdef void reset_body(self, bint expect_continue)
-    cdef void prepare_fixed_body(self, Py_ssize_t expected_size)
+    cdef void prepare_body_capacity(self, Py_ssize_t expected_size)
     cdef void c_feed(self, const char* at, size_t length)
     cdef void c_complete(self)
     cdef void c_abort(self)
     cdef int _acc_add(self, const char* at, size_t length) except -1
     cdef int _acc_reserve(self, Py_ssize_t need) except -1
     cdef object _acc_to_bytes(self)
+    cdef void _emit_from_acc(self, Py_ssize_t n)
     cdef void reset_response(self, object accept_encoding)
     cdef void _apply_compression(self, object compression)
     cdef int _buf_add(self, const char* src, Py_ssize_t n) except -1
@@ -89,9 +92,9 @@ cdef class RequestExchange:
     cdef int _ensure_gzip(self) except -1
     cdef void _free_compressors(self)
     cdef object _select(self, object data, object content_type, bint streaming)
-    cdef void _drain_acc(self)
     cdef void _raise_abort(self)
     cdef void _wake(self)
+    cdef void _resolve_body_fut(self, object value)
     cdef object _take_chunk(self, int index)
     cdef void _maybe_continue(self)
     cdef void _done(self)

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -38,9 +38,11 @@ cdef class RequestExchange:
     cdef object _chunks
     cdef object _cached
     cdef object _data_ready
+    cdef object _stall_handle
     cdef int _buffered
     cdef int _total_read
     cdef int _max_size
+    cdef Py_ssize_t _read_max_size
     cdef double _timeout
     cdef int _consumed_as
     cdef int _abort_reason
@@ -102,6 +104,8 @@ cdef class RequestExchange:
     cdef object _select(self, object data, object content_type, bint streaming)
     cdef void _raise_abort(self)
     cdef void _wake(self)
+    cdef void _cancel_stall_timer(self)
+    cdef void _reset_stall_timer(self)
     cdef object _take_chunk(self, int index)
     cdef void _maybe_continue(self)
     cdef void _done(self)

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -49,6 +49,7 @@ cdef class RequestExchange:
     cdef char* _acc
     cdef Py_ssize_t _acc_len
     cdef Py_ssize_t _acc_cap
+    cdef Py_ssize_t _expected_body
 
     cdef void reset(
         self,
@@ -66,10 +67,13 @@ cdef class RequestExchange:
     cdef void park(self)
     cdef void release_global(self)
     cdef void reset_body(self, bint expect_continue)
+    cdef void prepare_fixed_body(self, Py_ssize_t expected_size)
     cdef void c_feed(self, const char* at, size_t length)
     cdef void c_complete(self)
     cdef void c_abort(self)
     cdef int _acc_add(self, const char* at, size_t length) except -1
+    cdef int _acc_reserve(self, Py_ssize_t need) except -1
+    cdef object _acc_to_bytes(self)
     cdef void reset_response(self, object accept_encoding)
     cdef void _apply_compression(self, object compression)
     cdef int _buf_add(self, const char* src, Py_ssize_t n) except -1
@@ -91,6 +95,7 @@ cdef class RequestExchange:
     cdef object _take_chunk(self, int index)
     cdef void _maybe_continue(self)
     cdef void _done(self)
+    cdef void _maybe_pause(self)
 
 cdef RequestExchange acquire_exchange(
     object connection,

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -23,6 +23,8 @@ from stario.exceptions import (
 from stario.http.compression import (
     DEFAULT_BROTLI_LEVEL,
     DEFAULT_GZIP_LEVEL,
+    DEFAULT_MIN_SIZE,
+    content_type_is_compressible,
     negotiate_content_encoding,
 )
 from stario.http.context import EMPTY_ROUTE_MATCH, _Alive
@@ -144,6 +146,8 @@ cdef class RequestExchange:
         self._data_ready = None
         self._compression = _UNBOUND
         self._available = ()
+        self._compress_min_size = DEFAULT_MIN_SIZE
+        self._compress_enabled = False
         self._state = None
         self.in_pool = False
         self._body_active = False
@@ -171,17 +175,23 @@ cdef class RequestExchange:
         self._brotli_window = 0
         self._gzip_level = DEFAULT_GZIP_LEVEL
         self._available = ()
+        self._compress_min_size = DEFAULT_MIN_SIZE
+        self._compress_enabled = False
         if compression is None:
             return
+        # Snapshot user CompressionConfig onto C fields so hot paths don't
+        # re-enter Python for min_size / enabled-encodings on every respond().
         self._brotli_level = compression.brotli_level
         window = compression.brotli_window_log
         self._brotli_window = 0 if window is None else window
         self._gzip_level = compression.gzip_level
+        self._compress_min_size = compression.min_size
         self._available = tuple(
             enc
             for enc in compression.enabled_encodings()
             if enc == b"br" or enc == b"gzip"
         )
+        self._compress_enabled = len(self._available) > 0
 
     cdef int _ensure_brotli(self) except -1:
         if self._brotli != NULL:
@@ -237,6 +247,89 @@ cdef class RequestExchange:
         p = data
         return self._buf_add(p, n)
 
+    cdef Py_ssize_t _body_nbytes(self, object body) except -2:
+        """Total byte length of ``bytes`` or a list/tuple of bytes-like parts."""
+        cdef Py_ssize_t total
+        cdef object part
+        if body is None:
+            return 0
+        if isinstance(body, (bytes, bytearray, memoryview)):
+            return <Py_ssize_t>len(body)
+        if isinstance(body, (list, tuple)):
+            total = 0
+            for part in body:
+                if not isinstance(part, (bytes, bytearray, memoryview)):
+                    raise TypeError(
+                        "body parts must be bytes-like, got "
+                        + type(part).__name__
+                    )
+                total += <Py_ssize_t>len(part)
+            return total
+        raise TypeError(
+            "body must be bytes-like or a list/tuple of bytes-like objects"
+        )
+
+    cdef object _body_as_bytes(self, object body):
+        """Contiguous bytes for one-shot compression (joins list/tuple once)."""
+        if body is None:
+            return b""
+        if isinstance(body, bytes):
+            return body
+        if isinstance(body, (bytearray, memoryview)):
+            return bytes(body)
+        if isinstance(body, (list, tuple)):
+            if not body:
+                return b""
+            if len(body) == 1 and isinstance(body[0], bytes):
+                return body[0]
+            return b"".join(body)
+        raise TypeError(
+            "body must be bytes-like or a list/tuple of bytes-like objects"
+        )
+
+    cdef int _buf_body(self, object body) except -1:
+        """Append body bytes or each list/tuple part into ``_out_buf`` (no join)."""
+        cdef object part
+        if body is None:
+            return 0
+        if isinstance(body, (bytes, bytearray, memoryview)):
+            return self._buf_bytes(body)
+        if isinstance(body, (list, tuple)):
+            for part in body:
+                if not isinstance(part, (bytes, bytearray, memoryview)):
+                    raise TypeError(
+                        "body parts must be bytes-like, got "
+                        + type(part).__name__
+                    )
+                self._buf_bytes(part)
+            return 0
+        raise TypeError(
+            "body must be bytes-like or a list/tuple of bytes-like objects"
+        )
+
+    cdef int _write_body_raw(self, object body) except -1:
+        """Write body parts directly to the transport (known Content-Length)."""
+        cdef object part
+        if body is None:
+            return 0
+        if isinstance(body, (bytes, bytearray, memoryview)):
+            if len(body):
+                self._transport.write(body)
+            return 0
+        if isinstance(body, (list, tuple)):
+            for part in body:
+                if not isinstance(part, (bytes, bytearray, memoryview)):
+                    raise TypeError(
+                        "body parts must be bytes-like, got "
+                        + type(part).__name__
+                    )
+                if len(part):
+                    self._transport.write(part)
+            return 0
+        raise TypeError(
+            "body must be bytes-like or a list/tuple of bytes-like objects"
+        )
+
     cdef int _buf_uint(self, size_t n, int base) except -1:
         cdef char tmp[16]
         cdef int i
@@ -275,14 +368,21 @@ cdef class RequestExchange:
         return self._completed
 
     cdef bint _may_compress(self, object data, object content_type, bint streaming):
-        if self._compression is None or self._compression is _UNBOUND:
+        cdef Py_ssize_t n
+        # Snapshotted from CompressionConfig in _apply_compression — respects
+        # user-defined min_size / enabled encodings without a Python round-trip
+        # on every tiny respond().
+        if not self._compress_enabled or self._accept is None:
             return False
-        return self._compression.may_compress(
-            self._accept,
-            data=data,
-            content_type=content_type,
-            streaming=streaming,
-        )
+        if content_type is not None and not content_type_is_compressible(content_type):
+            return False
+        if not streaming:
+            if data is None:
+                return False
+            n = self._body_nbytes(data)
+            if n < self._compress_min_size:
+                return False
+        return True
 
     cdef int _frame(
         self,
@@ -445,7 +545,8 @@ cdef class RequestExchange:
     def respond(self, body, content_type, int status=200):
         cdef Headers h = self.headers
         cdef object encoding
-        cdef object response
+        cdef object flat
+        cdef Py_ssize_t nbytes
         cdef const unsigned char* native_out = NULL
         cdef size_t native_len = 0
         if self._transport.is_closing():
@@ -463,30 +564,29 @@ cdef class RequestExchange:
             )
         if not _may_have_body(status):
             body = b""
-        self._declared_length = 0 if not _may_have_body(status) else len(body)
+            nbytes = 0
+        else:
+            nbytes = self._body_nbytes(body)
+        self._declared_length = nbytes
         self._bytes_written = 0
+        # Empty custom headers + no compression: one _out_buf assemble + flush.
+        # Body parts are copied into the write buffer (no b"".join of the entity).
         if h.c_empty() and (
             not _may_have_body(status)
             or not self._may_compress(body, content_type, False)
         ):
+            self._buf_bytes(_status_line(status))
+            self._buf_bytes(self._date_box[0])
             if not _may_have_body(status):
-                response = b"".join((
-                    _status_line(status),
-                    self._date_box[0],
-                    ZERO_CL,
-                ))
+                self._buf_bytes(ZERO_CL)
             else:
-                response = b"".join((
-                    _status_line(status),
-                    self._date_box[0],
-                    CT_PREFIX,
-                    content_type,
-                    CL_PREFIX,
-                    _dec(<size_t>len(body)),
-                    CRLF2,
-                    body,
-                ))
-            self._transport.write(response)
+                self._buf_bytes(CT_PREFIX)
+                self._buf_bytes(content_type)
+                self._buf_bytes(CL_PREFIX)
+                self._buf_uint(<size_t>nbytes, 10)
+                self._buf_bytes(CRLF2)
+                self._buf_body(body)
+            self._flush()
         else:
             if not _may_have_body(status):
                 body = b""
@@ -494,8 +594,10 @@ cdef class RequestExchange:
             elif h.c_get(b"content-encoding") is None:
                 encoding = self._select(body, content_type, False)
                 if encoding is not None:
+                    # One-shot compressors need contiguous input; join list once.
+                    flat = self._body_as_bytes(body)
                     try:
-                        self._frame(body, encoding, &native_out, &native_len)
+                        self._frame(flat, encoding, &native_out, &native_len)
                         h.c_set(b"content-encoding", encoding)
                         h.c_merge_vary(b"accept-encoding")
                         h.c_set(b"content-type", content_type)
@@ -518,16 +620,17 @@ cdef class RequestExchange:
                     self._done()
                     return
             h.c_set(b"content-type", content_type)
-            h.c_set(b"content-length", _dec(<size_t>len(body)))
-            self._declared_length = len(body)
+            h.c_set(b"content-length", _dec(<size_t>nbytes))
+            self._declared_length = nbytes
             self._bytes_written = 0
+            # Headers + body in one flush (one-shot respond).
             self._buf_bytes(_status_line(status))
             self._buf_bytes(self._date_box[0])
             if self._out_buf is None:
                 self._out_buf = bytearray(256)
             h.c_write_wire_ba(self._out_buf, &self._out_len)
             self._buf_bytes(CRLF)
-            self._buf_bytes(body)
+            self._buf_body(body)
             self._flush()
         self._status_code = status
         self._bytes_written = self._declared_length if self._declared_length > 0 else 0
@@ -603,6 +706,7 @@ cdef class RequestExchange:
 
     def write(self, data):
         cdef Py_ssize_t n
+        cdef object part
         cdef const unsigned char* native_out = NULL
         cdef size_t native_len = 0
         if self._transport.is_closing():
@@ -630,19 +734,35 @@ cdef class RequestExchange:
                     "204/304 and 1xx responses must not include a message body."
                 ),
             )
+        n = self._body_nbytes(data)
+        if n == 0:
+            return self
         if self._declared_length >= 0:
-            self._bytes_written += len(data)
-            self._buf_bytes(data)
-            self._flush()
+            # Known Content-Length: write parts directly (no _out_buf copy).
+            self._bytes_written += n
+            self._write_body_raw(data)
             return self
         if self._brotli != NULL or self._gzip != NULL:
-            self._block(data, &native_out, &native_len)
-            self._write_native_chunk(native_out, native_len)
+            # Chunked + compressed: feed each part to the streaming compressor.
+            if isinstance(data, (list, tuple)):
+                for part in data:
+                    if not isinstance(part, (bytes, bytearray, memoryview)):
+                        raise TypeError(
+                            "body parts must be bytes-like, got "
+                            + type(part).__name__
+                        )
+                    if not part:
+                        continue
+                    self._block(part, &native_out, &native_len)
+                    self._write_native_chunk(native_out, native_len)
+            else:
+                self._block(data, &native_out, &native_len)
+                self._write_native_chunk(native_out, native_len)
             return self
-        n = len(data)
+        # Chunked identity: one chunk framed around all parts (no join).
         self._buf_uint(<size_t>n, 16)
         self._buf_bytes(CRLF)
-        self._buf_bytes(data)
+        self._buf_body(data)
         self._buf_bytes(CRLF)
         self._flush()
         return self
@@ -659,7 +779,11 @@ cdef class RequestExchange:
             self._done()
             return
         if self._status_code < 0:
-            cl = _dec(<size_t>(len(data) if data is not None else 0))
+            cl = _dec(
+                <size_t>(
+                    self._body_nbytes(data) if data is not None else 0
+                )
+            )
             self.headers.c_set(b"content-length", cl)
             self.write_headers(200 if data is not None else 204)
         if data:

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -132,6 +132,7 @@ cdef class RequestExchange:
         self._acc = NULL
         self._acc_len = 0
         self._acc_cap = 0
+        self._acc_pos = 0
         self._expected_body = -1
 
     def __init__(self):
@@ -418,6 +419,7 @@ cdef class RequestExchange:
         self._data_ready = None
         self._body_fut = None
         self._acc_len = 0
+        self._acc_pos = 0
         self._body_active = False
         self._stream_max_chunk = DEFAULT_STREAM_CHUNK
         if self._chunks is not None:
@@ -734,6 +736,7 @@ cdef class RequestExchange:
         self._body_complete = False
         self._waiting = False
         self._acc_len = 0
+        self._acc_pos = 0
         self._expected_body = -1
         self._stream_max_chunk = DEFAULT_STREAM_CHUNK
 
@@ -743,9 +746,24 @@ cdef class RequestExchange:
         if expected_size > 0:
             self._acc_reserve(expected_size)
 
+    cdef int _acc_compact(self) except -1:
+        cdef Py_ssize_t unread
+        if self._acc_pos == 0:
+            return 0
+        unread = self._acc_len - self._acc_pos
+        if unread == 0:
+            self._acc_pos = 0
+            self._acc_len = 0
+            return 0
+        memmove(self._acc, self._acc + self._acc_pos, <size_t>unread)
+        self._acc_len = unread
+        self._acc_pos = 0
+        return 0
+
     cdef int _acc_reserve(self, Py_ssize_t need) except -1:
         cdef Py_ssize_t next_cap
         cdef char* p
+        # ``need`` is the absolute write-end offset (_acc_len after the next append).
         if need <= self._acc_cap:
             return 0
         next_cap = 64 if self._acc_cap == 0 else self._acc_cap * 2
@@ -759,7 +777,13 @@ cdef class RequestExchange:
         return 0
 
     cdef int _acc_add(self, const char* at, size_t length) except -1:
-        cdef Py_ssize_t need = self._acc_len + <Py_ssize_t>length
+        cdef Py_ssize_t need
+        if (
+            self._acc_pos > 0
+            and self._acc_len + <Py_ssize_t>length > self._acc_cap
+        ):
+            self._acc_compact()
+        need = self._acc_len + <Py_ssize_t>length
         self._acc_reserve(need)
         memcpy(self._acc + self._acc_len, at, length)
         self._acc_len = need
@@ -767,29 +791,37 @@ cdef class RequestExchange:
 
     cdef object _acc_to_bytes(self):
         cdef object out
-        if self._acc_len == 0:
+        cdef Py_ssize_t unread = self._acc_len - self._acc_pos
+        if unread <= 0:
+            self._acc_pos = 0
+            self._acc_len = 0
             return b""
-        out = PyBytes_FromStringAndSize(self._acc, self._acc_len)
+        out = PyBytes_FromStringAndSize(self._acc + self._acc_pos, unread)
+        self._acc_pos = 0
         self._acc_len = 0
         return out
 
     cdef void _emit_from_acc(self, Py_ssize_t n):
-        """Peel ``n`` bytes from the front of ``_acc`` into the stream chunk list."""
-        cdef Py_ssize_t rest
+        """Peel ``n`` unread bytes from ``_acc`` into the stream chunk list (no slide)."""
+        cdef Py_ssize_t unread
         cdef object chunk
-        if n <= 0 or self._acc_len == 0:
+        unread = self._acc_len - self._acc_pos
+        if n <= 0 or unread <= 0:
             return
-        if n > self._acc_len:
-            n = self._acc_len
+        if n > unread:
+            n = unread
         if self._chunks is None:
             self._chunks = []
-        chunk = PyBytes_FromStringAndSize(self._acc, n)
+        chunk = PyBytes_FromStringAndSize(self._acc + self._acc_pos, n)
         self._chunks.append(chunk)
         self._buffered += n
-        rest = self._acc_len - n
-        if rest > 0:
-            memmove(self._acc, self._acc + n, <size_t>rest)
-        self._acc_len = rest
+        self._acc_pos += n
+        if self._acc_pos >= self._acc_len:
+            self._acc_pos = 0
+            self._acc_len = 0
+
+    cdef Py_ssize_t _acc_unread(self) noexcept:
+        return self._acc_len - self._acc_pos
 
     cdef void _raise_abort(self):
         if self._abort_reason == ABORT_TOO_LARGE:
@@ -834,7 +866,7 @@ cdef class RequestExchange:
         # contiguous _acc up to max_body_bytes / Content-Length.
         if self._consumed_as != CONSUMED_STREAM:
             return
-        if self._buffered + self._acc_len > HIGH_WATER:
+        if self._buffered + self._acc_unread() > HIGH_WATER:
             transport = self._transport
             if transport is not None and not transport.is_closing():
                 transport.pause_reading()
@@ -854,7 +886,7 @@ cdef class RequestExchange:
         self._acc_add(at, length)
         if self._consumed_as == CONSUMED_STREAM:
             max_chunk = self._stream_max_chunk
-            while self._acc_len >= max_chunk:
+            while self._acc_unread() >= max_chunk:
                 self._emit_from_acc(max_chunk)
                 self._wake()
             self._maybe_pause()
@@ -867,12 +899,13 @@ cdef class RequestExchange:
             return
         self._body_complete = True
         if self._consumed_as == CONSUMED_STREAM:
-            if self._acc_len > 0:
-                self._emit_from_acc(self._acc_len)
+            if self._acc_unread() > 0:
+                self._emit_from_acc(self._acc_unread())
             self._wake()
             self._maybe_recycle()
             return
         if self._abort_reason != ABORT_NONE:
+            self._acc_pos = 0
             self._acc_len = 0
             self._resolve_body_fut(None)
             self._wake()
@@ -958,7 +991,7 @@ cdef class RequestExchange:
             return
         self._maybe_continue()
         # Emit any already-buffered full batches; leave a partial in _acc.
-        while self._acc_len >= chunk_size:
+        while self._acc_unread() >= chunk_size:
             self._emit_from_acc(chunk_size)
         index = 0
         while True:
@@ -966,8 +999,8 @@ cdef class RequestExchange:
                 index, chunk = self._take_chunk(index)
                 yield chunk
             if self._body_complete:
-                if self._acc_len > 0:
-                    self._emit_from_acc(self._acc_len)
+                if self._acc_unread() > 0:
+                    self._emit_from_acc(self._acc_unread())
                     continue
                 if self._chunks is not None:
                     self._chunks.clear()
@@ -1007,7 +1040,7 @@ cdef class RequestExchange:
             while not fut.done():
                 if self._abort_reason != ABORT_NONE:
                     self._raise_abort()
-                if max_size is not None and self._acc_len > max_size:
+                if max_size is not None and self._acc_unread() > max_size:
                     raise HttpException(413, "Request body too large")
                 await self._wait_for_body_data()
             if self._abort_reason != ABORT_NONE:

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -569,24 +569,32 @@ cdef class RequestExchange:
             nbytes = self._body_nbytes(body)
         self._declared_length = nbytes
         self._bytes_written = 0
-        # Empty custom headers + no compression: one _out_buf assemble + flush.
-        # Body parts are copied into the write buffer (no b"".join of the entity).
+        # Empty custom headers + no compression: writelines of existing buffers.
+        # Avoids (a) b"".join copying the entity and (b) _out_buf/memoryview churn
+        # that regressed tiny plaintext/json vs the old join path.
         if h.c_empty() and (
             not _may_have_body(status)
             or not self._may_compress(body, content_type, False)
         ):
-            self._buf_bytes(_status_line(status))
-            self._buf_bytes(self._date_box[0])
             if not _may_have_body(status):
-                self._buf_bytes(ZERO_CL)
+                self._transport.writelines(
+                    (_status_line(status), self._date_box[0], ZERO_CL)
+                )
             else:
-                self._buf_bytes(CT_PREFIX)
-                self._buf_bytes(content_type)
-                self._buf_bytes(CL_PREFIX)
-                self._buf_uint(<size_t>nbytes, 10)
-                self._buf_bytes(CRLF2)
-                self._buf_body(body)
-            self._flush()
+                flat = [
+                    _status_line(status),
+                    self._date_box[0],
+                    CT_PREFIX,
+                    content_type,
+                    CL_PREFIX,
+                    _dec(<size_t>nbytes),
+                    CRLF2,
+                ]
+                if isinstance(body, (list, tuple)):
+                    flat.extend(body)
+                else:
+                    flat.append(body)
+                self._transport.writelines(flat)
         else:
             if not _may_have_body(status):
                 body = b""
@@ -623,7 +631,7 @@ cdef class RequestExchange:
             h.c_set(b"content-length", _dec(<size_t>nbytes))
             self._declared_length = nbytes
             self._bytes_written = 0
-            # Headers + body in one flush (one-shot respond).
+            # Custom headers: one _out_buf assemble + flush (headers + body parts).
             self._buf_bytes(_status_line(status))
             self._buf_bytes(self._date_box[0])
             if self._out_buf is None:

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -28,6 +28,7 @@ from stario.http.compression import (
     negotiate_content_encoding,
 )
 from stario.http.context import EMPTY_ROUTE_MATCH, _Alive
+from stario.http.request import DEFAULT_BODY_TIMEOUT
 from stario.http.writer import get_status_line
 
 from stario_cython.compression_buf cimport (
@@ -46,10 +47,12 @@ from stario_cython.request cimport Request
 # Stream backpressure window. max_chunk must be strictly below HIGH_WATER.
 cdef int LOW_WATER = 64 * 1024
 cdef int HIGH_WATER = 256 * 1024
-# Default stream() yield size — keep bytes in _acc until this big (or message done).
 cdef int DEFAULT_STREAM_CHUNK = 64 * 1024
-cdef double DEFAULT_TIMEOUT = 30.0
 cdef int POOL_MAX = 1024
+
+cdef object BODY_TYPE_ERROR = (
+    "body must be bytes-like or a list/tuple of bytes-like objects"
+)
 
 cdef int CONSUMED_NONE = 0
 cdef int CONSUMED_BODY = 1
@@ -83,6 +86,17 @@ cdef object STARTED_ERROR = (
 
 cdef list _POOL = []
 cdef object _UNBOUND = object()
+
+
+cdef inline bint _is_bytes_like(object obj) noexcept:
+    return isinstance(obj, (bytes, bytearray, memoryview))
+
+
+cdef inline void _require_bytes_like(object part):
+    if not _is_bytes_like(part):
+        raise TypeError(
+            "body parts must be bytes-like, got " + type(part).__name__
+        )
 
 
 cdef inline bint _may_have_body(int status) noexcept:
@@ -135,7 +149,6 @@ cdef class RequestExchange:
         self._acc_len = 0
         self._acc_cap = 0
         self._acc_pos = 0
-        self._expected_body = -1
 
     def __init__(self):
         self.headers = Headers()
@@ -148,7 +161,6 @@ cdef class RequestExchange:
         self._compression = _UNBOUND
         self._available = ()
         self._compress_min_size = DEFAULT_MIN_SIZE
-        self._compress_enabled = False
         self._state = None
         self.in_pool = False
         self._body_active = False
@@ -178,11 +190,9 @@ cdef class RequestExchange:
         self._gzip_level = DEFAULT_GZIP_LEVEL
         self._available = ()
         self._compress_min_size = DEFAULT_MIN_SIZE
-        self._compress_enabled = False
         if compression is None:
             return
-        # Snapshot user CompressionConfig onto C fields so hot paths don't
-        # re-enter Python for min_size / enabled-encodings on every respond().
+        # Snapshot CompressionConfig so hot paths skip Python attribute access.
         self._brotli_level = compression.brotli_level
         window = compression.brotli_window_log
         self._brotli_window = 0 if window is None else window
@@ -193,7 +203,6 @@ cdef class RequestExchange:
             for enc in compression.enabled_encodings()
             if enc == b"br" or enc == b"gzip"
         )
-        self._compress_enabled = len(self._available) > 0
 
     cdef int _ensure_brotli(self) except -1:
         if self._brotli != NULL:
@@ -255,21 +264,15 @@ cdef class RequestExchange:
         cdef object part
         if body is None:
             return 0
-        if isinstance(body, (bytes, bytearray, memoryview)):
+        if _is_bytes_like(body):
             return <Py_ssize_t>len(body)
         if isinstance(body, (list, tuple)):
             total = 0
             for part in body:
-                if not isinstance(part, (bytes, bytearray, memoryview)):
-                    raise TypeError(
-                        "body parts must be bytes-like, got "
-                        + type(part).__name__
-                    )
+                _require_bytes_like(part)
                 total += <Py_ssize_t>len(part)
             return total
-        raise TypeError(
-            "body must be bytes-like or a list/tuple of bytes-like objects"
-        )
+        raise TypeError(BODY_TYPE_ERROR)
 
     cdef object _body_as_bytes(self, object body):
         """Contiguous bytes for one-shot compression (joins list/tuple once)."""
@@ -285,52 +288,38 @@ cdef class RequestExchange:
             if len(body) == 1 and isinstance(body[0], bytes):
                 return body[0]
             return b"".join(body)
-        raise TypeError(
-            "body must be bytes-like or a list/tuple of bytes-like objects"
-        )
+        raise TypeError(BODY_TYPE_ERROR)
 
     cdef int _buf_body(self, object body) except -1:
         """Append body bytes or each list/tuple part into ``_out_buf`` (no join)."""
         cdef object part
         if body is None:
             return 0
-        if isinstance(body, (bytes, bytearray, memoryview)):
+        if _is_bytes_like(body):
             return self._buf_bytes(body)
         if isinstance(body, (list, tuple)):
             for part in body:
-                if not isinstance(part, (bytes, bytearray, memoryview)):
-                    raise TypeError(
-                        "body parts must be bytes-like, got "
-                        + type(part).__name__
-                    )
+                _require_bytes_like(part)
                 self._buf_bytes(part)
             return 0
-        raise TypeError(
-            "body must be bytes-like or a list/tuple of bytes-like objects"
-        )
+        raise TypeError(BODY_TYPE_ERROR)
 
     cdef int _write_body_raw(self, object body) except -1:
         """Write body parts directly to the transport (known Content-Length)."""
         cdef object part
         if body is None:
             return 0
-        if isinstance(body, (bytes, bytearray, memoryview)):
+        if _is_bytes_like(body):
             if len(body):
                 self._transport.write(body)
             return 0
         if isinstance(body, (list, tuple)):
             for part in body:
-                if not isinstance(part, (bytes, bytearray, memoryview)):
-                    raise TypeError(
-                        "body parts must be bytes-like, got "
-                        + type(part).__name__
-                    )
+                _require_bytes_like(part)
                 if len(part):
                     self._transport.write(part)
             return 0
-        raise TypeError(
-            "body must be bytes-like or a list/tuple of bytes-like objects"
-        )
+        raise TypeError(BODY_TYPE_ERROR)
 
     cdef int _buf_uint(self, size_t n, int base) except -1:
         cdef char tmp[16]
@@ -369,20 +358,23 @@ cdef class RequestExchange:
     def completed(self):
         return self._completed
 
-    cdef bint _may_compress(self, object data, object content_type, bint streaming):
-        cdef Py_ssize_t n
-        # Snapshotted from CompressionConfig in _apply_compression — respects
-        # user-defined min_size / enabled encodings without a Python round-trip
-        # on every tiny respond().
-        if not self._compress_enabled or self._accept is None:
+    cdef bint _may_compress(
+        self,
+        object data,
+        object content_type,
+        bint streaming,
+        Py_ssize_t nbytes,
+    ):
+        if not self._available or self._accept is None:
             return False
         if content_type is not None and not content_type_is_compressible(content_type):
             return False
         if not streaming:
             if data is None:
                 return False
-            n = self._body_nbytes(data)
-            if n < self._compress_min_size:
+            if nbytes < 0:
+                nbytes = self._body_nbytes(data)
+            if nbytes < self._compress_min_size:
                 return False
         return True
 
@@ -455,8 +447,14 @@ cdef class RequestExchange:
         self._flush()
         return 0
 
-    cdef object _select(self, object data, object content_type, bint streaming):
-        if not self._may_compress(data, content_type, streaming):
+    cdef object _select(
+        self,
+        object data,
+        object content_type,
+        bint streaming,
+        Py_ssize_t nbytes,
+    ):
+        if not self._may_compress(data, content_type, streaming, nbytes):
             return None
         return negotiate_content_encoding(self._accept, self._available)
 
@@ -476,7 +474,7 @@ cdef class RequestExchange:
             self._transport = transport
             self._date_box = date_box
             self._max_size = max_body_size
-            self._timeout = DEFAULT_TIMEOUT
+            self._timeout = DEFAULT_BODY_TIMEOUT
             if self._compression is not compression:
                 self._compression = compression
                 self._apply_compression(compression)
@@ -484,42 +482,31 @@ cdef class RequestExchange:
         self.route = EMPTY_ROUTE_MATCH
         self._state = None
         self.request_headers.c_clear()
-        self._req_accept_encoding = None
-        self._req_connection = None
-        self._req_expect = None
-        self._req_content_type = None
-        self._req_host = None
-        self._req_expect_continue = False
-        self._req_connection_close = False
-        self._resp_connection_close = False
+        self._clear_hot_request_headers()
         self.handler_done = False
         self.handler_started = False
 
+    cdef void _clear_hot_request_headers(self):
+        self._req_accept_encoding = None
+        self._req_expect_continue = False
+        self._req_connection_close = False
+
     cdef void cache_hot_request_headers(self):
-        """Snapshot hot request headers for protocol/compression (dict API unchanged)."""
+        """Snapshot keep-alive / expect / accept-encoding (Headers API unchanged)."""
         cdef Headers h = self.request_headers
         cdef object v
         self._req_accept_encoding = h.c_get(b"accept-encoding")
         v = h.c_get(b"connection")
-        if v is None:
-            self._req_connection = None
-            self._req_connection_close = False
-        else:
-            self._req_connection = v.lower()
-            self._req_connection_close = self._req_connection == b"close"
+        self._req_connection_close = (
+            v is not None and v.lower() == b"close"
+        )
         v = h.c_get(b"expect")
-        if v is None:
-            self._req_expect = None
-            self._req_expect_continue = False
-        else:
-            self._req_expect = v.lower()
-            self._req_expect_continue = self._req_expect == b"100-continue"
-        self._req_content_type = h.c_get(b"content-type")
-        self._req_host = h.c_get(b"host")
+        self._req_expect_continue = (
+            v is not None and v.lower() == b"100-continue"
+        )
 
     cdef void start_response(self):
         self.handler_started = True
-        self._resp_connection_close = False
         self.reset_response(self._req_accept_encoding)
 
     cdef void handler_finished(self):
@@ -554,14 +541,7 @@ cdef class RequestExchange:
         self._acc_pos = 0
         self._body_active = False
         self._read_max_size = -1
-        self._req_accept_encoding = None
-        self._req_connection = None
-        self._req_expect = None
-        self._req_content_type = None
-        self._req_host = None
-        self._req_expect_continue = False
-        self._req_connection_close = False
-        self._resp_connection_close = False
+        self._clear_hot_request_headers()
         self._stream_max_chunk = DEFAULT_STREAM_CHUNK
         if self._chunks is not None:
             self._chunks.clear()
@@ -575,14 +555,7 @@ cdef class RequestExchange:
         self.route = EMPTY_ROUTE_MATCH
         self._state = None
         self._accept = None
-        self._req_accept_encoding = None
-        self._req_connection = None
-        self._req_expect = None
-        self._req_content_type = None
-        self._req_host = None
-        self._req_expect_continue = False
-        self._req_connection_close = False
-        self._resp_connection_close = False
+        self._clear_hot_request_headers()
         self.app = None
         self._connection = None
         self._transport = None
@@ -620,12 +593,11 @@ cdef class RequestExchange:
             nbytes = self._body_nbytes(body)
         self._declared_length = nbytes
         self._bytes_written = 0
-        # Empty custom headers + no compression: writelines of existing buffers.
-        # Avoids (a) b"".join copying the entity and (b) _out_buf/memoryview churn
-        # that regressed tiny plaintext/json vs the old join path.
+        # Empty headers + no compression: writelines of existing buffers (no join,
+        # no _out_buf churn — keeps tiny plaintext/json competitive).
         if h.c_empty() and (
             not _may_have_body(status)
-            or not self._may_compress(body, content_type, False)
+            or not self._may_compress(body, content_type, False, nbytes)
         ):
             if not _may_have_body(status):
                 self._transport.writelines(
@@ -651,9 +623,8 @@ cdef class RequestExchange:
                 body = b""
                 h.c_set(b"content-length", b"0")
             elif h.c_get(b"content-encoding") is None:
-                encoding = self._select(body, content_type, False)
+                encoding = self._select(body, content_type, False, nbytes)
                 if encoding is not None:
-                    # One-shot compressors need contiguous input; join list once.
                     flat = self._body_as_bytes(body)
                     try:
                         self._frame(flat, encoding, &native_out, &native_len)
@@ -682,7 +653,6 @@ cdef class RequestExchange:
             h.c_set(b"content-length", _dec(<size_t>nbytes))
             self._declared_length = nbytes
             self._bytes_written = 0
-            # Custom headers: one _out_buf assemble + flush (headers + body parts).
             self._buf_bytes(_status_line(status))
             self._buf_bytes(self._date_box[0])
             if self._out_buf is None:
@@ -701,7 +671,6 @@ cdef class RequestExchange:
             return
         self._free_compressors()
         self._completed = True
-        self._resp_connection_close = True
         self.headers.c_set(b"connection", b"close")
         self._transport.close()
         self._done()
@@ -745,7 +714,7 @@ cdef class RequestExchange:
             headers.c_set(b"transfer-encoding", b"chunked")
             if headers.c_get(b"content-encoding") is None:
                 encoding = self._select(
-                    None, headers.c_get(b"content-type"), True
+                    None, headers.c_get(b"content-type"), True, -1
                 )
                 if encoding is not None:
                     if encoding == b"br":
@@ -798,19 +767,13 @@ cdef class RequestExchange:
         if n == 0:
             return self
         if self._declared_length >= 0:
-            # Known Content-Length: write parts directly (no _out_buf copy).
             self._bytes_written += n
             self._write_body_raw(data)
             return self
         if self._brotli != NULL or self._gzip != NULL:
-            # Chunked + compressed: feed each part to the streaming compressor.
             if isinstance(data, (list, tuple)):
                 for part in data:
-                    if not isinstance(part, (bytes, bytearray, memoryview)):
-                        raise TypeError(
-                            "body parts must be bytes-like, got "
-                            + type(part).__name__
-                        )
+                    _require_bytes_like(part)
                     if not part:
                         continue
                     self._block(part, &native_out, &native_len)
@@ -819,7 +782,6 @@ cdef class RequestExchange:
                 self._block(data, &native_out, &native_len)
                 self._write_native_chunk(native_out, native_len)
             return self
-        # Chunked identity: one chunk framed around all parts (no join).
         self._buf_uint(<size_t>n, 16)
         self._buf_bytes(CRLF)
         self._buf_body(data)
@@ -839,11 +801,7 @@ cdef class RequestExchange:
             self._done()
             return
         if self._status_code < 0:
-            cl = _dec(
-                <size_t>(
-                    self._body_nbytes(data) if data is not None else 0
-                )
-            )
+            cl = _dec(<size_t>self._body_nbytes(data))
             self.headers.c_set(b"content-length", cl)
             self.write_headers(200 if data is not None else 204)
         if data:
@@ -920,12 +878,10 @@ cdef class RequestExchange:
         self._waiting = False
         self._acc_len = 0
         self._acc_pos = 0
-        self._expected_body = -1
         self._stream_max_chunk = DEFAULT_STREAM_CHUNK
 
     cdef void prepare_body_capacity(self, Py_ssize_t expected_size):
-        """Pre-size the C accumulator for a known Content-Length (handler already running)."""
-        self._expected_body = expected_size
+        """Pre-size the C accumulator for a known Content-Length."""
         if expected_size > 0:
             self._acc_reserve(expected_size)
 
@@ -946,7 +902,6 @@ cdef class RequestExchange:
     cdef int _acc_reserve(self, Py_ssize_t need) except -1:
         cdef Py_ssize_t next_cap
         cdef char* p
-        # ``need`` is the absolute write-end offset (_acc_len after the next append).
         if need <= self._acc_cap:
             return 0
         next_cap = 64 if self._acc_cap == 0 else self._acc_cap * 2
@@ -985,7 +940,7 @@ cdef class RequestExchange:
         return out
 
     cdef void _emit_from_acc(self, Py_ssize_t n):
-        """Peel ``n`` unread bytes from ``_acc`` into the stream chunk list (no slide)."""
+        """Peel ``n`` unread bytes from ``_acc`` into the stream chunk list."""
         cdef Py_ssize_t unread
         cdef object chunk
         unread = self._acc_len - self._acc_pos
@@ -1067,8 +1022,7 @@ cdef class RequestExchange:
 
     cdef void _maybe_pause(self):
         cdef object transport
-        # Backpressure only while a stream consumer is draining — body() keeps one
-        # contiguous _acc up to max_body_bytes / Content-Length.
+        # Pause only for stream consumers; body() keeps one contiguous _acc.
         if self._consumed_as != CONSUMED_STREAM:
             return
         if self._buffered + self._acc_unread() > HIGH_WATER:
@@ -1078,6 +1032,7 @@ cdef class RequestExchange:
 
     cdef void c_feed(self, const char* at, size_t length):
         cdef Py_ssize_t max_chunk
+        cdef bint emitted
         if not self._body_active:
             self.reset_body(False)
         self._total_read += <int>length
@@ -1086,8 +1041,6 @@ cdef class RequestExchange:
             self._cancel_stall_timer()
             self._wake()
             return
-        # Always append into the C accumulator. body() materializes once at complete;
-        # stream() peels max_chunk-sized Python bytes.
         self._acc_add(at, length)
         if (
             self._read_max_size >= 0
@@ -1099,16 +1052,17 @@ cdef class RequestExchange:
             return
         if self._consumed_as == CONSUMED_STREAM:
             max_chunk = self._stream_max_chunk
+            emitted = False
             while self._acc_unread() >= max_chunk:
                 self._emit_from_acc(max_chunk)
+                emitted = True
+            if emitted:
                 self._wake()
-            # Progress resets stall; do not rely on wait_for.
             if self._waiting:
                 self._reset_stall_timer()
             self._maybe_pause()
             return
-        # body() waits only for message complete — refresh stall on progress,
-        # but do not Event-wake on every TCP segment.
+        # body(): refresh stall on progress; wake only on complete/abort.
         if self._waiting:
             self._reset_stall_timer()
 
@@ -1129,8 +1083,6 @@ cdef class RequestExchange:
             self._wake()
             self._maybe_recycle()
             return
-        # body() already waiting: materialize once. Otherwise leave bytes in _acc
-        # until body() (or never — then park drops them).
         if self._consumed_as == CONSUMED_BODY:
             if self._cached is None:
                 self._cached = self._acc_to_bytes()
@@ -1207,7 +1159,6 @@ cdef class RequestExchange:
             yield self._cached
             return
         self._maybe_continue()
-        # Emit any already-buffered full batches; leave a partial in _acc.
         while self._acc_unread() >= chunk_size:
             self._emit_from_acc(chunk_size)
         index = 0
@@ -1242,8 +1193,6 @@ cdef class RequestExchange:
         self._consumed_as = CONSUMED_BODY
         self._read_max_size = -1 if max_size is None else <Py_ssize_t>max_size
         self._maybe_continue()
-        # Stall-aware Event wait until message complete (wake only from
-        # c_complete / abort — not every TCP segment), then one materialization.
         while not self._body_complete:
             if self._abort_reason != ABORT_NONE:
                 self._raise_abort()

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -144,6 +144,7 @@ cdef class RequestExchange:
         self._chunks = None
         self._cached = None
         self._data_ready = None
+        self._stall_handle = None
         self._compression = _UNBOUND
         self._available = ()
         self._compress_min_size = DEFAULT_MIN_SIZE
@@ -151,6 +152,7 @@ cdef class RequestExchange:
         self._state = None
         self.in_pool = False
         self._body_active = False
+        self._read_max_size = -1
         self._stream_max_chunk = DEFAULT_STREAM_CHUNK
 
     def __dealloc__(self):
@@ -516,9 +518,11 @@ cdef class RequestExchange:
         self.in_pool = True
         self._cached = None
         self._data_ready = None
+        self._cancel_stall_timer()
         self._acc_len = 0
         self._acc_pos = 0
         self._body_active = False
+        self._read_max_size = -1
         self._stream_max_chunk = DEFAULT_STREAM_CHUNK
         if self._chunks is not None:
             self._chunks.clear()
@@ -857,9 +861,11 @@ cdef class RequestExchange:
             self._chunks.clear()
         self._cached = None
         self._data_ready = None
+        self._cancel_stall_timer()
         self._expect_continue = expect_continue
         self._buffered = 0
         self._total_read = 0
+        self._read_max_size = -1
         self._consumed_as = CONSUMED_NONE
         self._abort_reason = ABORT_NONE
         self._body_complete = False
@@ -968,6 +974,33 @@ cdef class RequestExchange:
         if self._data_ready is not None:
             self._data_ready.set()
 
+    cdef void _cancel_stall_timer(self):
+        cdef object handle = self._stall_handle
+        if handle is not None:
+            handle.cancel()
+            self._stall_handle = None
+
+    cdef void _reset_stall_timer(self):
+        """Arm/refresh slowloris stall timeout while a body consumer is waiting."""
+        cdef object loop
+        self._cancel_stall_timer()
+        if not self._waiting or self._body_complete or self._timeout <= 0:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        self._stall_handle = loop.call_later(self._timeout, self._on_stall_timeout)
+
+    def _on_stall_timeout(self):
+        self._stall_handle = None
+        if self._abort_reason != ABORT_NONE or self._body_complete:
+            return
+        self._abort_reason = ABORT_TIMEOUT
+        if self._chunks is not None:
+            self._chunks.clear()
+        self._wake()
+
     cdef object _take_chunk(self, int index):
         cdef object chunk = self._chunks[index]
         cdef object transport
@@ -1002,25 +1035,40 @@ cdef class RequestExchange:
         self._total_read += <int>length
         if self._total_read > self._max_size:
             self._abort_reason = ABORT_TOO_LARGE
+            self._cancel_stall_timer()
             self._wake()
             return
         # Always append into the C accumulator. body() materializes once at complete;
         # stream() peels max_chunk-sized Python bytes.
         self._acc_add(at, length)
+        if (
+            self._read_max_size >= 0
+            and self._acc_unread() > self._read_max_size
+        ):
+            self._abort_reason = ABORT_TOO_LARGE
+            self._cancel_stall_timer()
+            self._wake()
+            return
         if self._consumed_as == CONSUMED_STREAM:
             max_chunk = self._stream_max_chunk
             while self._acc_unread() >= max_chunk:
                 self._emit_from_acc(max_chunk)
                 self._wake()
+            # Progress resets stall; do not rely on wait_for.
+            if self._waiting:
+                self._reset_stall_timer()
             self._maybe_pause()
             return
+        # body() waits only for message complete — refresh stall on progress,
+        # but do not Event-wake on every TCP segment.
         if self._waiting:
-            self._wake()
+            self._reset_stall_timer()
 
     cdef void c_complete(self):
         if not self._body_active:
             return
         self._body_complete = True
+        self._cancel_stall_timer()
         if self._consumed_as == CONSUMED_STREAM:
             if self._acc_unread() > 0:
                 self._emit_from_acc(self._acc_unread())
@@ -1048,6 +1096,7 @@ cdef class RequestExchange:
         self._free_compressors()
         self._abort_reason = ABORT_DISCONNECTED
         self._body_complete = True
+        self._cancel_stall_timer()
         self._wake()
         self._maybe_recycle()
 
@@ -1064,16 +1113,17 @@ cdef class RequestExchange:
         if self._data_ready is None:
             self._data_ready = asyncio.Event()
         self._waiting = True
+        self._reset_stall_timer()
         try:
-            await asyncio.wait_for(self._data_ready.wait(), self._timeout)
-        except TimeoutError:
-            self._abort_reason = ABORT_TIMEOUT
+            await self._data_ready.wait()
+        finally:
+            self._waiting = False
+            self._cancel_stall_timer()
+        self._data_ready.clear()
+        if self._abort_reason != ABORT_NONE:
             if self._chunks is not None:
                 self._chunks.clear()
             self._raise_abort()
-        finally:
-            self._waiting = False
-        self._data_ready.clear()
 
     async def stream(self, max_chunk=None):
         cdef int index
@@ -1142,12 +1192,17 @@ cdef class RequestExchange:
             self._consumed_as = CONSUMED_BODY
             return self._cached
         self._consumed_as = CONSUMED_BODY
+        self._read_max_size = -1 if max_size is None else <Py_ssize_t>max_size
         self._maybe_continue()
-        # Stall-aware Event wait until message complete, then one materialization.
+        # Stall-aware Event wait until message complete (wake only from
+        # c_complete / abort — not every TCP segment), then one materialization.
         while not self._body_complete:
             if self._abort_reason != ABORT_NONE:
                 self._raise_abort()
-            if max_size is not None and self._acc_unread() > max_size:
+            if (
+                self._read_max_size >= 0
+                and self._acc_unread() > self._read_max_size
+            ):
                 raise HttpException(413, "Request body too large")
             await self._wait_for_body_data()
         if self._abort_reason != ABORT_NONE:

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -6,7 +6,7 @@ import asyncio
 from libc.stddef cimport size_t
 from libc.stdio cimport sprintf
 from libc.stdlib cimport free, realloc
-from libc.string cimport memcpy
+from libc.string cimport memcpy, memmove
 from cpython.bytearray cimport (
     PyByteArray_AS_STRING,
     PyByteArray_GET_SIZE,
@@ -41,10 +41,11 @@ from stario_cython.compression_buf cimport (
 from stario_cython.headers cimport Headers
 from stario_cython.request cimport Request
 
-cdef int LOW_WATER = 16 * 1024
-cdef int HIGH_WATER = 64 * 1024
-# Yield / chunk batch size for stream() consumers — keep data in _acc until this big.
-cdef int STREAM_BATCH = 64 * 1024
+# Stream backpressure window. max_chunk must be strictly below HIGH_WATER.
+cdef int LOW_WATER = 64 * 1024
+cdef int HIGH_WATER = 256 * 1024
+# Default stream() yield size — keep bytes in _acc until this big (or message done).
+cdef int DEFAULT_STREAM_CHUNK = 64 * 1024
 cdef double DEFAULT_TIMEOUT = 30.0
 cdef int POOL_MAX = 1024
 
@@ -140,11 +141,13 @@ cdef class RequestExchange:
         self._chunks = None
         self._cached = None
         self._data_ready = None
+        self._body_fut = None
         self._compression = _UNBOUND
         self._available = ()
         self._state = None
         self.in_pool = False
         self._body_active = False
+        self._stream_max_chunk = DEFAULT_STREAM_CHUNK
 
     def __dealloc__(self):
         self._free_compressors()
@@ -413,8 +416,10 @@ cdef class RequestExchange:
         self.in_pool = True
         self._cached = None
         self._data_ready = None
+        self._body_fut = None
         self._acc_len = 0
         self._body_active = False
+        self._stream_max_chunk = DEFAULT_STREAM_CHUNK
         if self._chunks is not None:
             self._chunks.clear()
 
@@ -720,6 +725,7 @@ cdef class RequestExchange:
             self._chunks.clear()
         self._cached = None
         self._data_ready = None
+        self._body_fut = None
         self._expect_continue = expect_continue
         self._buffered = 0
         self._total_read = 0
@@ -729,10 +735,10 @@ cdef class RequestExchange:
         self._waiting = False
         self._acc_len = 0
         self._expected_body = -1
+        self._stream_max_chunk = DEFAULT_STREAM_CHUNK
 
-    cdef void prepare_fixed_body(self, Py_ssize_t expected_size):
-        """Start buffering a known Content-Length body before the handler runs."""
-        self.reset_body(False)
+    cdef void prepare_body_capacity(self, Py_ssize_t expected_size):
+        """Pre-size the C accumulator for a known Content-Length (handler already running)."""
         self._expected_body = expected_size
         if expected_size > 0:
             self._acc_reserve(expected_size)
@@ -767,14 +773,23 @@ cdef class RequestExchange:
         self._acc_len = 0
         return out
 
-    cdef void _drain_acc(self):
-        if self._acc_len == 0:
+    cdef void _emit_from_acc(self, Py_ssize_t n):
+        """Peel ``n`` bytes from the front of ``_acc`` into the stream chunk list."""
+        cdef Py_ssize_t rest
+        cdef object chunk
+        if n <= 0 or self._acc_len == 0:
             return
+        if n > self._acc_len:
+            n = self._acc_len
         if self._chunks is None:
             self._chunks = []
-        self._chunks.append(PyBytes_FromStringAndSize(self._acc, self._acc_len))
-        self._buffered += self._acc_len
-        self._acc_len = 0
+        chunk = PyBytes_FromStringAndSize(self._acc, n)
+        self._chunks.append(chunk)
+        self._buffered += n
+        rest = self._acc_len - n
+        if rest > 0:
+            memmove(self._acc, self._acc + n, <size_t>rest)
+        self._acc_len = rest
 
     cdef void _raise_abort(self):
         if self._abort_reason == ABORT_TOO_LARGE:
@@ -791,6 +806,11 @@ cdef class RequestExchange:
     cdef void _wake(self):
         if self._data_ready is not None:
             self._data_ready.set()
+
+    cdef void _resolve_body_fut(self, object value):
+        cdef object fut = self._body_fut
+        if fut is not None and not fut.done():
+            fut.set_result(value)
 
     cdef object _take_chunk(self, int index):
         cdef object chunk = self._chunks[index]
@@ -810,8 +830,8 @@ cdef class RequestExchange:
 
     cdef void _maybe_pause(self):
         cdef object transport
-        # Only apply read backpressure when a stream consumer is draining chunks.
-        # body()/pre-dispatch paths keep a single _acc buffer up to Content-Length.
+        # Backpressure only while a stream consumer is draining — body() keeps one
+        # contiguous _acc up to max_body_bytes / Content-Length.
         if self._consumed_as != CONSUMED_STREAM:
             return
         if self._buffered + self._acc_len > HIGH_WATER:
@@ -820,19 +840,22 @@ cdef class RequestExchange:
                 transport.pause_reading()
 
     cdef void c_feed(self, const char* at, size_t length):
+        cdef Py_ssize_t max_chunk
         if not self._body_active:
             self.reset_body(False)
         self._total_read += <int>length
         if self._total_read > self._max_size:
             self._abort_reason = ABORT_TOO_LARGE
+            self._resolve_body_fut(None)
             self._wake()
             return
-        # Always append into the C accumulator. body() materializes once at the end;
-        # stream() drains in STREAM_BATCH-sized Python bytes chunks.
+        # Always append into the C accumulator. body() materializes once at complete;
+        # stream() peels DEFAULT_STREAM_CHUNK / max_chunk-sized Python bytes.
         self._acc_add(at, length)
         if self._consumed_as == CONSUMED_STREAM:
-            if self._acc_len >= STREAM_BATCH or self._waiting:
-                self._drain_acc()
+            max_chunk = self._stream_max_chunk
+            while self._acc_len >= max_chunk:
+                self._emit_from_acc(max_chunk)
                 self._wake()
             self._maybe_pause()
             return
@@ -843,23 +866,25 @@ cdef class RequestExchange:
         if not self._body_active:
             return
         self._body_complete = True
-        if self._abort_reason == ABORT_NONE and self._consumed_as != CONSUMED_STREAM:
-            # Single allocation for the full body (pre-dispatch or body() waiters).
-            if self._cached is None:
-                self._cached = self._acc_to_bytes()
-            elif self._acc_len > 0:
-                # Should not happen for body path; fold any remainder.
-                if self._chunks is None:
-                    self._chunks = []
-                self._chunks.append(self._acc_to_bytes())
-                self._cached = self._cached + b"".join(self._chunks)
-                self._chunks.clear()
-            self._buffered = 0
+        if self._consumed_as == CONSUMED_STREAM:
+            if self._acc_len > 0:
+                self._emit_from_acc(self._acc_len)
             self._wake()
             self._maybe_recycle()
             return
-        # Streaming consumer: flush remainder into the chunk list.
-        self._drain_acc()
+        if self._abort_reason != ABORT_NONE:
+            self._acc_len = 0
+            self._resolve_body_fut(None)
+            self._wake()
+            self._maybe_recycle()
+            return
+        # body() already waiting: materialize once and resolve the Future.
+        # Otherwise leave bytes in _acc until body() (or never — then park drops them).
+        if self._consumed_as == CONSUMED_BODY or self._body_fut is not None:
+            if self._cached is None:
+                self._cached = self._acc_to_bytes()
+            self._buffered = 0
+            self._resolve_body_fut(self._cached)
         self._wake()
         self._maybe_recycle()
 
@@ -869,6 +894,7 @@ cdef class RequestExchange:
         self._free_compressors()
         self._abort_reason = ABORT_DISCONNECTED
         self._body_complete = True
+        self._resolve_body_fut(None)
         self._wake()
         self._maybe_recycle()
 
@@ -891,14 +917,16 @@ cdef class RequestExchange:
             self._abort_reason = ABORT_TIMEOUT
             if self._chunks is not None:
                 self._chunks.clear()
+            self._resolve_body_fut(None)
             self._raise_abort()
         finally:
             self._waiting = False
         self._data_ready.clear()
 
-    async def stream(self):
+    async def stream(self, max_chunk=None):
         cdef int index
         cdef object chunk
+        cdef Py_ssize_t chunk_size
         if self._abort_reason != ABORT_NONE:
             self._raise_abort()
         if self._consumed_as == CONSUMED_BODY:
@@ -912,13 +940,26 @@ cdef class RequestExchange:
                 "Body already streaming. Each request body can only be streamed once.",
                 help_text="Call stream() only once per request.",
             )
+        if max_chunk is None:
+            chunk_size = DEFAULT_STREAM_CHUNK
+        else:
+            chunk_size = <Py_ssize_t>max_chunk
+            if chunk_size <= 0:
+                raise ValueError("max_chunk must be positive")
+            if chunk_size >= HIGH_WATER:
+                raise ValueError(
+                    f"max_chunk ({chunk_size}) must be lower than "
+                    f"high water mark ({HIGH_WATER})"
+                )
+        self._stream_max_chunk = chunk_size
         self._consumed_as = CONSUMED_STREAM
         if self._cached is not None:
             yield self._cached
             return
         self._maybe_continue()
-        # Move any bytes already buffered in _acc into yieldable chunks.
-        self._drain_acc()
+        # Emit any already-buffered full batches; leave a partial in _acc.
+        while self._acc_len >= chunk_size:
+            self._emit_from_acc(chunk_size)
         index = 0
         while True:
             while self._chunks is not None and index < len(self._chunks):
@@ -926,15 +967,16 @@ cdef class RequestExchange:
                 yield chunk
             if self._body_complete:
                 if self._acc_len > 0:
-                    self._drain_acc()
+                    self._emit_from_acc(self._acc_len)
                     continue
                 if self._chunks is not None:
                     self._chunks.clear()
                 return
             await self._wait_for_body_data()
-            self._drain_acc()
 
     async def read(self, max_size=None):
+        cdef object fut
+        cdef object result
         if max_size is not None and max_size < 0:
             raise ValueError("max_size must be non-negative.")
         if self._abort_reason != ABORT_NONE:
@@ -951,20 +993,36 @@ cdef class RequestExchange:
             return self._cached
         self._consumed_as = CONSUMED_BODY
         self._maybe_continue()
-        while not self._body_complete:
+        if self._body_complete:
+            if self._cached is None:
+                self._cached = self._acc_to_bytes()
+            if max_size is not None and len(self._cached) > max_size:
+                raise HttpException(413, "Request body too large")
+            self._buffered = 0
+            return self._cached
+        # One-shot Future resolved in c_complete / c_abort; stall timeout via Event.
+        fut = asyncio.get_running_loop().create_future()
+        self._body_fut = fut
+        try:
+            while not fut.done():
+                if self._abort_reason != ABORT_NONE:
+                    self._raise_abort()
+                if max_size is not None and self._acc_len > max_size:
+                    raise HttpException(413, "Request body too large")
+                await self._wait_for_body_data()
             if self._abort_reason != ABORT_NONE:
                 self._raise_abort()
-            if max_size is not None and self._acc_len > max_size:
+            result = fut.result()
+            if result is None:
+                if self._cached is None:
+                    self._cached = self._acc_to_bytes()
+                result = self._cached
+            if max_size is not None and len(result) > max_size:
                 raise HttpException(413, "Request body too large")
-            await self._wait_for_body_data()
-        if self._abort_reason != ABORT_NONE:
-            self._raise_abort()
-        if self._cached is None:
-            self._cached = self._acc_to_bytes()
-        if max_size is not None and len(self._cached) > max_size:
-            raise HttpException(413, "Request body too large")
-        self._buffered = 0
-        return self._cached
+            self._buffered = 0
+            return result
+        finally:
+            self._body_fut = None
 
 
 cdef RequestExchange acquire_exchange(

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -142,7 +142,6 @@ cdef class RequestExchange:
         self._chunks = None
         self._cached = None
         self._data_ready = None
-        self._body_fut = None
         self._compression = _UNBOUND
         self._available = ()
         self._state = None
@@ -417,7 +416,6 @@ cdef class RequestExchange:
         self.in_pool = True
         self._cached = None
         self._data_ready = None
-        self._body_fut = None
         self._acc_len = 0
         self._acc_pos = 0
         self._body_active = False
@@ -727,7 +725,6 @@ cdef class RequestExchange:
             self._chunks.clear()
         self._cached = None
         self._data_ready = None
-        self._body_fut = None
         self._expect_continue = expect_continue
         self._buffered = 0
         self._total_read = 0
@@ -839,11 +836,6 @@ cdef class RequestExchange:
         if self._data_ready is not None:
             self._data_ready.set()
 
-    cdef void _resolve_body_fut(self, object value):
-        cdef object fut = self._body_fut
-        if fut is not None and not fut.done():
-            fut.set_result(value)
-
     cdef object _take_chunk(self, int index):
         cdef object chunk = self._chunks[index]
         cdef object transport
@@ -878,11 +870,10 @@ cdef class RequestExchange:
         self._total_read += <int>length
         if self._total_read > self._max_size:
             self._abort_reason = ABORT_TOO_LARGE
-            self._resolve_body_fut(None)
             self._wake()
             return
         # Always append into the C accumulator. body() materializes once at complete;
-        # stream() peels DEFAULT_STREAM_CHUNK / max_chunk-sized Python bytes.
+        # stream() peels max_chunk-sized Python bytes.
         self._acc_add(at, length)
         if self._consumed_as == CONSUMED_STREAM:
             max_chunk = self._stream_max_chunk
@@ -907,17 +898,15 @@ cdef class RequestExchange:
         if self._abort_reason != ABORT_NONE:
             self._acc_pos = 0
             self._acc_len = 0
-            self._resolve_body_fut(None)
             self._wake()
             self._maybe_recycle()
             return
-        # body() already waiting: materialize once and resolve the Future.
-        # Otherwise leave bytes in _acc until body() (or never — then park drops them).
-        if self._consumed_as == CONSUMED_BODY or self._body_fut is not None:
+        # body() already waiting: materialize once. Otherwise leave bytes in _acc
+        # until body() (or never — then park drops them).
+        if self._consumed_as == CONSUMED_BODY:
             if self._cached is None:
                 self._cached = self._acc_to_bytes()
             self._buffered = 0
-            self._resolve_body_fut(self._cached)
         self._wake()
         self._maybe_recycle()
 
@@ -927,7 +916,6 @@ cdef class RequestExchange:
         self._free_compressors()
         self._abort_reason = ABORT_DISCONNECTED
         self._body_complete = True
-        self._resolve_body_fut(None)
         self._wake()
         self._maybe_recycle()
 
@@ -950,7 +938,6 @@ cdef class RequestExchange:
             self._abort_reason = ABORT_TIMEOUT
             if self._chunks is not None:
                 self._chunks.clear()
-            self._resolve_body_fut(None)
             self._raise_abort()
         finally:
             self._waiting = False
@@ -1008,8 +995,6 @@ cdef class RequestExchange:
             await self._wait_for_body_data()
 
     async def read(self, max_size=None):
-        cdef object fut
-        cdef object result
         if max_size is not None and max_size < 0:
             raise ValueError("max_size must be non-negative.")
         if self._abort_reason != ABORT_NONE:
@@ -1026,36 +1011,21 @@ cdef class RequestExchange:
             return self._cached
         self._consumed_as = CONSUMED_BODY
         self._maybe_continue()
-        if self._body_complete:
-            if self._cached is None:
-                self._cached = self._acc_to_bytes()
-            if max_size is not None and len(self._cached) > max_size:
-                raise HttpException(413, "Request body too large")
-            self._buffered = 0
-            return self._cached
-        # One-shot Future resolved in c_complete / c_abort; stall timeout via Event.
-        fut = asyncio.get_running_loop().create_future()
-        self._body_fut = fut
-        try:
-            while not fut.done():
-                if self._abort_reason != ABORT_NONE:
-                    self._raise_abort()
-                if max_size is not None and self._acc_unread() > max_size:
-                    raise HttpException(413, "Request body too large")
-                await self._wait_for_body_data()
+        # Stall-aware Event wait until message complete, then one materialization.
+        while not self._body_complete:
             if self._abort_reason != ABORT_NONE:
                 self._raise_abort()
-            result = fut.result()
-            if result is None:
-                if self._cached is None:
-                    self._cached = self._acc_to_bytes()
-                result = self._cached
-            if max_size is not None and len(result) > max_size:
+            if max_size is not None and self._acc_unread() > max_size:
                 raise HttpException(413, "Request body too large")
-            self._buffered = 0
-            return result
-        finally:
-            self._body_fut = None
+            await self._wait_for_body_data()
+        if self._abort_reason != ABORT_NONE:
+            self._raise_abort()
+        if self._cached is None:
+            self._cached = self._acc_to_bytes()
+        if max_size is not None and len(self._cached) > max_size:
+            raise HttpException(413, "Request body too large")
+        self._buffered = 0
+        return self._cached
 
 
 cdef RequestExchange acquire_exchange(

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -43,6 +43,8 @@ from stario_cython.request cimport Request
 
 cdef int LOW_WATER = 16 * 1024
 cdef int HIGH_WATER = 64 * 1024
+# Yield / chunk batch size for stream() consumers — keep data in _acc until this big.
+cdef int STREAM_BATCH = 64 * 1024
 cdef double DEFAULT_TIMEOUT = 30.0
 cdef int POOL_MAX = 1024
 
@@ -129,6 +131,7 @@ cdef class RequestExchange:
         self._acc = NULL
         self._acc_len = 0
         self._acc_cap = 0
+        self._expected_body = -1
 
     def __init__(self):
         self.headers = Headers()
@@ -725,23 +728,44 @@ cdef class RequestExchange:
         self._body_complete = False
         self._waiting = False
         self._acc_len = 0
+        self._expected_body = -1
+
+    cdef void prepare_fixed_body(self, Py_ssize_t expected_size):
+        """Start buffering a known Content-Length body before the handler runs."""
+        self.reset_body(False)
+        self._expected_body = expected_size
+        if expected_size > 0:
+            self._acc_reserve(expected_size)
+
+    cdef int _acc_reserve(self, Py_ssize_t need) except -1:
+        cdef Py_ssize_t next_cap
+        cdef char* p
+        if need <= self._acc_cap:
+            return 0
+        next_cap = 64 if self._acc_cap == 0 else self._acc_cap * 2
+        if next_cap < need:
+            next_cap = need
+        p = <char*>realloc(self._acc, <size_t>next_cap)
+        if p == NULL:
+            raise MemoryError()
+        self._acc = p
+        self._acc_cap = next_cap
+        return 0
 
     cdef int _acc_add(self, const char* at, size_t length) except -1:
         cdef Py_ssize_t need = self._acc_len + <Py_ssize_t>length
-        cdef Py_ssize_t next_cap
-        cdef char* p
-        if need > self._acc_cap:
-            next_cap = 64 if self._acc_cap == 0 else self._acc_cap * 2
-            if next_cap < need:
-                next_cap = need
-            p = <char*>realloc(self._acc, <size_t>next_cap)
-            if p == NULL:
-                raise MemoryError()
-            self._acc = p
-            self._acc_cap = next_cap
+        self._acc_reserve(need)
         memcpy(self._acc + self._acc_len, at, length)
         self._acc_len = need
         return 0
+
+    cdef object _acc_to_bytes(self):
+        cdef object out
+        if self._acc_len == 0:
+            return b""
+        out = PyBytes_FromStringAndSize(self._acc, self._acc_len)
+        self._acc_len = 0
+        return out
 
     cdef void _drain_acc(self):
         if self._acc_len == 0:
@@ -749,6 +773,7 @@ cdef class RequestExchange:
         if self._chunks is None:
             self._chunks = []
         self._chunks.append(PyBytes_FromStringAndSize(self._acc, self._acc_len))
+        self._buffered += self._acc_len
         self._acc_len = 0
 
     cdef void _raise_abort(self):
@@ -783,9 +808,18 @@ cdef class RequestExchange:
             if self._transport is not None and not self._transport.is_closing():
                 self._transport.write(b"HTTP/1.1 100 Continue\r\n\r\n")
 
-    cdef void c_feed(self, const char* at, size_t length):
-        cdef object chunk
+    cdef void _maybe_pause(self):
         cdef object transport
+        # Only apply read backpressure when a stream consumer is draining chunks.
+        # body()/pre-dispatch paths keep a single _acc buffer up to Content-Length.
+        if self._consumed_as != CONSUMED_STREAM:
+            return
+        if self._buffered + self._acc_len > HIGH_WATER:
+            transport = self._transport
+            if transport is not None and not transport.is_closing():
+                transport.pause_reading()
+
+    cdef void c_feed(self, const char* at, size_t length):
         if not self._body_active:
             self.reset_body(False)
         self._total_read += <int>length
@@ -793,39 +827,39 @@ cdef class RequestExchange:
             self._abort_reason = ABORT_TOO_LARGE
             self._wake()
             return
-        if self._waiting or self._consumed_as == CONSUMED_STREAM:
-            self._drain_acc()
-            chunk = PyBytes_FromStringAndSize(at, <Py_ssize_t>length)
-            if self._chunks is None:
-                self._chunks = []
-            self._chunks.append(chunk)
-            self._buffered += <int>length
+        # Always append into the C accumulator. body() materializes once at the end;
+        # stream() drains in STREAM_BATCH-sized Python bytes chunks.
+        self._acc_add(at, length)
+        if self._consumed_as == CONSUMED_STREAM:
+            if self._acc_len >= STREAM_BATCH or self._waiting:
+                self._drain_acc()
+                self._wake()
+            self._maybe_pause()
+            return
+        if self._waiting:
             self._wake()
-        else:
-            self._acc_add(at, length)
-            self._buffered += <int>length
-        if self._buffered > HIGH_WATER:
-            transport = self._transport
-            if transport is not None and not transport.is_closing():
-                transport.pause_reading()
 
     cdef void c_complete(self):
         if not self._body_active:
             return
         self._body_complete = True
-        self._drain_acc()
-        if self._abort_reason == ABORT_NONE and self._consumed_as == CONSUMED_NONE:
-            if self._chunks is None or not self._chunks:
-                self._cached = b""
-            elif len(self._chunks) == 1:
-                self._cached = self._chunks[0]
-            else:
-                self._cached = b"".join(self._chunks)
-            if self._chunks is not None:
+        if self._abort_reason == ABORT_NONE and self._consumed_as != CONSUMED_STREAM:
+            # Single allocation for the full body (pre-dispatch or body() waiters).
+            if self._cached is None:
+                self._cached = self._acc_to_bytes()
+            elif self._acc_len > 0:
+                # Should not happen for body path; fold any remainder.
+                if self._chunks is None:
+                    self._chunks = []
+                self._chunks.append(self._acc_to_bytes())
+                self._cached = self._cached + b"".join(self._chunks)
                 self._chunks.clear()
             self._buffered = 0
+            self._wake()
             self._maybe_recycle()
             return
+        # Streaming consumer: flush remainder into the chunk list.
+        self._drain_acc()
         self._wake()
         self._maybe_recycle()
 
@@ -883,23 +917,24 @@ cdef class RequestExchange:
             yield self._cached
             return
         self._maybe_continue()
+        # Move any bytes already buffered in _acc into yieldable chunks.
+        self._drain_acc()
         index = 0
         while True:
-            self._drain_acc()
             while self._chunks is not None and index < len(self._chunks):
                 index, chunk = self._take_chunk(index)
                 yield chunk
             if self._body_complete:
+                if self._acc_len > 0:
+                    self._drain_acc()
+                    continue
                 if self._chunks is not None:
                     self._chunks.clear()
                 return
             await self._wait_for_body_data()
+            self._drain_acc()
 
     async def read(self, max_size=None):
-        cdef list chunks = []
-        cdef int total = 0
-        cdef int index = 0
-        cdef object chunk
         if max_size is not None and max_size < 0:
             raise ValueError("max_size must be non-negative.")
         if self._abort_reason != ABORT_NONE:
@@ -916,21 +951,20 @@ cdef class RequestExchange:
             return self._cached
         self._consumed_as = CONSUMED_BODY
         self._maybe_continue()
-        while True:
-            self._drain_acc()
-            while self._chunks is not None and index < len(self._chunks):
-                chunk = self._chunks[index]
-                if max_size is not None and total + len(chunk) > max_size:
-                    raise HttpException(413, "Request body too large")
-                index, chunk = self._take_chunk(index)
-                total += len(chunk)
-                chunks.append(chunk)
-            if self._body_complete:
-                self._cached = b"".join(chunks)
-                if self._chunks is not None:
-                    self._chunks.clear()
-                return self._cached
+        while not self._body_complete:
+            if self._abort_reason != ABORT_NONE:
+                self._raise_abort()
+            if max_size is not None and self._acc_len > max_size:
+                raise HttpException(413, "Request body too large")
             await self._wait_for_body_data()
+        if self._abort_reason != ABORT_NONE:
+            self._raise_abort()
+        if self._cached is None:
+            self._cached = self._acc_to_bytes()
+        if max_size is not None and len(self._cached) > max_size:
+            raise HttpException(413, "Request body too large")
+        self._buffered = 0
+        return self._cached
 
 
 cdef RequestExchange acquire_exchange(

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -484,12 +484,43 @@ cdef class RequestExchange:
         self.route = EMPTY_ROUTE_MATCH
         self._state = None
         self.request_headers.c_clear()
+        self._req_accept_encoding = None
+        self._req_connection = None
+        self._req_expect = None
+        self._req_content_type = None
+        self._req_host = None
+        self._req_expect_continue = False
+        self._req_connection_close = False
+        self._resp_connection_close = False
         self.handler_done = False
         self.handler_started = False
 
+    cdef void cache_hot_request_headers(self):
+        """Snapshot hot request headers for protocol/compression (dict API unchanged)."""
+        cdef Headers h = self.request_headers
+        cdef object v
+        self._req_accept_encoding = h.c_get(b"accept-encoding")
+        v = h.c_get(b"connection")
+        if v is None:
+            self._req_connection = None
+            self._req_connection_close = False
+        else:
+            self._req_connection = v.lower()
+            self._req_connection_close = self._req_connection == b"close"
+        v = h.c_get(b"expect")
+        if v is None:
+            self._req_expect = None
+            self._req_expect_continue = False
+        else:
+            self._req_expect = v.lower()
+            self._req_expect_continue = self._req_expect == b"100-continue"
+        self._req_content_type = h.c_get(b"content-type")
+        self._req_host = h.c_get(b"host")
+
     cdef void start_response(self):
         self.handler_started = True
-        self.reset_response(self.request_headers.c_get(b"accept-encoding"))
+        self._resp_connection_close = False
+        self.reset_response(self._req_accept_encoding)
 
     cdef void handler_finished(self):
         self.handler_done = True
@@ -523,6 +554,14 @@ cdef class RequestExchange:
         self._acc_pos = 0
         self._body_active = False
         self._read_max_size = -1
+        self._req_accept_encoding = None
+        self._req_connection = None
+        self._req_expect = None
+        self._req_content_type = None
+        self._req_host = None
+        self._req_expect_continue = False
+        self._req_connection_close = False
+        self._resp_connection_close = False
         self._stream_max_chunk = DEFAULT_STREAM_CHUNK
         if self._chunks is not None:
             self._chunks.clear()
@@ -536,6 +575,14 @@ cdef class RequestExchange:
         self.route = EMPTY_ROUTE_MATCH
         self._state = None
         self._accept = None
+        self._req_accept_encoding = None
+        self._req_connection = None
+        self._req_expect = None
+        self._req_content_type = None
+        self._req_host = None
+        self._req_expect_continue = False
+        self._req_connection_close = False
+        self._resp_connection_close = False
         self.app = None
         self._connection = None
         self._transport = None
@@ -654,6 +701,7 @@ cdef class RequestExchange:
             return
         self._free_compressors()
         self._completed = True
+        self._resp_connection_close = True
         self.headers.c_set(b"connection", b"close")
         self._transport.close()
         self._done()

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -18,9 +18,8 @@ from stario_cython.request cimport Request
 
 cdef int F_CHUNKED = 0x8
 cdef int F_CONTENT_LENGTH = 0x20
-# Fixed Content-Length bodies are fully buffered in C before the handler runs
-# (up to max_body_bytes). Early dispatch is reserved for chunked uploads and
-# Expect: 100-continue, where the handler must start before the body finishes.
+# Handlers always start at headers-complete. Body bytes accumulate on the exchange;
+# body() awaits one completion Future, stream() drains with backpressure.
 
 cdef object METH_DELETE = "DELETE"
 cdef object METH_GET = "GET"
@@ -190,7 +189,6 @@ cdef class HttpProtocol:
     cdef int max_body_bytes
     cdef bint have_value
     cdef bint rejected
-    cdef bint stream_body
     cdef bint request_dispatched
     cdef bint request_keep_alive
 
@@ -258,7 +256,6 @@ cdef class HttpProtocol:
         self.max_body_bytes = max_body_bytes
         self.have_value = False
         self.rejected = False
-        self.stream_body = False
         self.request_dispatched = False
         self.request_keep_alive = True
 
@@ -384,7 +381,6 @@ cdef class HttpProtocol:
                 self.max_body_bytes,
             )
         self.head_bytes = 40
-        self.stream_body = False
         self.request_dispatched = False
         self.request_keep_alive = True
         self.url = b""
@@ -449,14 +445,12 @@ cdef class HttpProtocol:
         expect_continue = (
             (headers.c_get(b"expect") or b"").lower() == b"100-continue"
         )
-        # Chunked / 100-continue need the handler before the body finishes.
-        # Known Content-Length bodies stay in the C accumulator until complete,
-        # then dispatch with a single bytes object (same fast path as small POSTs).
-        self.stream_body = expect_continue or (flags & F_CHUNKED) != 0
-        if self.stream_body:
-            self.complete_headers(expect_continue)
-        elif flags & F_CONTENT_LENGTH:
-            self.reading_exchange.prepare_fixed_body(<Py_ssize_t>content_length)
+        # Always start the handler at headers-complete. Pre-size _acc when the
+        # Content-Length is known so body() can materialize without realloc churn.
+        if flags & F_CONTENT_LENGTH:
+            self.complete_headers(expect_continue, <Py_ssize_t>content_length)
+        else:
+            self.complete_headers(expect_continue, -1)
 
     cdef void _on_body(self, const char* at, size_t length):
         self.reading_exchange.c_feed(at, length)
@@ -466,18 +460,8 @@ cdef class HttpProtocol:
         if self.rejected:
             return
         exchange = self.reading_exchange
-        if self.stream_body:
+        if exchange is not None and exchange._body_active:
             exchange.c_complete()
-            self.reading_exchange = None
-            return
-        if exchange._body_active:
-            exchange.c_complete()
-            # Pass materialized bytes so req.body() is a sync return (no async read).
-            self.complete_request(
-                exchange._cached if exchange._cached is not None else b""
-            )
-        else:
-            self.complete_request(None)
         self.reading_exchange = None
 
     cdef Request _build_request(self, RequestExchange exchange, object body):
@@ -508,7 +492,7 @@ cdef class HttpProtocol:
         )
         return request
 
-    cdef void complete_headers(self, bint expect_continue):
+    cdef void complete_headers(self, bint expect_continue, Py_ssize_t expected_body):
         cdef RequestExchange exchange
         cdef Request request
         if self.request_dispatched or self.rejected:
@@ -518,16 +502,9 @@ cdef class HttpProtocol:
         exchange = self.reading_exchange
         request = self._build_request(exchange, exchange)
         exchange.reset_body(expect_continue)
+        if expected_body > 0:
+            exchange.prepare_body_capacity(expected_body)
         self._dispatch(exchange, request)
-
-    cdef void complete_request(self, object body):
-        cdef RequestExchange exchange
-        if self.request_dispatched or self.rejected:
-            return
-        if self.transport is None or self.transport.is_closing():
-            return
-        exchange = self.reading_exchange
-        self._dispatch(exchange, self._build_request(exchange, body))
 
     cdef void _dispatch(self, RequestExchange exchange, Request request):
         cdef object span

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -545,6 +545,13 @@ cdef class HttpProtocol:
         self.pending_exchanges.clear()
 
     def response_completed(self, RequestExchange exchange):
+        """Advance the connection after the response is fully sent.
+
+        Fired from ``respond()`` / ``end()`` / ``abort()`` via ``_done`` — not when
+        the handler coroutine returns. The handler (or ``app.create_task`` work)
+        may still run after this; the connection is free to start the next
+        pipelined/keep-alive exchange immediately.
+        """
         cdef object transport = self.transport
         cdef object conn
         cdef RequestExchange next_exchange

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -18,7 +18,9 @@ from stario_cython.request cimport Request
 
 cdef int F_CHUNKED = 0x8
 cdef int F_CONTENT_LENGTH = 0x20
-cdef int STREAM_BODY_AFTER = 65536
+# Fixed Content-Length bodies are fully buffered in C before the handler runs
+# (up to max_body_bytes). Early dispatch is reserved for chunked uploads and
+# Expect: 100-continue, where the handler must start before the body finishes.
 
 cdef object METH_DELETE = "DELETE"
 cdef object METH_GET = "GET"
@@ -447,11 +449,14 @@ cdef class HttpProtocol:
         expect_continue = (
             (headers.c_get(b"expect") or b"").lower() == b"100-continue"
         )
-        self.stream_body = expect_continue or (flags & F_CHUNKED) != 0 or (
-            (flags & F_CONTENT_LENGTH) != 0 and content_length > STREAM_BODY_AFTER
-        )
+        # Chunked / 100-continue need the handler before the body finishes.
+        # Known Content-Length bodies stay in the C accumulator until complete,
+        # then dispatch with a single bytes object (same fast path as small POSTs).
+        self.stream_body = expect_continue or (flags & F_CHUNKED) != 0
         if self.stream_body:
             self.complete_headers(expect_continue)
+        elif flags & F_CONTENT_LENGTH:
+            self.reading_exchange.prepare_fixed_body(<Py_ssize_t>content_length)
 
     cdef void _on_body(self, const char* at, size_t length):
         self.reading_exchange.c_feed(at, length)
@@ -467,7 +472,10 @@ cdef class HttpProtocol:
             return
         if exchange._body_active:
             exchange.c_complete()
-            self.complete_request(exchange)
+            # Pass materialized bytes so req.body() is a sync return (no async read).
+            self.complete_request(
+                exchange._cached if exchange._cached is not None else b""
+            )
         else:
             self.complete_request(None)
         self.reading_exchange = None

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -414,10 +414,9 @@ cdef class HttpProtocol:
         self.have_value = True
 
     cdef void _on_headers_complete(self):
-        cdef Headers headers
+        cdef RequestExchange exchange
         cdef uint16_t flags
         cdef uint64_t content_length
-        cdef bint expect_continue
         if self.url_buf != NULL and self.url_len > 0:
             self.url = PyBytes_FromStringAndSize(self.url_buf, self.url_len)
         else:
@@ -425,7 +424,7 @@ cdef class HttpProtocol:
         self._flush_header()
         if self.rejected or self.reading_exchange is None:
             return
-        headers = self.reading_exchange.request_headers
+        exchange = self.reading_exchange
         if llhttp_get_upgrade(self.parser):
             self._close_error(400, "Upgrade not supported")
             return
@@ -434,23 +433,25 @@ cdef class HttpProtocol:
         if flags & F_CONTENT_LENGTH and content_length > <uint64_t>self.max_body_bytes:
             self._close_error(413, "Request body too large")
             return
+        # One dict pass into exchange slots; keep-alive / expect / accept-encoding
+        # then use those fields (Headers public API unchanged).
+        exchange.cache_hot_request_headers()
         self.request_keep_alive = (
             llhttp_should_keep_alive(self.parser) != 0
             or (
                 llhttp_get_http_major(self.parser) == 1
                 and llhttp_get_http_minor(self.parser) == 1
-                and (headers.c_get(b"connection") or b"").lower() != b"close"
+                and not exchange._req_connection_close
             )
-        )
-        expect_continue = (
-            (headers.c_get(b"expect") or b"").lower() == b"100-continue"
         )
         # Always start the handler at headers-complete. Pre-size _acc when the
         # Content-Length is known so body() can materialize without realloc churn.
         if flags & F_CONTENT_LENGTH:
-            self.complete_headers(expect_continue, <Py_ssize_t>content_length)
+            self.complete_headers(
+                exchange._req_expect_continue, <Py_ssize_t>content_length
+            )
         else:
-            self.complete_headers(expect_continue, -1)
+            self.complete_headers(exchange._req_expect_continue, -1)
 
     cdef void _on_body(self, const char* at, size_t length):
         self.reading_exchange.c_feed(at, length)
@@ -561,6 +562,11 @@ cdef class HttpProtocol:
         if transport is None or transport.is_closing():
             self._drop_pending()
             return
+        if exchange._resp_connection_close:
+            transport.close()
+            self._drop_pending()
+            return
+        # User may have set Connection: close on the response Headers dict.
         conn = exchange.headers.c_get(b"connection")
         if conn is not None and conn.lower() == b"close":
             transport.close()

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -19,7 +19,7 @@ from stario_cython.request cimport Request
 cdef int F_CHUNKED = 0x8
 cdef int F_CONTENT_LENGTH = 0x20
 # Handlers always start at headers-complete. Body bytes accumulate on the exchange;
-# body() awaits one completion Future, stream() drains with backpressure.
+# body() awaits one completion Event, stream() drains with backpressure.
 
 cdef object METH_DELETE = "DELETE"
 cdef object METH_GET = "GET"
@@ -433,8 +433,7 @@ cdef class HttpProtocol:
         if flags & F_CONTENT_LENGTH and content_length > <uint64_t>self.max_body_bytes:
             self._close_error(413, "Request body too large")
             return
-        # One dict pass into exchange slots; keep-alive / expect / accept-encoding
-        # then use those fields (Headers public API unchanged).
+        # Snapshot keep-alive / expect / accept-encoding into exchange slots.
         exchange.cache_hot_request_headers()
         self.request_keep_alive = (
             llhttp_should_keep_alive(self.parser) != 0
@@ -560,10 +559,6 @@ cdef class HttpProtocol:
             return
         self.active_exchange = None
         if transport is None or transport.is_closing():
-            self._drop_pending()
-            return
-        if exchange._resp_connection_close:
-            transport.close()
             self._drop_pending()
             return
         # User may have set Connection: close on the response Headers dict.

--- a/src/stario_cython/request.pyx
+++ b/src/stario_cython/request.pyx
@@ -105,11 +105,11 @@ cdef class Request:
             return self._body
         return await self._body.read(max_size=max_size)
 
-    async def stream(self):
+    async def stream(self, max_chunk=None):
         if self._body is None:
             return
         if type(self._body) is bytes:
             yield self._body
             return
-        async for chunk in self._body.stream():
+        async for chunk in self._body.stream(max_chunk=max_chunk):
             yield chunk

--- a/tests/cython/test_headers_writer.py
+++ b/tests/cython/test_headers_writer.py
@@ -318,3 +318,150 @@ async def test_exchange_rejects_negative_content_length() -> None:
         finally:
             writer.close()
             await writer.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_respond_accepts_list_of_bytes_parts() -> None:
+    app = App()
+
+    async def multi(_c, w):
+        w.respond([b"hel", b"lo", b", ", b"parts"], b"text/plain; charset=utf-8")
+
+    app.get("/", multi)
+    async with _running_server(app, date=b"date: now\r\n") as port:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            writer.write(
+                b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+            )
+            await writer.drain()
+            payload = await _read_response(reader)
+            assert b"content-length: 12\r\n" in payload
+            assert payload.endswith(b"hello, parts")
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_write_known_length_accepts_list_of_bytes_parts() -> None:
+    app = App()
+
+    async def multi(_c, w):
+        w.headers.unsafe_set(b"content-type", b"text/plain")
+        w.headers.unsafe_set(b"content-length", b"11")
+        w.write_headers(200)
+        w.write([b"hello", b" ", b"world"])
+        w.end()
+
+    app.get("/", multi)
+    async with _running_server(app, date=b"date: now\r\n") as port:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            writer.write(
+                b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+            )
+            await writer.drain()
+            payload = await _read_response(reader)
+            assert payload.endswith(b"hello world")
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_write_chunked_accepts_list_of_bytes_parts() -> None:
+    app = App()
+
+    async def multi(_c, w):
+        w.headers.set("content-type", "text/plain")
+        w.write_headers(200)
+        w.write([b"aaa", b"bbb", b"ccc"])
+        w.end()
+
+    app.get("/", multi)
+    async with _running_server(
+        app,
+        date=b"date: now\r\n",
+        compression=CompressionConfig(
+            brotli_level=-1, zstd_level=-1, gzip_level=-1
+        ),
+    ) as port:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            writer.write(
+                b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+            )
+            await writer.drain()
+            header = await reader.readuntil(b"\r\n\r\n")
+            assert b"transfer-encoding: chunked" in header.lower()
+            assert await _read_chunk(reader) == b"aaabbbccc"
+            assert await _read_chunk(reader) == b""
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_respond_list_parts_native_compression_round_trip() -> None:
+    app = App()
+    parts = [b"native ", b"list ", b"compression " * 32]
+
+    async def compressed(_c, w):
+        w.respond(parts, b"text/plain; charset=utf-8")
+
+    app.get("/", compressed)
+    async with _running_server(
+        app,
+        date=b"date: now\r\n",
+        compression=CompressionConfig(
+            min_size=0,
+            brotli_level=4,
+            brotli_window_log=18,
+            zstd_level=-1,
+            gzip_level=-1,
+        ),
+    ) as port:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            writer.write(
+                b"GET / HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"Accept-Encoding: br\r\n"
+                b"Connection: close\r\n\r\n"
+            )
+            await writer.drain()
+            payload = await _read_response(reader)
+            header, compressed_body = payload.split(b"\r\n\r\n", 1)
+            assert b"content-encoding: br\r\n" in header + b"\r\n"
+            assert brotli.decompress(compressed_body) == b"".join(parts)
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_respond_rejects_non_bytes_parts() -> None:
+    app = App()
+    caught = asyncio.get_running_loop().create_future()
+
+    async def bad(_c, w):
+        try:
+            w.respond([b"ok", "nope"], b"text/plain")  # type: ignore[list-item]
+        except TypeError as exc:
+            caught.set_result(exc)
+            w.respond(b"err", b"text/plain", 500)
+
+    app.get("/", bad)
+    async with _running_server(app, date=b"date: now\r\n") as port:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            writer.write(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            await writer.drain()
+            async with asyncio.timeout(2):
+                exc = await caught
+            assert "bytes-like" in str(exc)
+            await _read_response(reader)
+        finally:
+            writer.close()
+            await writer.wait_closed()

--- a/tests/cython/test_headers_writer.py
+++ b/tests/cython/test_headers_writer.py
@@ -344,6 +344,29 @@ async def test_respond_accepts_list_of_bytes_parts() -> None:
 
 
 @pytest.mark.asyncio
+async def test_respond_accepts_tuple_of_bytes_parts() -> None:
+    app = App()
+
+    async def multi(_c, w):
+        w.respond((b"tup", b"le"), b"text/plain; charset=utf-8")
+
+    app.get("/", multi)
+    async with _running_server(app, date=b"date: now\r\n") as port:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            writer.write(
+                b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+            )
+            await writer.drain()
+            payload = await _read_response(reader)
+            assert b"content-length: 5\r\n" in payload
+            assert payload.endswith(b"tuple")
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+
+@pytest.mark.asyncio
 async def test_write_known_length_accepts_list_of_bytes_parts() -> None:
     app = App()
 

--- a/tests/cython/test_protocol.py
+++ b/tests/cython/test_protocol.py
@@ -457,3 +457,148 @@ async def test_exchange_pool_reuses_across_connections() -> None:
     finally:
         server.close()
         await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_handler_starts_before_content_length_body_arrives() -> None:
+    loop = asyncio.get_running_loop()
+    app = App()
+    started = asyncio.Event()
+
+    async def echo(c, w):
+        started.set()
+        body = await c.req.body()
+        w.respond(body, b"text/plain")
+
+    app.post("/echo", echo)
+    connections: set[HttpProtocol] = set()
+    server = await loop.create_server(
+        lambda: HttpProtocol(
+            loop,
+            app,
+            NoOpTracer(),
+            [b"date: Tue, 18 Aug 2026 00:00:00 GMT\r\n"],
+            CompressionConfig(),
+            connections,
+        ),
+        "127.0.0.1",
+        _free_port(),
+    )
+    port = server.sockets[0].getsockname()[1]
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(
+            b"POST /echo HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Content-Length: 5\r\n\r\n"
+        )
+        await writer.drain()
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        writer.write(b"hello")
+        await writer.drain()
+        assert b"hello" in await _read_response(reader)
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_stream_max_chunk_must_be_below_high_water() -> None:
+    loop = asyncio.get_running_loop()
+    app = App()
+    errors: list[BaseException] = []
+
+    async def upload(c, w):
+        try:
+            async for _ in c.req.stream(max_chunk=256 * 1024):
+                pass
+        except BaseException as exc:
+            errors.append(exc)
+            raise
+        w.respond(b"ok", b"text/plain")
+
+    app.post("/upload", upload)
+    connections: set[HttpProtocol] = set()
+    server = await loop.create_server(
+        lambda: HttpProtocol(
+            loop,
+            app,
+            NoOpTracer(),
+            [b"date: Tue, 18 Aug 2026 00:00:00 GMT\r\n"],
+            CompressionConfig(),
+            connections,
+        ),
+        "127.0.0.1",
+        _free_port(),
+    )
+    port = server.sockets[0].getsockname()[1]
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(
+            b"POST /upload HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Content-Length: 1\r\n\r\n"
+            b"x"
+        )
+        await writer.drain()
+        response = await _read_response(reader)
+        assert b"500" in response.split(b"\r\n", 1)[0] or errors
+        assert errors
+        assert isinstance(errors[0], ValueError)
+        assert "high water" in str(errors[0])
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_stream_respects_max_chunk_batches() -> None:
+    loop = asyncio.get_running_loop()
+    app = App()
+    sizes: list[int] = []
+
+    async def upload(c, w):
+        async for chunk in c.req.stream(max_chunk=8 * 1024):
+            sizes.append(len(chunk))
+        w.respond(str(sum(sizes)).encode("ascii"), b"text/plain")
+
+    app.post("/upload", upload)
+    connections: set[HttpProtocol] = set()
+    server = await loop.create_server(
+        lambda: HttpProtocol(
+            loop,
+            app,
+            NoOpTracer(),
+            [b"date: Tue, 18 Aug 2026 00:00:00 GMT\r\n"],
+            CompressionConfig(),
+            connections,
+        ),
+        "127.0.0.1",
+        _free_port(),
+    )
+    port = server.sockets[0].getsockname()[1]
+    payload = b"z" * (40 * 1024)
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(
+            b"POST /upload HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Content-Length: "
+            + str(len(payload)).encode("ascii")
+            + b"\r\n\r\n"
+            + payload
+        )
+        await writer.drain()
+        assert b"40960" in await _read_response(reader)
+        assert sizes
+        assert all(size <= 8 * 1024 for size in sizes)
+        assert any(size == 8 * 1024 for size in sizes[:-1] or sizes)
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        server.close()
+        await server.wait_closed()

--- a/tests/cython/test_protocol.py
+++ b/tests/cython/test_protocol.py
@@ -505,6 +505,119 @@ async def test_handler_starts_before_content_length_body_arrives() -> None:
 
 
 @pytest.mark.asyncio
+async def test_body_wait_survives_multi_segment_upload() -> None:
+    """body() must not require per-segment Event wakes — only completion."""
+    loop = asyncio.get_running_loop()
+    app = App()
+    started = asyncio.Event()
+
+    async def echo(c, w):
+        started.set()
+        body = await c.req.body()
+        w.respond(body, b"text/plain")
+
+    app.post("/echo", echo)
+    connections: set[HttpProtocol] = set()
+    server = await loop.create_server(
+        lambda: HttpProtocol(
+            loop,
+            app,
+            NoOpTracer(),
+            [b"date: Tue, 18 Aug 2026 00:00:00 GMT\r\n"],
+            CompressionConfig(),
+            connections,
+        ),
+        "127.0.0.1",
+        _free_port(),
+    )
+    port = server.sockets[0].getsockname()[1]
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        payload = b"abcdefghij" * 1000  # 10 KiB
+        writer.write(
+            b"POST /echo HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Content-Length: "
+            + str(len(payload)).encode("ascii")
+            + b"\r\n\r\n"
+        )
+        await writer.drain()
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        # Deliver body in small segments with yields so body() is waiting.
+        for i in range(0, len(payload), 512):
+            writer.write(payload[i : i + 512])
+            await writer.drain()
+            await asyncio.sleep(0)
+        assert payload in await _read_response(reader)
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_next_request_starts_after_respond_before_handler_returns() -> None:
+    """Connection advances on response send, not when the handler coroutine ends."""
+    loop = asyncio.get_running_loop()
+    app = App()
+    first_responded = asyncio.Event()
+    second_started = asyncio.Event()
+    release_first = asyncio.Event()
+    order: list[str] = []
+
+    async def first(_c, w):
+        order.append("first-enter")
+        w.respond(b"one", b"text/plain")
+        first_responded.set()
+        await release_first.wait()
+        order.append("first-exit")
+
+    async def second(_c, w):
+        order.append("second-enter")
+        second_started.set()
+        w.respond(b"two", b"text/plain")
+
+    app.get("/first", first)
+    app.get("/second", second)
+    connections: set[HttpProtocol] = set()
+    server = await loop.create_server(
+        lambda: HttpProtocol(
+            loop,
+            app,
+            NoOpTracer(),
+            [b"date: Tue, 18 Aug 2026 00:00:00 GMT\r\n"],
+            CompressionConfig(),
+            connections,
+        ),
+        "127.0.0.1",
+        _free_port(),
+    )
+    port = server.sockets[0].getsockname()[1]
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(
+            b"GET /first HTTP/1.1\r\nHost: localhost\r\n\r\n"
+            b"GET /second HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        )
+        await writer.drain()
+        assert b"one" in await _read_response(reader)
+        await asyncio.wait_for(first_responded.wait(), timeout=1.0)
+        await asyncio.wait_for(second_started.wait(), timeout=1.0)
+        assert "second-enter" in order
+        assert "first-exit" not in order
+        release_first.set()
+        assert b"two" in await _read_response(reader)
+        await asyncio.sleep(0)
+        assert order == ["first-enter", "second-enter", "first-exit"]
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
 async def test_stream_max_chunk_must_be_below_high_water() -> None:
     loop = asyncio.get_running_loop()
     app = App()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Always start handlers at headers-complete, buffer request bodies in a C accumulator, and speed up the Cython respond/write path — without gaming the benches.

### Body

- Accumulate into `_acc`; `body()` / `read()` wait on an Event until message complete, then materialize once
- Stall timeout via `call_later` refreshed on progress (not `asyncio.wait_for` per wait)
- `stream(max_chunk)` peels size batches; `max_chunk` must be &lt; high water; pause at watermark
- Read cursor avoids O(n²) peel when headers+body arrive before the consumer
- Next keep-alive/pipelined request starts when the response is sent (`response_completed`), not when the handler returns

### Writer

- Empty-header identity `respond()` uses `transport.writelines` (keeps tiny plaintext/json competitive)
- Known Content-Length `write()` goes straight to the transport; chunked(+compress) still frames/feeds parts
- `respond` / `write` / `end` accept `bytes` or `list`/`tuple` of bytes-like; join only for one-shot compress
- Snapshot `CompressionConfig` onto C fields for hot `_may_compress`

### Hot headers

- At headers-complete, snapshot accept-encoding plus Connection-close / Expect-100-continue flags on the exchange (public `Headers` API unchanged)

### Tests / benches

- Cython protocol + writer coverage for multi-segment body, stream, list/tuple parts, respond-before-handler-return
- Uploads clearly ahead of prior Cython baseline; reads ≈ flat; CPU efficiency up vs Python Stario

## Suggested squash commit message

```
Optimize Cython HTTP/1.1 body and writer path

Always start handlers at headers-complete so proxies can begin before the
upload finishes. Request bytes accumulate in a C `_acc` on the exchange:
body()/read() wait on an Event until the message is complete (stall timer
refreshed on progress, no per-segment wake), then materialize once; stream()
peels max_chunk-sized batches with backpressure (max_chunk < high water).
A read cursor avoids O(n²) peeling when the body arrives before the consumer.
The next keep-alive request starts when the response is sent, not when the
handler coroutine returns.

On the writer path, empty-header identity respond() uses transport.writelines
to keep tiny plaintext/json competitive; known Content-Length write() goes
straight to the transport; respond/write/end accept bytes or list/tuple of
bytes-like (join only for one-shot compression); CompressionConfig is
snapshotted onto C fields for hot may_compress checks.

Cache accept-encoding and Connection/Expect flags on the exchange at
headers-complete (Headers dict API unchanged). Simplify unused slots and
share DEFAULT_BODY_TIMEOUT with the Python body reader.

Co-authored-by: Adam Bobowski <bobowskiadam@gmail.com>
Co-authored-by: Cursor Agent <cursoragent@cursor.com>
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abb1a665-aab6-4b40-8c33-0656179ae27e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abb1a665-aab6-4b40-8c33-0656179ae27e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

