### PR TITLE
Optimize Cython HTTP protocol hot paths

### DIFF
--- a/src/stario/http/app.py
+++ b/src/stario/http/app.py
@@ -147,9 +147,8 @@ class App(Router):
                     help_text="Call app.create_task() from async code while the app is running.",
                 ) from exc
         if eager_start:
-            task = asyncio.Task(
+            task = loop.create_task(
                 coro,
-                loop=loop,
                 name=name,
                 eager_start=True,
             )

--- a/src/stario/http/app.py
+++ b/src/stario/http/app.py
@@ -121,6 +121,7 @@ class App(Router):
         *,
         loop: asyncio.AbstractEventLoop | None = None,
         name: str | None = None,
+        eager_start: bool = False,
     ) -> asyncio.Task[T]:
         """Schedule a coroutine on the running loop and retain the task until it completes.
 
@@ -131,6 +132,7 @@ class App(Router):
         - `coro`: Coroutine to run.
         - `loop`: Optional loop to schedule on when the caller already has it.
         - `name`: Optional task name for debuggers.
+        - `eager_start`: Run immediately until the first suspension.
 
         The new `asyncio.Task`.
 
@@ -144,9 +146,15 @@ class App(Router):
                     "app.create_task() requires a running event loop",
                     help_text="Call app.create_task() from async code while the app is running.",
                 ) from exc
-        task = loop.create_task(coro, name=name)
-        self.tasks.add(task)
-        task.add_done_callback(self.tasks.discard)
+        task = asyncio.Task(
+            coro,
+            loop=loop,
+            name=name,
+            eager_start=eager_start,
+        )
+        if not task.done():
+            self.tasks.add(task)
+            task.add_done_callback(self.tasks.discard)
         return task
 
     async def drain_tasks(self) -> None:

--- a/src/stario/http/app.py
+++ b/src/stario/http/app.py
@@ -146,12 +146,15 @@ class App(Router):
                     "app.create_task() requires a running event loop",
                     help_text="Call app.create_task() from async code while the app is running.",
                 ) from exc
-        task = asyncio.Task(
-            coro,
-            loop=loop,
-            name=name,
-            eager_start=eager_start,
-        )
+        if eager_start:
+            task = asyncio.Task(
+                coro,
+                loop=loop,
+                name=name,
+                eager_start=True,
+            )
+        else:
+            task = loop.create_task(coro, name=name)
         if not task.done():
             self.tasks.add(task)
             task.add_done_callback(self.tasks.discard)

--- a/src/stario_cython/compression_buf.pxd
+++ b/src/stario_cython/compression_buf.pxd
@@ -5,6 +5,7 @@ cdef extern from "compression_buf.h":
         pass
 
     StarioBrotli* stario_brotli_new(int level, int window_log)
+    StarioBrotli* stario_brotli_acquire(int level, int window_log)
     int stario_brotli_block_borrowed(
         StarioBrotli* brotli,
         const unsigned char* data,
@@ -20,11 +21,13 @@ cdef extern from "compression_buf.h":
         size_t* out_len,
     )
     void stario_brotli_free(StarioBrotli* brotli)
+    void stario_brotli_release(StarioBrotli* brotli)
 
     ctypedef struct StarioGzip:
         pass
 
-    StarioGzip* stario_gzip_new(int level)
+    StarioGzip* stario_gzip_new(int level, int window_bits)
+    StarioGzip* stario_gzip_acquire(int level, int window_bits)
     int stario_gzip_block_borrowed(
         StarioGzip* gzip,
         const unsigned char* data,
@@ -40,3 +43,4 @@ cdef extern from "compression_buf.h":
         size_t* out_len,
     )
     void stario_gzip_free(StarioGzip* gzip)
+    void stario_gzip_release(StarioGzip* gzip)

--- a/src/stario_cython/compression_buf.pxd
+++ b/src/stario_cython/compression_buf.pxd
@@ -4,7 +4,6 @@ cdef extern from "compression_buf.h":
     ctypedef struct StarioBrotli:
         pass
 
-    StarioBrotli* stario_brotli_new(int level, int window_log)
     StarioBrotli* stario_brotli_acquire(int level, int window_log)
     int stario_brotli_block_borrowed(
         StarioBrotli* brotli,
@@ -20,13 +19,11 @@ cdef extern from "compression_buf.h":
         const unsigned char** out,
         size_t* out_len,
     )
-    void stario_brotli_free(StarioBrotli* brotli)
     void stario_brotli_release(StarioBrotli* brotli)
 
     ctypedef struct StarioGzip:
         pass
 
-    StarioGzip* stario_gzip_new(int level, int window_bits)
     StarioGzip* stario_gzip_acquire(int level, int window_bits)
     int stario_gzip_block_borrowed(
         StarioGzip* gzip,
@@ -42,5 +39,4 @@ cdef extern from "compression_buf.h":
         const unsigned char** out,
         size_t* out_len,
     )
-    void stario_gzip_free(StarioGzip* gzip)
     void stario_gzip_release(StarioGzip* gzip)

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -6,8 +6,7 @@ cdef class RequestExchange:
     cdef object _transport
     cdef list _date_box
     cdef object _compression
-    cdef object _accept
-    cdef object _req_accept_encoding
+    cdef int _req_encoding
     cdef bint _req_expect_continue
     cdef bint _req_connection_close
     cdef public Headers headers
@@ -19,7 +18,8 @@ cdef class RequestExchange:
     cdef int _status_code
     cdef Py_ssize_t _declared_length
     cdef Py_ssize_t _bytes_written
-    cdef object _available
+    cdef bint _brotli_enabled
+    cdef bint _gzip_enabled
     cdef int _brotli_level
     cdef int _brotli_window
     cdef int _gzip_level
@@ -83,7 +83,7 @@ cdef class RequestExchange:
     cdef int _ensure_body_tail(self, Py_ssize_t received_before) except -1
     cdef int _seal_body_tail(self) except -1
     cdef object _body_to_bytes(self)
-    cdef void reset_response(self, object accept_encoding)
+    cdef void reset_response(self, int encoding)
     cdef void _apply_compression(self, object compression)
     cdef int _buf_add(self, const char* src, Py_ssize_t n) except -1
     cdef int _buf_bytes(self, object data) except -1

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -52,10 +52,10 @@ cdef class RequestExchange:
     cdef bint _body_complete
     cdef bint _expect_continue
     cdef bint _waiting
-    cdef char* _acc
-    cdef Py_ssize_t _acc_len
-    cdef Py_ssize_t _acc_cap
-    cdef Py_ssize_t _acc_pos
+    cdef object _body_tail
+    cdef Py_ssize_t _tail_used
+    cdef Py_ssize_t _tail_cap
+    cdef Py_ssize_t _expected_size
     cdef Py_ssize_t _stream_max_chunk
 
     cdef void reset(
@@ -73,19 +73,16 @@ cdef class RequestExchange:
     cdef void _maybe_recycle(self)
     cdef void park(self)
     cdef void release_global(self)
-    cdef void reset_body(self, bint expect_continue)
+    cdef void reset_body(self, bint expect_continue, Py_ssize_t expected_size)
     cdef void _clear_hot_request_headers(self)
     cdef void cache_hot_request_headers(self)
-    cdef void prepare_body_capacity(self, Py_ssize_t expected_size)
     cdef void c_feed(self, const char* at, size_t length)
     cdef void c_complete(self)
     cdef void c_abort(self)
-    cdef int _acc_add(self, const char* at, size_t length) except -1
-    cdef int _acc_reserve(self, Py_ssize_t need) except -1
-    cdef int _acc_compact(self) except -1
-    cdef Py_ssize_t _acc_unread(self) noexcept
-    cdef object _acc_to_bytes(self)
-    cdef void _emit_from_acc(self, Py_ssize_t n)
+    cdef void _clear_body_storage(self)
+    cdef int _ensure_body_tail(self, Py_ssize_t received_before) except -1
+    cdef int _seal_body_tail(self) except -1
+    cdef object _body_to_bytes(self)
     cdef void reset_response(self, object accept_encoding)
     cdef void _apply_compression(self, object compression)
     cdef int _buf_add(self, const char* src, Py_ssize_t n) except -1
@@ -120,7 +117,6 @@ cdef class RequestExchange:
     cdef void _wake(self)
     cdef void _cancel_stall_timer(self)
     cdef void _reset_stall_timer(self)
-    cdef object _take_chunk(self, int index)
     cdef void _maybe_continue(self)
     cdef void _done(self)
     cdef void _maybe_pause(self)

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -52,6 +52,7 @@ cdef class RequestExchange:
     cdef bint _body_complete
     cdef bint _expect_continue
     cdef bint _waiting
+    cdef bint _discard_body
     cdef object _body_tail
     cdef Py_ssize_t _tail_used
     cdef Py_ssize_t _tail_cap

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -23,6 +23,7 @@ cdef class RequestExchange:
     cdef int _brotli_level
     cdef int _brotli_window
     cdef int _gzip_level
+    cdef int _gzip_window
     cdef Py_ssize_t _compress_min_size
     cdef bint _completed
 

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -76,7 +76,6 @@ cdef class RequestExchange:
     cdef void reset_body(self, bint expect_continue)
     cdef void _clear_hot_request_headers(self)
     cdef void cache_hot_request_headers(self)
-    cdef void prepare_body_capacity(self, Py_ssize_t expected_size)
     cdef void c_feed(self, const char* at, size_t length)
     cdef void c_complete(self)
     cdef void c_abort(self)
@@ -95,7 +94,6 @@ cdef class RequestExchange:
     cdef void _flush(self)
     cdef Py_ssize_t _body_nbytes(self, object body) except -2
     cdef object _body_as_bytes(self, object body)
-    cdef int _write_body_raw(self, object body) except -1
     cdef bint _may_compress(
         self,
         object data,

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -76,6 +76,7 @@ cdef class RequestExchange:
     cdef void reset_body(self, bint expect_continue)
     cdef void _clear_hot_request_headers(self)
     cdef void cache_hot_request_headers(self)
+    cdef void prepare_body_capacity(self, Py_ssize_t expected_size)
     cdef void c_feed(self, const char* at, size_t length)
     cdef void c_complete(self)
     cdef void c_abort(self)

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -473,10 +473,13 @@ cdef class RequestExchange:
     cdef void cache_hot_request_headers(self):
         """Snapshot keep-alive / expect / accept-encoding (Headers API unchanged)."""
         cdef Headers h = self.request_headers
-        self._req_encoding = h.c_select_request_encoding(
-            self._brotli_enabled,
-            self._gzip_enabled,
-        )
+        if self._brotli_enabled or self._gzip_enabled:
+            self._req_encoding = h.c_select_request_encoding(
+                self._brotli_enabled,
+                self._gzip_enabled,
+            )
+        else:
+            self._req_encoding = ENCODING_NONE
         self._req_connection_close = h.c_request_connection_close()
         self._req_expect_continue = h.c_request_expect_continue()
 

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -81,6 +81,7 @@ cdef bytes CL_PREFIX = b"\r\ncontent-length: "
 cdef bytes CRLF2 = b"\r\n\r\n"
 cdef bytes CRLF = b"\r\n"
 cdef bytes CHUNK_END = b"0\r\n\r\n"
+cdef tuple _DEC_SMALL = tuple(str(i).encode("ascii") for i in range(256))
 
 cdef object STARTED_ERROR = (
     "Response already started (headers sent). "
@@ -132,7 +133,10 @@ cdef object _status_line(int status):
 
 cdef object _dec(size_t n):
     cdef char buf[16]
-    cdef int i = sprintf(buf, "%zu", n)
+    cdef int i
+    if n < 256:
+        return _DEC_SMALL[n]
+    i = sprintf(buf, "%zu", n)
     return PyBytes_FromStringAndSize(buf, i)
 
 
@@ -585,8 +589,8 @@ cdef class RequestExchange:
                 self._transport.writelines(
                     (_status_line(status), self._date_box[0], ZERO_CL)
                 )
-            else:
-                flat = [
+            elif isinstance(body, (list, tuple)):
+                self._transport.writelines((
                     _status_line(status),
                     self._date_box[0],
                     CT_PREFIX,
@@ -594,12 +598,19 @@ cdef class RequestExchange:
                     CL_PREFIX,
                     _dec(<size_t>nbytes),
                     CRLF2,
-                ]
-                if isinstance(body, (list, tuple)):
-                    flat.extend(body)
-                else:
-                    flat.append(body)
-                self._transport.writelines(flat)
+                ))
+                self._transport.writelines(body)
+            else:
+                self._transport.writelines((
+                    _status_line(status),
+                    self._date_box[0],
+                    CT_PREFIX,
+                    content_type,
+                    CL_PREFIX,
+                    _dec(<size_t>nbytes),
+                    CRLF2,
+                    body,
+                ))
         else:
             if not _may_have_body(status):
                 body = b""
@@ -641,8 +652,13 @@ cdef class RequestExchange:
                 self._out_buf = bytearray(256)
             h.c_write_wire_ba(self._out_buf, &self._out_len)
             self._buf_bytes(CRLF)
-            self._buf_body(body)
             self._flush()
+            self._status_code = status
+            if nbytes:
+                if isinstance(body, (list, tuple)):
+                    self._transport.writelines(body)
+                else:
+                    self._transport.write(body)
         self._status_code = status
         self._bytes_written = self._declared_length if self._declared_length > 0 else 0
         self._completed = True

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -77,6 +77,7 @@ cdef bytes STATUS_431 = b"HTTP/1.1 431 Request Header Fields Too Large\r\n"
 cdef bytes STATUS_500 = b"HTTP/1.1 500 Internal Server Error\r\n"
 cdef bytes ZERO_CL = b"content-length: 0\r\n\r\n"
 cdef bytes CT_PREFIX = b"content-type: "
+cdef bytes CL_HEADER = b"content-length: "
 cdef bytes CL_PREFIX = b"\r\ncontent-length: "
 cdef bytes CRLF2 = b"\r\n\r\n"
 cdef bytes CRLF = b"\r\n"
@@ -709,7 +710,6 @@ cdef class RequestExchange:
         else:
             if not _may_have_body(status):
                 body = b""
-                h.c_set(b"content-length", b"0")
             elif h.c_get(b"content-encoding") is None:
                 encoding = self._select(body, content_type, False, nbytes)
                 if encoding is not None:
@@ -737,16 +737,19 @@ cdef class RequestExchange:
                     self._completed = True
                     self._done()
                     return
-            h.c_set(b"content-type", content_type)
-            h.c_set(b"content-length", _dec(<size_t>nbytes))
             self._declared_length = nbytes
             self._bytes_written = 0
             self._buf_bytes(_status_line(status))
             self._buf_bytes(self._date_box[0])
             if self._out_buf is None:
                 self._out_buf = bytearray(256)
-            h.c_write_wire_ba(self._out_buf, &self._out_len)
+            h.c_write_response_wire_ba(self._out_buf, &self._out_len)
+            self._buf_bytes(CT_PREFIX)
+            self._buf_bytes(content_type)
             self._buf_bytes(CRLF)
+            self._buf_bytes(CL_HEADER)
+            self._buf_uint(<size_t>nbytes, 10)
+            self._buf_bytes(CRLF2)
             self._flush()
             self._status_code = status
             if nbytes:

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -469,16 +469,9 @@ cdef class RequestExchange:
     cdef void cache_hot_request_headers(self):
         """Snapshot keep-alive / expect / accept-encoding (Headers API unchanged)."""
         cdef Headers h = self.request_headers
-        cdef object v
-        self._req_accept_encoding = h.c_get(b"accept-encoding")
-        v = h.c_get(b"connection")
-        self._req_connection_close = (
-            v is not None and v.lower() == b"close"
-        )
-        v = h.c_get(b"expect")
-        self._req_expect_continue = (
-            v is not None and v.lower() == b"100-continue"
-        )
+        self._req_accept_encoding = h.c_request_accept_encoding()
+        self._req_connection_close = h.c_request_connection_close()
+        self._req_expect_continue = h.c_request_expect_continue()
 
     cdef void start_response(self):
         self.handler_started = True

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -304,23 +304,6 @@ cdef class RequestExchange:
             return 0
         raise TypeError(BODY_TYPE_ERROR)
 
-    cdef int _write_body_raw(self, object body) except -1:
-        """Write body parts directly to the transport (known Content-Length)."""
-        cdef object part
-        if body is None:
-            return 0
-        if _is_bytes_like(body):
-            if len(body):
-                self._transport.write(body)
-            return 0
-        if isinstance(body, (list, tuple)):
-            for part in body:
-                _require_bytes_like(part)
-                if len(part):
-                    self._transport.write(part)
-            return 0
-        raise TypeError(BODY_TYPE_ERROR)
-
     cdef int _buf_uint(self, size_t n, int base) except -1:
         cdef char tmp[16]
         cdef int i
@@ -367,15 +350,11 @@ cdef class RequestExchange:
     ):
         if not self._available or self._accept is None:
             return False
+        if not streaming:
+            if data is None or nbytes < self._compress_min_size:
+                return False
         if content_type is not None and not content_type_is_compressible(content_type):
             return False
-        if not streaming:
-            if data is None:
-                return False
-            if nbytes < 0:
-                nbytes = self._body_nbytes(data)
-            if nbytes < self._compress_min_size:
-                return False
         return True
 
     cdef int _frame(
@@ -768,7 +747,10 @@ cdef class RequestExchange:
             return self
         if self._declared_length >= 0:
             self._bytes_written += n
-            self._write_body_raw(data)
+            if isinstance(data, (list, tuple)):
+                self._transport.writelines(data)
+            else:
+                self._transport.write(data)
             return self
         if self._brotli != NULL or self._gzip != NULL:
             if isinstance(data, (list, tuple)):
@@ -879,11 +861,6 @@ cdef class RequestExchange:
         self._acc_len = 0
         self._acc_pos = 0
         self._stream_max_chunk = DEFAULT_STREAM_CHUNK
-
-    cdef void prepare_body_capacity(self, Py_ssize_t expected_size):
-        """Pre-size the C accumulator for a known Content-Length."""
-        if expected_size > 0:
-            self._acc_reserve(expected_size)
 
     cdef int _acc_compact(self) except -1:
         cdef Py_ssize_t unread
@@ -1086,7 +1063,6 @@ cdef class RequestExchange:
         if self._consumed_as == CONSUMED_BODY:
             if self._cached is None:
                 self._cached = self._acc_to_bytes()
-            self._buffered = 0
         self._wake()
         self._maybe_recycle()
 
@@ -1166,12 +1142,13 @@ cdef class RequestExchange:
             while self._chunks is not None and index < len(self._chunks):
                 index, chunk = self._take_chunk(index)
                 yield chunk
+            if index:
+                self._chunks.clear()
+                index = 0
             if self._body_complete:
                 if self._acc_unread() > 0:
                     self._emit_from_acc(self._acc_unread())
                     continue
-                if self._chunks is not None:
-                    self._chunks.clear()
                 return
             await self._wait_for_body_data()
 
@@ -1208,7 +1185,6 @@ cdef class RequestExchange:
             self._cached = self._acc_to_bytes()
         if max_size is not None and len(self._cached) > max_size:
             raise HttpException(413, "Request body too large")
-        self._buffered = 0
         return self._cached
 
 

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -46,7 +46,6 @@ from stario_cython.request cimport Request
 cdef int LOW_WATER = 64 * 1024
 cdef int HIGH_WATER = 256 * 1024
 cdef int DEFAULT_STREAM_CHUNK = 64 * 1024
-cdef int IDENTITY_COALESCE_MAX = 4 * 1024
 cdef int POOL_MAX = 1024
 
 cdef object BODY_TYPE_ERROR = (
@@ -134,86 +133,6 @@ cdef object _dec(size_t n):
     cdef char buf[16]
     cdef int i = sprintf(buf, "%zu", n)
     return PyBytes_FromStringAndSize(buf, i)
-
-
-cdef inline int _uint_digits(size_t n) noexcept:
-    cdef int digits = 1
-    while n >= 10:
-        n //= 10
-        digits += 1
-    return digits
-
-
-cdef inline int _write_uint(char* dst, size_t n) noexcept:
-    cdef int digits = _uint_digits(n)
-    cdef int i = digits
-    while i:
-        i -= 1
-        dst[i] = <char>(48 + n % 10)
-        n //= 10
-    return digits
-
-
-cdef object _serialize_identity_response(
-    object status,
-    object date,
-    object content_type,
-    object body,
-):
-    cdef Py_ssize_t status_len = len(status)
-    cdef Py_ssize_t date_len = len(date)
-    cdef Py_ssize_t content_type_len = len(content_type)
-    cdef Py_ssize_t body_len = len(body)
-    cdef int length_digits = _uint_digits(<size_t>body_len)
-    cdef Py_ssize_t total = (
-        status_len
-        + date_len
-        + len(CT_PREFIX)
-        + content_type_len
-        + len(CL_PREFIX)
-        + length_digits
-        + len(CRLF2)
-        + body_len
-    )
-    cdef object out
-    cdef char* dst
-    cdef Py_ssize_t pos = 0
-    if total > IDENTITY_COALESCE_MAX:
-        return None
-    out = PyBytes_FromStringAndSize(NULL, total)
-    dst = PyBytes_AS_STRING(out)
-    memcpy(dst + pos, <const char*>status, <size_t>status_len)
-    pos += status_len
-    memcpy(dst + pos, <const char*>date, <size_t>date_len)
-    pos += date_len
-    memcpy(dst + pos, <const char*>CT_PREFIX, <size_t>len(CT_PREFIX))
-    pos += len(CT_PREFIX)
-    memcpy(dst + pos, <const char*>content_type, <size_t>content_type_len)
-    pos += content_type_len
-    memcpy(dst + pos, <const char*>CL_PREFIX, <size_t>len(CL_PREFIX))
-    pos += len(CL_PREFIX)
-    pos += _write_uint(dst + pos, <size_t>body_len)
-    memcpy(dst + pos, <const char*>CRLF2, <size_t>len(CRLF2))
-    pos += len(CRLF2)
-    if body_len:
-        memcpy(dst + pos, <const char*>body, <size_t>body_len)
-    return out
-
-
-cdef object _serialize_empty_response(object status, object date):
-    cdef Py_ssize_t status_len = len(status)
-    cdef Py_ssize_t date_len = len(date)
-    cdef Py_ssize_t total = status_len + date_len + len(ZERO_CL)
-    cdef object out = PyBytes_FromStringAndSize(NULL, total)
-    cdef char* dst = PyBytes_AS_STRING(out)
-    memcpy(dst, <const char*>status, <size_t>status_len)
-    memcpy(dst + status_len, <const char*>date, <size_t>date_len)
-    memcpy(
-        dst + status_len + date_len,
-        <const char*>ZERO_CL,
-        <size_t>len(ZERO_CL),
-    )
-    return out
 
 
 cdef class RequestExchange:
@@ -622,7 +541,6 @@ cdef class RequestExchange:
         cdef Headers h = self.headers
         cdef object encoding
         cdef object flat
-        cdef object serialized
         cdef Py_ssize_t nbytes
         cdef const unsigned char* native_out = NULL
         cdef size_t native_len = 0
@@ -653,32 +571,9 @@ cdef class RequestExchange:
             or not self._may_compress(body, content_type, False, nbytes)
         ):
             if not _may_have_body(status):
-                self._transport.write(
-                    _serialize_empty_response(
-                        _status_line(status),
-                        self._date_box[0],
-                    )
+                self._transport.writelines(
+                    (_status_line(status), self._date_box[0], ZERO_CL)
                 )
-            elif type(body) is bytes and type(content_type) is bytes:
-                serialized = _serialize_identity_response(
-                    _status_line(status),
-                    self._date_box[0],
-                    content_type,
-                    body,
-                )
-                if serialized is not None:
-                    self._transport.write(serialized)
-                else:
-                    self._transport.writelines((
-                        _status_line(status),
-                        self._date_box[0],
-                        CT_PREFIX,
-                        content_type,
-                        CL_PREFIX,
-                        _dec(<size_t>nbytes),
-                        CRLF2,
-                        body,
-                    ))
             else:
                 flat = [
                     _status_line(status),

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -31,13 +31,13 @@ from stario.http.writer import get_status_line
 
 from stario_cython.compression_buf cimport (
     stario_brotli_block_borrowed,
+    stario_brotli_acquire,
     stario_brotli_finish_borrowed,
-    stario_brotli_free,
-    stario_brotli_new,
+    stario_brotli_release,
     stario_gzip_block_borrowed,
+    stario_gzip_acquire,
     stario_gzip_finish_borrowed,
-    stario_gzip_free,
-    stario_gzip_new,
+    stario_gzip_release,
 )
 from stario_cython.headers cimport Headers
 from stario_cython.request cimport Request
@@ -280,6 +280,7 @@ cdef class RequestExchange:
         self._brotli_level = DEFAULT_BROTLI_LEVEL
         self._brotli_window = 0
         self._gzip_level = DEFAULT_GZIP_LEVEL
+        self._gzip_window = 15
         self._brotli_enabled = False
         self._gzip_enabled = False
         self._compress_min_size = DEFAULT_MIN_SIZE
@@ -290,6 +291,8 @@ cdef class RequestExchange:
         window = compression.brotli_window_log
         self._brotli_window = 0 if window is None else window
         self._gzip_level = compression.gzip_level
+        window = compression.gzip_window_bits
+        self._gzip_window = 15 if window is None else window
         self._compress_min_size = compression.min_size
         self._brotli_enabled = self._brotli_level >= 0
         self._gzip_enabled = self._gzip_level >= 0
@@ -297,7 +300,10 @@ cdef class RequestExchange:
     cdef int _ensure_brotli(self) except -1:
         if self._brotli != NULL:
             return 0
-        self._brotli = stario_brotli_new(self._brotli_level, self._brotli_window)
+        self._brotli = stario_brotli_acquire(
+            self._brotli_level,
+            self._brotli_window,
+        )
         if self._brotli == NULL:
             raise StarioError("brotli stream init failed")
         return 0
@@ -305,17 +311,20 @@ cdef class RequestExchange:
     cdef int _ensure_gzip(self) except -1:
         if self._gzip != NULL:
             return 0
-        self._gzip = stario_gzip_new(self._gzip_level)
+        self._gzip = stario_gzip_acquire(
+            self._gzip_level,
+            self._gzip_window,
+        )
         if self._gzip == NULL:
             raise StarioError("gzip stream init failed")
         return 0
 
     cdef void _free_compressors(self):
         if self._brotli != NULL:
-            stario_brotli_free(self._brotli)
+            stario_brotli_release(self._brotli)
             self._brotli = NULL
         if self._gzip != NULL:
-            stario_gzip_free(self._gzip)
+            stario_gzip_release(self._gzip)
             self._gzip = NULL
 
     cdef int _buf_add(self, const char* src, Py_ssize_t n) except -1:

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -47,6 +47,7 @@ from stario_cython.request cimport Request
 cdef int LOW_WATER = 64 * 1024
 cdef int HIGH_WATER = 256 * 1024
 cdef int DEFAULT_STREAM_CHUNK = 64 * 1024
+cdef int IDENTITY_COALESCE_MAX = 4 * 1024
 cdef int POOL_MAX = 1024
 
 cdef object BODY_TYPE_ERROR = (
@@ -130,6 +131,86 @@ cdef object _dec(size_t n):
     cdef char buf[16]
     cdef int i = sprintf(buf, "%zu", n)
     return PyBytes_FromStringAndSize(buf, i)
+
+
+cdef inline int _uint_digits(size_t n) noexcept:
+    cdef int digits = 1
+    while n >= 10:
+        n //= 10
+        digits += 1
+    return digits
+
+
+cdef inline int _write_uint(char* dst, size_t n) noexcept:
+    cdef int digits = _uint_digits(n)
+    cdef int i = digits
+    while i:
+        i -= 1
+        dst[i] = <char>(48 + n % 10)
+        n //= 10
+    return digits
+
+
+cdef object _serialize_identity_response(
+    object status,
+    object date,
+    object content_type,
+    object body,
+):
+    cdef Py_ssize_t status_len = len(status)
+    cdef Py_ssize_t date_len = len(date)
+    cdef Py_ssize_t content_type_len = len(content_type)
+    cdef Py_ssize_t body_len = len(body)
+    cdef int length_digits = _uint_digits(<size_t>body_len)
+    cdef Py_ssize_t total = (
+        status_len
+        + date_len
+        + len(CT_PREFIX)
+        + content_type_len
+        + len(CL_PREFIX)
+        + length_digits
+        + len(CRLF2)
+        + body_len
+    )
+    cdef object out
+    cdef char* dst
+    cdef Py_ssize_t pos = 0
+    if total > IDENTITY_COALESCE_MAX:
+        return None
+    out = PyBytes_FromStringAndSize(NULL, total)
+    dst = PyBytes_AS_STRING(out)
+    memcpy(dst + pos, <const char*>status, <size_t>status_len)
+    pos += status_len
+    memcpy(dst + pos, <const char*>date, <size_t>date_len)
+    pos += date_len
+    memcpy(dst + pos, <const char*>CT_PREFIX, <size_t>len(CT_PREFIX))
+    pos += len(CT_PREFIX)
+    memcpy(dst + pos, <const char*>content_type, <size_t>content_type_len)
+    pos += content_type_len
+    memcpy(dst + pos, <const char*>CL_PREFIX, <size_t>len(CL_PREFIX))
+    pos += len(CL_PREFIX)
+    pos += _write_uint(dst + pos, <size_t>body_len)
+    memcpy(dst + pos, <const char*>CRLF2, <size_t>len(CRLF2))
+    pos += len(CRLF2)
+    if body_len:
+        memcpy(dst + pos, <const char*>body, <size_t>body_len)
+    return out
+
+
+cdef object _serialize_empty_response(object status, object date):
+    cdef Py_ssize_t status_len = len(status)
+    cdef Py_ssize_t date_len = len(date)
+    cdef Py_ssize_t total = status_len + date_len + len(ZERO_CL)
+    cdef object out = PyBytes_FromStringAndSize(NULL, total)
+    cdef char* dst = PyBytes_AS_STRING(out)
+    memcpy(dst, <const char*>status, <size_t>status_len)
+    memcpy(dst + status_len, <const char*>date, <size_t>date_len)
+    memcpy(
+        dst + status_len + date_len,
+        <const char*>ZERO_CL,
+        <size_t>len(ZERO_CL),
+    )
+    return out
 
 
 cdef class RequestExchange:
@@ -535,6 +616,7 @@ cdef class RequestExchange:
         cdef Headers h = self.headers
         cdef object encoding
         cdef object flat
+        cdef object serialized
         cdef Py_ssize_t nbytes
         cdef const unsigned char* native_out = NULL
         cdef size_t native_len = 0
@@ -565,9 +647,32 @@ cdef class RequestExchange:
             or not self._may_compress(body, content_type, False, nbytes)
         ):
             if not _may_have_body(status):
-                self._transport.writelines(
-                    (_status_line(status), self._date_box[0], ZERO_CL)
+                self._transport.write(
+                    _serialize_empty_response(
+                        _status_line(status),
+                        self._date_box[0],
+                    )
                 )
+            elif type(body) is bytes and type(content_type) is bytes:
+                serialized = _serialize_identity_response(
+                    _status_line(status),
+                    self._date_box[0],
+                    content_type,
+                    body,
+                )
+                if serialized is not None:
+                    self._transport.write(serialized)
+                else:
+                    self._transport.writelines((
+                        _status_line(status),
+                        self._date_box[0],
+                        CT_PREFIX,
+                        content_type,
+                        CL_PREFIX,
+                        _dec(<size_t>nbytes),
+                        CRLF2,
+                        body,
+                    ))
             else:
                 flat = [
                     _status_line(status),

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -865,7 +865,13 @@ cdef class RequestExchange:
         if self._body_tail is not None:
             return 0
         cap = self._stream_max_chunk
-        if self._consumed_as != CONSUMED_STREAM:
+        if (
+            self._consumed_as == CONSUMED_BODY
+            and self._expected_size > 0
+            and received_before == 0
+        ):
+            cap = self._expected_size
+        elif self._consumed_as != CONSUMED_STREAM:
             cap = DEFAULT_STREAM_CHUNK
         if self._expected_size >= 0:
             remaining = self._expected_size - received_before

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -862,6 +862,14 @@ cdef class RequestExchange:
         self._acc_pos = 0
         self._stream_max_chunk = DEFAULT_STREAM_CHUNK
 
+    cdef void prepare_body_capacity(self, Py_ssize_t expected_size):
+        # Preserve the small-body fast path without reserving an entire upload
+        # before the handler chooses body() or stream().
+        if expected_size > DEFAULT_STREAM_CHUNK:
+            expected_size = DEFAULT_STREAM_CHUNK
+        if expected_size > 0:
+            self._acc_reserve(expected_size)
+
     cdef int _acc_compact(self) except -1:
         cdef Py_ssize_t unread
         if self._acc_pos == 0:

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -42,10 +42,11 @@ from stario_cython.compression_buf cimport (
 from stario_cython.headers cimport Headers
 from stario_cython.request cimport Request
 
-# Stream backpressure window. max_chunk must be strictly below HIGH_WATER.
+# Stream batching limit and independent transport backpressure window.
 cdef int LOW_WATER = 128 * 1024
 cdef int HIGH_WATER = 512 * 1024
-cdef int MAX_STREAM_CHUNK = 256 * 1024
+cdef int STREAM_CHUNK_LIMIT = 256 * 1024
+cdef int OUTPUT_BUFFER_RETAIN_MAX = 64 * 1024
 cdef int DEFAULT_STREAM_CHUNK = 64 * 1024
 cdef int POOL_MAX = 1024
 
@@ -628,6 +629,16 @@ cdef class RequestExchange:
         self._read_max_size = -1
         self._clear_hot_request_headers()
         self._stream_max_chunk = DEFAULT_STREAM_CHUNK
+        if (
+            self._out_buf is not None
+            and PyByteArray_GET_SIZE(self._out_buf) > OUTPUT_BUFFER_RETAIN_MAX
+        ):
+            self._out_buf = None
+        if (
+            self._out_hold is not None
+            and PyByteArray_GET_SIZE(self._out_hold) > OUTPUT_BUFFER_RETAIN_MAX
+        ):
+            self._out_hold = None
 
     cdef void release_global(self):
         self._free_compressors()
@@ -1250,10 +1261,10 @@ cdef class RequestExchange:
             chunk_size = <Py_ssize_t>max_chunk
             if chunk_size <= 0:
                 raise ValueError("max_chunk must be positive")
-            if chunk_size >= MAX_STREAM_CHUNK:
+            if chunk_size >= STREAM_CHUNK_LIMIT:
                 raise ValueError(
                     f"max_chunk ({chunk_size}) must be lower than "
-                    f"high water mark ({MAX_STREAM_CHUNK})"
+                    f"stream chunk limit ({STREAM_CHUNK_LIMIT})"
                 )
         self._stream_max_chunk = chunk_size
         self._consumed_as = CONSUMED_STREAM

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -103,6 +103,92 @@ cdef inline void _require_bytes_like(object part):
         )
 
 
+cdef inline bint _range_equals_ci(
+    const char* value,
+    Py_ssize_t length,
+    const char* expected,
+    Py_ssize_t expected_length,
+) noexcept:
+    cdef Py_ssize_t i
+    cdef unsigned char c
+    if length != expected_length:
+        return False
+    for i in range(length):
+        c = <unsigned char>value[i]
+        if 65 <= c <= 90:
+            c += 32
+        if c != <unsigned char>expected[i]:
+            return False
+    return True
+
+
+cdef inline bint _range_starts_ci(
+    const char* value,
+    Py_ssize_t length,
+    const char* prefix,
+    Py_ssize_t prefix_length,
+) noexcept:
+    if length < prefix_length:
+        return False
+    return _range_equals_ci(value, prefix_length, prefix, prefix_length)
+
+
+cdef bint _content_type_is_compressible(object content_type):
+    cdef bytes raw
+    cdef const char* value
+    cdef Py_ssize_t start
+    cdef Py_ssize_t end
+    cdef Py_ssize_t i
+    if type(content_type) is not bytes:
+        return content_type_is_compressible(content_type)
+    raw = content_type
+    value = raw
+    end = len(raw)
+    for i in range(end):
+        if value[i] == <char>59:
+            end = i
+            break
+    start = 0
+    while start < end and (
+        value[start] == <char>32
+        or 9 <= <unsigned char>value[start] <= 13
+    ):
+        start += 1
+    while end > start and (
+        value[end - 1] == <char>32
+        or 9 <= <unsigned char>value[end - 1] <= 13
+    ):
+        end -= 1
+    value += start
+    end -= start
+    if end == 0:
+        return False
+    if (
+        _range_starts_ci(value, end, "image/", 6)
+        or _range_starts_ci(value, end, "audio/", 6)
+        or _range_starts_ci(value, end, "video/", 6)
+    ):
+        return False
+    if (
+        _range_equals_ci(value, end, "application/gzip", 16)
+        or _range_equals_ci(value, end, "application/x-gzip", 18)
+        or _range_equals_ci(value, end, "application/zip", 15)
+        or _range_equals_ci(value, end, "application/x-zip-compressed", 28)
+        or _range_equals_ci(value, end, "application/x-7z-compressed", 27)
+        or _range_equals_ci(value, end, "application/vnd.rar", 19)
+        or _range_equals_ci(value, end, "application/x-rar-compressed", 28)
+        or _range_equals_ci(value, end, "application/x-bzip", 18)
+        or _range_equals_ci(value, end, "application/x-bzip2", 19)
+        or _range_equals_ci(value, end, "application/x-xz", 16)
+        or _range_equals_ci(value, end, "application/zstd", 16)
+        or _range_equals_ci(value, end, "application/x-zstd", 18)
+        or _range_equals_ci(value, end, "font/woff", 9)
+        or _range_equals_ci(value, end, "font/woff2", 10)
+    ):
+        return False
+    return True
+
+
 cdef inline bint _may_have_body(int status) noexcept:
     if status == 204 or status == 304:
         return False
@@ -357,7 +443,7 @@ cdef class RequestExchange:
         if not streaming:
             if data is None or nbytes < self._compress_min_size:
                 return False
-        if content_type is not None and not content_type_is_compressible(content_type):
+        if content_type is not None and not _content_type_is_compressible(content_type):
             return False
         return True
 

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -24,7 +24,6 @@ from stario.http.compression import (
     DEFAULT_GZIP_LEVEL,
     DEFAULT_MIN_SIZE,
     content_type_is_compressible,
-    negotiate_content_encoding,
 )
 from stario.http.context import EMPTY_ROUTE_MATCH, _Alive
 from stario.http.request import DEFAULT_BODY_TIMEOUT
@@ -57,6 +56,10 @@ cdef object BODY_TYPE_ERROR = (
 cdef int CONSUMED_NONE = 0
 cdef int CONSUMED_BODY = 1
 cdef int CONSUMED_STREAM = 2
+
+cdef int ENCODING_NONE = 0
+cdef int ENCODING_BR = 1
+cdef int ENCODING_GZIP = 2
 
 cdef int ABORT_NONE = 0
 cdef int ABORT_TOO_LARGE = 1
@@ -239,7 +242,8 @@ cdef class RequestExchange:
         self._data_ready = None
         self._stall_handle = None
         self._compression = _UNBOUND
-        self._available = ()
+        self._brotli_enabled = False
+        self._gzip_enabled = False
         self._compress_min_size = DEFAULT_MIN_SIZE
         self._state = None
         self.in_pool = False
@@ -250,9 +254,9 @@ cdef class RequestExchange:
     def __dealloc__(self):
         self._free_compressors()
 
-    cdef void reset_response(self, object accept_encoding):
+    cdef void reset_response(self, int encoding):
         self._free_compressors()
-        self._accept = accept_encoding
+        self._req_encoding = encoding
         self._status_code = -1
         self._declared_length = -1
         self._bytes_written = 0
@@ -265,7 +269,8 @@ cdef class RequestExchange:
         self._brotli_level = DEFAULT_BROTLI_LEVEL
         self._brotli_window = 0
         self._gzip_level = DEFAULT_GZIP_LEVEL
-        self._available = ()
+        self._brotli_enabled = False
+        self._gzip_enabled = False
         self._compress_min_size = DEFAULT_MIN_SIZE
         if compression is None:
             return
@@ -275,11 +280,8 @@ cdef class RequestExchange:
         self._brotli_window = 0 if window is None else window
         self._gzip_level = compression.gzip_level
         self._compress_min_size = compression.min_size
-        self._available = tuple(
-            enc
-            for enc in compression.enabled_encodings()
-            if enc == b"br" or enc == b"gzip"
-        )
+        self._brotli_enabled = self._brotli_level >= 0
+        self._gzip_enabled = self._gzip_level >= 0
 
     cdef int _ensure_brotli(self) except -1:
         if self._brotli != NULL:
@@ -425,7 +427,7 @@ cdef class RequestExchange:
         bint streaming,
         Py_ssize_t nbytes,
     ):
-        if not self._available or self._accept is None:
+        if self._req_encoding == ENCODING_NONE:
             return False
         if not streaming:
             if data is None or nbytes < self._compress_min_size:
@@ -512,7 +514,9 @@ cdef class RequestExchange:
     ):
         if not self._may_compress(data, content_type, streaming, nbytes):
             return None
-        return negotiate_content_encoding(self._accept, self._available)
+        if self._req_encoding == ENCODING_BR:
+            return b"br"
+        return b"gzip"
 
     cdef void reset(
         self,
@@ -543,20 +547,23 @@ cdef class RequestExchange:
         self.handler_started = False
 
     cdef void _clear_hot_request_headers(self):
-        self._req_accept_encoding = None
+        self._req_encoding = ENCODING_NONE
         self._req_expect_continue = False
         self._req_connection_close = False
 
     cdef void cache_hot_request_headers(self):
         """Snapshot keep-alive / expect / accept-encoding (Headers API unchanged)."""
         cdef Headers h = self.request_headers
-        self._req_accept_encoding = h.c_request_accept_encoding()
+        self._req_encoding = h.c_select_request_encoding(
+            self._brotli_enabled,
+            self._gzip_enabled,
+        )
         self._req_connection_close = h.c_request_connection_close()
         self._req_expect_continue = h.c_request_expect_continue()
 
     cdef void start_response(self):
         self.handler_started = True
-        self.reset_response(self._req_accept_encoding)
+        self.reset_response(self._req_encoding)
 
     cdef void handler_finished(self):
         self.handler_done = True
@@ -600,7 +607,6 @@ cdef class RequestExchange:
         self.span = None
         self.route = EMPTY_ROUTE_MATCH
         self._state = None
-        self._accept = None
         self._clear_hot_request_headers()
         self.app = None
         self._connection = None

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -1048,6 +1048,7 @@ cdef class RequestExchange:
             return
         self._abort_reason = ABORT_TIMEOUT
         self._clear_body_storage()
+        self._connection.set_body_paused(self, False)
         self._wake()
 
     cdef void _maybe_continue(self):
@@ -1057,13 +1058,10 @@ cdef class RequestExchange:
                 self._transport.write(b"HTTP/1.1 100 Continue\r\n\r\n")
 
     cdef void _maybe_pause(self):
-        cdef object transport
         if self._consumed_as != CONSUMED_STREAM:
             return
         if self._buffered + self._tail_used > HIGH_WATER:
-            transport = self._transport
-            if transport is not None and not transport.is_closing():
-                transport.pause_reading()
+            self._connection.set_body_paused(self, True)
 
     cdef void c_feed(self, const char* at, size_t length):
         cdef Py_ssize_t new_total
@@ -1078,6 +1076,7 @@ cdef class RequestExchange:
             self._abort_reason = ABORT_TOO_LARGE
             self._cancel_stall_timer()
             self._clear_body_storage()
+            self._connection.set_body_paused(self, False)
             self._wake()
             return
         if (
@@ -1087,6 +1086,7 @@ cdef class RequestExchange:
             self._abort_reason = ABORT_TOO_LARGE
             self._cancel_stall_timer()
             self._clear_body_storage()
+            self._connection.set_body_paused(self, False)
             self._wake()
             return
         emitted = False
@@ -1148,6 +1148,8 @@ cdef class RequestExchange:
         self._body_complete = True
         self._cancel_stall_timer()
         self._clear_body_storage()
+        if self._connection is not None:
+            self._connection.set_body_paused(self, False)
         self._wake()
         self._maybe_recycle()
 
@@ -1181,7 +1183,6 @@ cdef class RequestExchange:
         cdef Py_ssize_t offset
         cdef Py_ssize_t remaining
         cdef Py_ssize_t consumed
-        cdef object transport
         if self._abort_reason != ABORT_NONE:
             self._raise_abort()
         if self._consumed_as == CONSUMED_BODY:
@@ -1229,9 +1230,7 @@ cdef class RequestExchange:
                     offset += chunk_size
                 self._buffered -= consumed
                 if self._buffered < LOW_WATER:
-                    transport = self._transport
-                    if transport is not None and not transport.is_closing():
-                        transport.resume_reading()
+                    self._connection.set_body_paused(self, False)
                 yield out
             if index:
                 self._chunks.clear()

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -5,14 +5,13 @@ import asyncio
 
 from libc.stddef cimport size_t
 from libc.stdio cimport sprintf
-from libc.stdlib cimport free, realloc
-from libc.string cimport memcpy, memmove
+from libc.string cimport memcpy
 from cpython.bytearray cimport (
     PyByteArray_AS_STRING,
     PyByteArray_GET_SIZE,
     PyByteArray_Resize,
 )
-from cpython.bytes cimport PyBytes_FromStringAndSize
+from cpython.bytes cimport PyBytes_AS_STRING, PyBytes_FromStringAndSize
 
 from stario.exceptions import (
     ClientDisconnected,
@@ -145,10 +144,10 @@ cdef class RequestExchange:
         self._bytes_written = 0
         self._completed = False
         self._date_box = None
-        self._acc = NULL
-        self._acc_len = 0
-        self._acc_cap = 0
-        self._acc_pos = 0
+        self._body_tail = None
+        self._tail_used = 0
+        self._tail_cap = 0
+        self._expected_size = -1
 
     def __init__(self):
         self.headers = Headers()
@@ -169,9 +168,6 @@ cdef class RequestExchange:
 
     def __dealloc__(self):
         self._free_compressors()
-        if self._acc != NULL:
-            free(self._acc)
-            self._acc = NULL
 
     cdef void reset_response(self, object accept_encoding):
         self._free_compressors()
@@ -516,14 +512,11 @@ cdef class RequestExchange:
         self._cached = None
         self._data_ready = None
         self._cancel_stall_timer()
-        self._acc_len = 0
-        self._acc_pos = 0
+        self._clear_body_storage()
         self._body_active = False
         self._read_max_size = -1
         self._clear_hot_request_headers()
         self._stream_max_chunk = DEFAULT_STREAM_CHUNK
-        if self._chunks is not None:
-            self._chunks.clear()
 
     cdef void release_global(self):
         self._free_compressors()
@@ -843,108 +836,79 @@ cdef class RequestExchange:
     def alive(self, source=None):
         return _Alive(self, source)
 
-    cdef void reset_body(self, bint expect_continue):
+    cdef void reset_body(self, bint expect_continue, Py_ssize_t expected_size):
         self._body_active = True
-        if self._chunks is not None:
-            self._chunks.clear()
+        self._clear_body_storage()
         self._cached = None
         self._data_ready = None
         self._cancel_stall_timer()
         self._expect_continue = expect_continue
-        self._buffered = 0
         self._total_read = 0
         self._read_max_size = -1
         self._consumed_as = CONSUMED_NONE
         self._abort_reason = ABORT_NONE
         self._body_complete = False
         self._waiting = False
-        self._acc_len = 0
-        self._acc_pos = 0
+        self._expected_size = expected_size
         self._stream_max_chunk = DEFAULT_STREAM_CHUNK
 
-    cdef void prepare_body_capacity(self, Py_ssize_t expected_size):
-        # Preserve the small-body fast path without reserving an entire upload
-        # before the handler chooses body() or stream().
-        if expected_size > DEFAULT_STREAM_CHUNK:
-            expected_size = DEFAULT_STREAM_CHUNK
-        if expected_size > 0:
-            self._acc_reserve(expected_size)
+    cdef void _clear_body_storage(self):
+        if self._chunks is not None:
+            self._chunks.clear()
+        self._body_tail = None
+        self._tail_used = 0
+        self._tail_cap = 0
+        self._buffered = 0
 
-    cdef int _acc_compact(self) except -1:
-        cdef Py_ssize_t unread
-        if self._acc_pos == 0:
+    cdef int _ensure_body_tail(self, Py_ssize_t received_before) except -1:
+        cdef Py_ssize_t cap
+        cdef Py_ssize_t remaining
+        if self._body_tail is not None:
             return 0
-        unread = self._acc_len - self._acc_pos
-        if unread == 0:
-            self._acc_pos = 0
-            self._acc_len = 0
-            return 0
-        memmove(self._acc, self._acc + self._acc_pos, <size_t>unread)
-        self._acc_len = unread
-        self._acc_pos = 0
+        cap = self._stream_max_chunk
+        if self._consumed_as != CONSUMED_STREAM:
+            cap = DEFAULT_STREAM_CHUNK
+        if self._expected_size >= 0:
+            remaining = self._expected_size - received_before
+            if 0 < remaining < cap:
+                cap = remaining
+        self._body_tail = PyBytes_FromStringAndSize(NULL, cap)
+        self._tail_used = 0
+        self._tail_cap = cap
         return 0
 
-    cdef int _acc_reserve(self, Py_ssize_t need) except -1:
-        cdef Py_ssize_t next_cap
-        cdef char* p
-        if need <= self._acc_cap:
-            return 0
-        next_cap = 64 if self._acc_cap == 0 else self._acc_cap * 2
-        if next_cap < need:
-            next_cap = need
-        p = <char*>realloc(self._acc, <size_t>next_cap)
-        if p == NULL:
-            raise MemoryError()
-        self._acc = p
-        self._acc_cap = next_cap
-        return 0
-
-    cdef int _acc_add(self, const char* at, size_t length) except -1:
-        cdef Py_ssize_t need
-        if (
-            self._acc_pos > 0
-            and self._acc_len + <Py_ssize_t>length > self._acc_cap
-        ):
-            self._acc_compact()
-        need = self._acc_len + <Py_ssize_t>length
-        self._acc_reserve(need)
-        memcpy(self._acc + self._acc_len, at, length)
-        self._acc_len = need
-        return 0
-
-    cdef object _acc_to_bytes(self):
-        cdef object out
-        cdef Py_ssize_t unread = self._acc_len - self._acc_pos
-        if unread <= 0:
-            self._acc_pos = 0
-            self._acc_len = 0
-            return b""
-        out = PyBytes_FromStringAndSize(self._acc + self._acc_pos, unread)
-        self._acc_pos = 0
-        self._acc_len = 0
-        return out
-
-    cdef void _emit_from_acc(self, Py_ssize_t n):
-        """Peel ``n`` unread bytes from ``_acc`` into the stream chunk list."""
-        cdef Py_ssize_t unread
+    cdef int _seal_body_tail(self) except -1:
         cdef object chunk
-        unread = self._acc_len - self._acc_pos
-        if n <= 0 or unread <= 0:
-            return
-        if n > unread:
-            n = unread
+        if self._body_tail is None or self._tail_used == 0:
+            return 0
+        if self._tail_used == self._tail_cap:
+            chunk = self._body_tail
+        else:
+            chunk = PyBytes_FromStringAndSize(
+                PyBytes_AS_STRING(self._body_tail),
+                self._tail_used,
+            )
         if self._chunks is None:
             self._chunks = []
-        chunk = PyBytes_FromStringAndSize(self._acc + self._acc_pos, n)
         self._chunks.append(chunk)
-        self._buffered += n
-        self._acc_pos += n
-        if self._acc_pos >= self._acc_len:
-            self._acc_pos = 0
-            self._acc_len = 0
+        self._buffered += self._tail_used
+        self._body_tail = None
+        self._tail_used = 0
+        self._tail_cap = 0
+        return 0
 
-    cdef Py_ssize_t _acc_unread(self) noexcept:
-        return self._acc_len - self._acc_pos
+    cdef object _body_to_bytes(self):
+        cdef object out
+        self._seal_body_tail()
+        if self._chunks is None or not self._chunks:
+            return b""
+        if len(self._chunks) == 1:
+            out = self._chunks[0]
+        else:
+            out = b"".join(self._chunks)
+        self._chunks.clear()
+        self._buffered = 0
+        return out
 
     cdef void _raise_abort(self):
         if self._abort_reason == ABORT_TOO_LARGE:
@@ -985,19 +949,8 @@ cdef class RequestExchange:
         if self._abort_reason != ABORT_NONE or self._body_complete:
             return
         self._abort_reason = ABORT_TIMEOUT
-        if self._chunks is not None:
-            self._chunks.clear()
+        self._clear_body_storage()
         self._wake()
-
-    cdef object _take_chunk(self, int index):
-        cdef object chunk = self._chunks[index]
-        cdef object transport
-        self._buffered -= len(chunk)
-        if self._buffered < LOW_WATER:
-            transport = self._transport
-            if transport is not None and not transport.is_closing():
-                transport.resume_reading()
-        return index + 1, chunk
 
     cdef void _maybe_continue(self):
         if self._expect_continue:
@@ -1007,40 +960,57 @@ cdef class RequestExchange:
 
     cdef void _maybe_pause(self):
         cdef object transport
-        # Pause only for stream consumers; body() keeps one contiguous _acc.
         if self._consumed_as != CONSUMED_STREAM:
             return
-        if self._buffered + self._acc_unread() > HIGH_WATER:
+        if self._buffered + self._tail_used > HIGH_WATER:
             transport = self._transport
             if transport is not None and not transport.is_closing():
                 transport.pause_reading()
 
     cdef void c_feed(self, const char* at, size_t length):
-        cdef Py_ssize_t max_chunk
+        cdef Py_ssize_t new_total
+        cdef Py_ssize_t offset
+        cdef Py_ssize_t available
+        cdef Py_ssize_t take
         cdef bint emitted
         if not self._body_active:
-            self.reset_body(False)
-        self._total_read += <int>length
-        if self._total_read > self._max_size:
+            self.reset_body(False, -1)
+        new_total = self._total_read + <Py_ssize_t>length
+        if new_total > self._max_size:
             self._abort_reason = ABORT_TOO_LARGE
             self._cancel_stall_timer()
+            self._clear_body_storage()
             self._wake()
             return
-        self._acc_add(at, length)
         if (
             self._read_max_size >= 0
-            and self._acc_unread() > self._read_max_size
+            and new_total > self._read_max_size
         ):
             self._abort_reason = ABORT_TOO_LARGE
             self._cancel_stall_timer()
+            self._clear_body_storage()
             self._wake()
             return
-        if self._consumed_as == CONSUMED_STREAM:
-            max_chunk = self._stream_max_chunk
-            emitted = False
-            while self._acc_unread() >= max_chunk:
-                self._emit_from_acc(max_chunk)
+        emitted = False
+        offset = 0
+        while offset < <Py_ssize_t>length:
+            self._ensure_body_tail(self._total_read + offset)
+            available = self._tail_cap - self._tail_used
+            take = <Py_ssize_t>length - offset
+            if take > available:
+                take = available
+            memcpy(
+                PyBytes_AS_STRING(self._body_tail) + self._tail_used,
+                at + offset,
+                <size_t>take,
+            )
+            self._tail_used += take
+            offset += take
+            if self._tail_used == self._tail_cap:
+                self._seal_body_tail()
                 emitted = True
+        self._total_read = new_total
+        if self._consumed_as == CONSUMED_STREAM:
             if emitted:
                 self._wake()
             if self._waiting:
@@ -1056,21 +1026,19 @@ cdef class RequestExchange:
             return
         self._body_complete = True
         self._cancel_stall_timer()
+        self._seal_body_tail()
         if self._consumed_as == CONSUMED_STREAM:
-            if self._acc_unread() > 0:
-                self._emit_from_acc(self._acc_unread())
             self._wake()
             self._maybe_recycle()
             return
         if self._abort_reason != ABORT_NONE:
-            self._acc_pos = 0
-            self._acc_len = 0
+            self._clear_body_storage()
             self._wake()
             self._maybe_recycle()
             return
         if self._consumed_as == CONSUMED_BODY:
             if self._cached is None:
-                self._cached = self._acc_to_bytes()
+                self._cached = self._body_to_bytes()
         self._wake()
         self._maybe_recycle()
 
@@ -1081,17 +1049,16 @@ cdef class RequestExchange:
         self._abort_reason = ABORT_DISCONNECTED
         self._body_complete = True
         self._cancel_stall_timer()
+        self._clear_body_storage()
         self._wake()
         self._maybe_recycle()
 
     async def _wait_for_body_data(self):
         if self._abort_reason != ABORT_NONE:
-            if self._chunks is not None:
-                self._chunks.clear()
+            self._clear_body_storage()
             self._raise_abort()
         if self.disconnected:
-            if self._chunks is not None:
-                self._chunks.clear()
+            self._clear_body_storage()
             self._abort_reason = ABORT_DISCONNECTED
             self._raise_abort()
         if self._data_ready is None:
@@ -1105,14 +1072,18 @@ cdef class RequestExchange:
             self._cancel_stall_timer()
         self._data_ready.clear()
         if self._abort_reason != ABORT_NONE:
-            if self._chunks is not None:
-                self._chunks.clear()
+            self._clear_body_storage()
             self._raise_abort()
 
     async def stream(self, max_chunk=None):
         cdef int index
         cdef object chunk
+        cdef object out
         cdef Py_ssize_t chunk_size
+        cdef Py_ssize_t offset
+        cdef Py_ssize_t remaining
+        cdef Py_ssize_t consumed
+        cdef object transport
         if self._abort_reason != ABORT_NONE:
             self._raise_abort()
         if self._consumed_as == CONSUMED_BODY:
@@ -1143,20 +1114,31 @@ cdef class RequestExchange:
             yield self._cached
             return
         self._maybe_continue()
-        while self._acc_unread() >= chunk_size:
-            self._emit_from_acc(chunk_size)
         index = 0
+        offset = 0
         while True:
             while self._chunks is not None and index < len(self._chunks):
-                index, chunk = self._take_chunk(index)
-                yield chunk
+                chunk = self._chunks[index]
+                remaining = len(chunk) - offset
+                if remaining <= chunk_size:
+                    out = chunk if offset == 0 else chunk[offset:]
+                    consumed = remaining
+                    index += 1
+                    offset = 0
+                else:
+                    out = chunk[offset : offset + chunk_size]
+                    consumed = chunk_size
+                    offset += chunk_size
+                self._buffered -= consumed
+                if self._buffered < LOW_WATER:
+                    transport = self._transport
+                    if transport is not None and not transport.is_closing():
+                        transport.resume_reading()
+                yield out
             if index:
                 self._chunks.clear()
                 index = 0
             if self._body_complete:
-                if self._acc_unread() > 0:
-                    self._emit_from_acc(self._acc_unread())
-                    continue
                 return
             await self._wait_for_body_data()
 
@@ -1183,14 +1165,14 @@ cdef class RequestExchange:
                 self._raise_abort()
             if (
                 self._read_max_size >= 0
-                and self._acc_unread() > self._read_max_size
+                and self._total_read > self._read_max_size
             ):
                 raise HttpException(413, "Request body too large")
             await self._wait_for_body_data()
         if self._abort_reason != ABORT_NONE:
             self._raise_abort()
         if self._cached is None:
-            self._cached = self._acc_to_bytes()
+            self._cached = self._body_to_bytes()
         if max_size is not None and len(self._cached) > max_size:
             raise HttpException(413, "Request body too large")
         return self._cached

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -43,8 +43,9 @@ from stario_cython.headers cimport Headers
 from stario_cython.request cimport Request
 
 # Stream backpressure window. max_chunk must be strictly below HIGH_WATER.
-cdef int LOW_WATER = 64 * 1024
-cdef int HIGH_WATER = 256 * 1024
+cdef int LOW_WATER = 128 * 1024
+cdef int HIGH_WATER = 512 * 1024
+cdef int MAX_STREAM_CHUNK = 256 * 1024
 cdef int DEFAULT_STREAM_CHUNK = 64 * 1024
 cdef int POOL_MAX = 1024
 
@@ -1112,10 +1113,10 @@ cdef class RequestExchange:
             chunk_size = <Py_ssize_t>max_chunk
             if chunk_size <= 0:
                 raise ValueError("max_chunk must be positive")
-            if chunk_size >= HIGH_WATER:
+            if chunk_size >= MAX_STREAM_CHUNK:
                 raise ValueError(
                     f"max_chunk ({chunk_size}) must be lower than "
-                    f"high water mark ({HIGH_WATER})"
+                    f"high water mark ({MAX_STREAM_CHUNK})"
                 )
         self._stream_max_chunk = chunk_size
         self._consumed_as = CONSUMED_STREAM

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -168,6 +168,7 @@ cdef class RequestExchange:
         self._state = None
         self.in_pool = False
         self._body_active = False
+        self._discard_body = False
         self._read_max_size = -1
         self._stream_max_chunk = DEFAULT_STREAM_CHUNK
 
@@ -490,6 +491,12 @@ cdef class RequestExchange:
 
     cdef void handler_finished(self):
         self.handler_done = True
+        if self._body_active and not self._body_complete:
+            self._discard_body = True
+            self._cached = None
+            self._clear_body_storage()
+            self._cancel_stall_timer()
+            self._connection.set_body_paused(self, False)
         self._maybe_recycle()
 
     cdef void cancel_before_start(self):
@@ -852,6 +859,7 @@ cdef class RequestExchange:
         self._abort_reason = ABORT_NONE
         self._body_complete = False
         self._waiting = False
+        self._discard_body = False
         self._expected_size = expected_size
         self._stream_max_chunk = DEFAULT_STREAM_CHUNK
 
@@ -989,6 +997,8 @@ cdef class RequestExchange:
             self._clear_body_storage()
             self._connection.set_body_paused(self, False)
             self._wake()
+            if self._discard_body and not self._transport.is_closing():
+                self._transport.close()
             return
         if (
             self._read_max_size >= 0
@@ -999,6 +1009,11 @@ cdef class RequestExchange:
             self._clear_body_storage()
             self._connection.set_body_paused(self, False)
             self._wake()
+            if self._discard_body and not self._transport.is_closing():
+                self._transport.close()
+            return
+        if self._discard_body:
+            self._total_read = new_total
             return
         emitted = False
         offset = 0
@@ -1035,6 +1050,10 @@ cdef class RequestExchange:
             return
         self._body_complete = True
         self._cancel_stall_timer()
+        if self._discard_body:
+            self._clear_body_storage()
+            self._maybe_recycle()
+            return
         self._seal_body_tail()
         if self._consumed_as == CONSUMED_STREAM:
             self._wake()
@@ -1094,6 +1113,10 @@ cdef class RequestExchange:
         cdef Py_ssize_t offset
         cdef Py_ssize_t remaining
         cdef Py_ssize_t consumed
+        if self._discard_body:
+            raise StarioRuntime(
+                "Request body is no longer available after its handler finished."
+            )
         if self._abort_reason != ABORT_NONE:
             self._raise_abort()
         if self._consumed_as == CONSUMED_BODY:
@@ -1151,6 +1174,10 @@ cdef class RequestExchange:
             await self._wait_for_body_data()
 
     async def read(self, max_size=None):
+        if self._discard_body:
+            raise StarioRuntime(
+                "Request body is no longer available after its handler finished."
+            )
         if max_size is not None and max_size < 0:
             raise ValueError("max_size must be non-negative.")
         if self._abort_reason != ABORT_NONE:

--- a/src/stario_cython/headers.pxd
+++ b/src/stario_cython/headers.pxd
@@ -8,12 +8,19 @@ ctypedef struct RawHeader:
 
 cdef class Headers:
     cdef dict _data
+    cdef char _raw_inline[2048]
     cdef char* _raw_arena
     cdef Py_ssize_t _raw_len
     cdef Py_ssize_t _raw_cap
+    cdef RawHeader _raw_headers_inline[16]
     cdef RawHeader* _raw_headers
     cdef Py_ssize_t _raw_count
     cdef Py_ssize_t _raw_headers_cap
+    cdef Py_ssize_t _pending_name_offset
+    cdef Py_ssize_t _pending_name_length
+    cdef Py_ssize_t _pending_value_offset
+    cdef Py_ssize_t _pending_value_length
+    cdef bint _pending_header
     cdef Py_ssize_t _request_host_index
     cdef bint _materialized
     cdef bint _request_connection_close
@@ -25,6 +32,10 @@ cdef class Headers:
     cdef int _request_identity_q
 
     cdef void add_raw(self, const char* name, size_t nlen, const char* value, size_t vlen)
+    cdef void start_raw_header(self)
+    cdef void append_raw_name(self, const char* data, size_t length)
+    cdef void append_raw_value(self, const char* data, size_t length)
+    cdef void finish_raw_header(self)
     cdef int _reserve_raw(self, Py_ssize_t bytes_needed) except -1
     cdef int _reserve_raw_headers(self) except -1
     cdef void _materialize(self)

--- a/src/stario_cython/headers.pxd
+++ b/src/stario_cython/headers.pxd
@@ -1,5 +1,21 @@
+from libc.stdint cimport uint32_t
+
+ctypedef struct RawHeader:
+    uint32_t name_offset
+    uint32_t name_length
+    uint32_t value_offset
+    uint32_t value_length
+
 cdef class Headers:
     cdef dict _data
+    cdef char* _raw_arena
+    cdef Py_ssize_t _raw_len
+    cdef Py_ssize_t _raw_cap
+    cdef RawHeader* _raw_headers
+    cdef Py_ssize_t _raw_count
+    cdef Py_ssize_t _raw_headers_cap
+    cdef Py_ssize_t _request_host_index
+    cdef bint _materialized
     cdef bint _request_connection_close
     cdef bint _request_expect_continue
     cdef bint _request_accept_present
@@ -9,6 +25,10 @@ cdef class Headers:
     cdef int _request_identity_q
 
     cdef void add_raw(self, const char* name, size_t nlen, const char* value, size_t vlen)
+    cdef int _reserve_raw(self, Py_ssize_t bytes_needed) except -1
+    cdef int _reserve_raw_headers(self) except -1
+    cdef void _materialize(self)
+    cdef object c_request_host(self)
     cdef void _scan_request_accept_encoding(
         self,
         const char* value,

--- a/src/stario_cython/headers.pxd
+++ b/src/stario_cython/headers.pxd
@@ -29,7 +29,6 @@ cdef class Headers:
     cdef int _request_wildcard_q
     cdef int _request_identity_q
 
-    cdef void add_raw(self, const char* name, size_t nlen, const char* value, size_t vlen)
     cdef void start_raw_header(self)
     cdef void append_raw_name(self, const char* data, size_t length)
     cdef void append_raw_value(self, const char* data, size_t length)

--- a/src/stario_cython/headers.pxd
+++ b/src/stario_cython/headers.pxd
@@ -1,13 +1,26 @@
 cdef class Headers:
     cdef dict _data
-    cdef object _request_accept_encoding
     cdef bint _request_connection_close
     cdef bint _request_expect_continue
+    cdef bint _request_accept_present
+    cdef int _request_br_q
+    cdef int _request_gzip_q
+    cdef int _request_wildcard_q
+    cdef int _request_identity_q
 
     cdef void add_raw(self, const char* name, size_t nlen, const char* value, size_t vlen)
-    cdef object c_request_accept_encoding(self)
+    cdef void _scan_request_accept_encoding(
+        self,
+        const char* value,
+        size_t length,
+    ) noexcept
     cdef bint c_request_connection_close(self) noexcept
     cdef bint c_request_expect_continue(self) noexcept
+    cdef int c_select_request_encoding(
+        self,
+        bint brotli_enabled,
+        bint gzip_enabled,
+    ) noexcept
     cdef object c_get(self, object name)
     cdef void c_set(self, object name, object value)
     cdef void c_add(self, object name, object value)

--- a/src/stario_cython/headers.pxd
+++ b/src/stario_cython/headers.pxd
@@ -50,3 +50,8 @@ cdef class Headers:
     cdef void c_merge_vary(self, object token)
     cdef int _add_ba(self, object buf, Py_ssize_t* length, const char* src, Py_ssize_t n) except -1
     cdef int c_write_wire_ba(self, object buf, Py_ssize_t* length) except -1
+    cdef int c_write_response_wire_ba(
+        self,
+        object buf,
+        Py_ssize_t* length,
+    ) except -1

--- a/src/stario_cython/headers.pxd
+++ b/src/stario_cython/headers.pxd
@@ -8,11 +8,9 @@ ctypedef struct RawHeader:
 
 cdef class Headers:
     cdef dict _data
-    cdef char _raw_inline[2048]
     cdef char* _raw_arena
     cdef Py_ssize_t _raw_len
     cdef Py_ssize_t _raw_cap
-    cdef RawHeader _raw_headers_inline[16]
     cdef RawHeader* _raw_headers
     cdef Py_ssize_t _raw_count
     cdef Py_ssize_t _raw_headers_cap

--- a/src/stario_cython/headers.pxd
+++ b/src/stario_cython/headers.pxd
@@ -1,7 +1,13 @@
 cdef class Headers:
     cdef dict _data
+    cdef object _request_accept_encoding
+    cdef bint _request_connection_close
+    cdef bint _request_expect_continue
 
     cdef void add_raw(self, const char* name, size_t nlen, const char* value, size_t vlen)
+    cdef object c_request_accept_encoding(self)
+    cdef bint c_request_connection_close(self) noexcept
+    cdef bint c_request_expect_continue(self) noexcept
     cdef object c_get(self, object name)
     cdef void c_set(self, object name, object value)
     cdef void c_add(self, object name, object value)

--- a/src/stario_cython/headers.pyx
+++ b/src/stario_cython/headers.pyx
@@ -81,6 +81,10 @@ cdef void _init_intern() noexcept:
 
 _init_intern()
 
+cdef object _CONNECTION_NAME = _INTERN_PY[1]
+cdef object _ACCEPT_ENCODING_NAME = _INTERN_PY[13]
+cdef object _EXPECT_NAME = _INTERN_PY[26]
+
 
 cdef inline void _lower_copy(char* dst, const char* src, size_t n) noexcept:
     cdef size_t i
@@ -91,6 +95,54 @@ cdef inline void _lower_copy(char* dst, const char* src, size_t n) noexcept:
             dst[i] = <char>(c + 32)
         else:
             dst[i] = <char>c
+
+
+cdef inline bint _token_equals(
+    const char* value,
+    size_t start,
+    size_t end,
+    const char* token,
+    size_t token_len,
+) noexcept:
+    cdef size_t i
+    cdef unsigned char c
+    if end - start != token_len:
+        return False
+    for i in range(token_len):
+        c = <unsigned char>value[start + i]
+        if 65 <= c <= 90:
+            c += 32
+        if c != <unsigned char>token[i]:
+            return False
+    return True
+
+
+cdef bint _contains_token(
+    const char* value,
+    size_t length,
+    const char* token,
+    size_t token_len,
+) noexcept:
+    cdef size_t start = 0
+    cdef size_t end
+    while start < length:
+        while start < length and (
+            value[start] == <char>32
+            or value[start] == <char>9
+            or value[start] == <char>44
+        ):
+            start += 1
+        end = start
+        while end < length and value[end] != <char>44:
+            end += 1
+        while end > start and (
+            value[end - 1] == <char>32 or value[end - 1] == <char>9
+        ):
+            end -= 1
+        if _token_equals(value, start, end, token, token_len):
+            return True
+        start = end + 1
+    return False
 
 
 cdef object _intern_name(const char* src, size_t n):
@@ -134,11 +186,31 @@ cdef object _encode_value(str value):
 cdef class Headers:
     def __init__(self, raw_header_data=None):
         self._data = raw_header_data if raw_header_data is not None else {}
+        self._request_accept_encoding = None
+        self._request_connection_close = False
+        self._request_expect_continue = False
 
     cdef void add_raw(self, const char* name, size_t nlen, const char* value, size_t vlen):
         cdef object key = _intern_name(name, nlen)
         cdef object val = PyBytes_FromStringAndSize(value, <Py_ssize_t>vlen)
+        if key is _CONNECTION_NAME:
+            if _contains_token(value, vlen, "close", 5):
+                self._request_connection_close = True
+        elif key is _EXPECT_NAME:
+            if _contains_token(value, vlen, "100-continue", 12):
+                self._request_expect_continue = True
+        elif key is _ACCEPT_ENCODING_NAME and self._request_accept_encoding is None:
+            self._request_accept_encoding = val
         self.c_add(key, val)
+
+    cdef object c_request_accept_encoding(self):
+        return self._request_accept_encoding
+
+    cdef bint c_request_connection_close(self) noexcept:
+        return self._request_connection_close
+
+    cdef bint c_request_expect_continue(self) noexcept:
+        return self._request_expect_continue
 
     cdef object c_get(self, object name):
         cdef object value = self._data.get(name)
@@ -167,6 +239,9 @@ cdef class Headers:
 
     cdef void c_clear(self):
         self._data.clear()
+        self._request_accept_encoding = None
+        self._request_connection_close = False
+        self._request_expect_continue = False
 
     cdef bint c_empty(self):
         return not self._data

--- a/src/stario_cython/headers.pyx
+++ b/src/stario_cython/headers.pyx
@@ -22,6 +22,8 @@ cdef enum:
     INTERN_MAX = 36
     INTERN_TABLE_SIZE = 64
     NAME_STACK = 256
+    RAW_ARENA_RETAIN_MAX = 8 * 1024
+    RAW_HEADERS_RETAIN_MAX = 64
 
 cdef const char* _INTERN_C[INTERN_MAX]
 cdef Py_ssize_t _INTERN_N[INTERN_MAX]
@@ -99,11 +101,6 @@ cdef void _init_intern() noexcept:
 
 
 _init_intern()
-
-cdef object _CONNECTION_NAME = _INTERN_PY[1]
-cdef object _ACCEPT_ENCODING_NAME = _INTERN_PY[13]
-cdef object _EXPECT_NAME = _INTERN_PY[27]
-
 
 cdef inline void _lower_copy(
     char* dst,
@@ -333,12 +330,6 @@ cdef class Headers:
         self._raw_headers_cap = cap
         return 0
 
-    cdef void add_raw(self, const char* name, size_t nlen, const char* value, size_t vlen):
-        self.start_raw_header()
-        self.append_raw_name(name, nlen)
-        self.append_raw_value(value, vlen)
-        self.finish_raw_header()
-
     cdef void start_raw_header(self):
         if self._pending_header:
             self.finish_raw_header()
@@ -377,6 +368,8 @@ cdef class Headers:
         cdef const char* value
         cdef size_t nlen
         cdef size_t vlen
+        cdef object key
+        cdef object materialized_value
         if not self._pending_header:
             return
         if self._pending_name_length == 0:
@@ -404,6 +397,10 @@ cdef class Headers:
                 self._request_expect_continue = True
         elif _token_equals(name, 0, nlen, "accept-encoding", 15):
             self._scan_request_accept_encoding(value, vlen)
+        if self._materialized:
+            key = _intern_name(name, nlen)
+            materialized_value = PyBytes_FromStringAndSize(value, vlen)
+            self.c_add(key, materialized_value)
         self._raw_count += 1
         self._pending_header = False
 
@@ -591,13 +588,13 @@ cdef class Headers:
 
     cdef void c_clear(self):
         self._data.clear()
-        if self._raw_arena != NULL and self._raw_cap > 8192:
+        if self._raw_arena != NULL and self._raw_cap > RAW_ARENA_RETAIN_MAX:
             free(self._raw_arena)
             self._raw_arena = NULL
             self._raw_cap = 0
         if (
             self._raw_headers != NULL
-            and self._raw_headers_cap > 64
+            and self._raw_headers_cap > RAW_HEADERS_RETAIN_MAX
         ):
             free(self._raw_headers)
             self._raw_headers = NULL

--- a/src/stario_cython/headers.pyx
+++ b/src/stario_cython/headers.pyx
@@ -2,6 +2,7 @@
 """Bytes-backed headers. Parser lowercases and interns names in C."""
 
 from libc.string cimport memcmp, memcpy
+from libc.stdint cimport uint8_t, uint32_t
 from cpython.bytearray cimport (
     PyByteArray_AS_STRING,
     PyByteArray_GET_SIZE,
@@ -18,18 +19,31 @@ cdef bytes _VALID_VALUE = bytes(
 
 cdef enum:
     INTERN_MAX = 36
+    INTERN_TABLE_SIZE = 64
     NAME_STACK = 256
 
 cdef const char* _INTERN_C[INTERN_MAX]
 cdef Py_ssize_t _INTERN_N[INTERN_MAX]
+cdef uint8_t _INTERN_SLOT[INTERN_TABLE_SIZE]
 cdef list _INTERN_PY = []
 cdef int _INTERN_COUNT = 0
+
+
+cdef inline uint32_t _hash_bytes(const char* src, size_t n) noexcept:
+    cdef uint32_t value = <uint32_t>2166136261
+    cdef size_t i
+    for i in range(n):
+        value = (
+            value ^ <uint8_t>src[i]
+        ) * <uint32_t>16777619
+    return value
 
 
 cdef void _intern_add(const char* s):
     global _INTERN_COUNT
     cdef Py_ssize_t n
     cdef int i = _INTERN_COUNT
+    cdef uint32_t slot
     if i >= INTERN_MAX:
         return
     n = 0
@@ -38,6 +52,10 @@ cdef void _intern_add(const char* s):
     _INTERN_C[i] = s
     _INTERN_N[i] = n
     _INTERN_PY.append(PyBytes_FromStringAndSize(s, n))
+    slot = _hash_bytes(s, <size_t>n) & (INTERN_TABLE_SIZE - 1)
+    while _INTERN_SLOT[slot] != 0:
+        slot = (slot + 1) & (INTERN_TABLE_SIZE - 1)
+    _INTERN_SLOT[slot] = <uint8_t>(i + 1)
     _INTERN_COUNT = i + 1
 
 
@@ -86,15 +104,21 @@ cdef object _ACCEPT_ENCODING_NAME = _INTERN_PY[13]
 cdef object _EXPECT_NAME = _INTERN_PY[27]
 
 
-cdef inline void _lower_copy(char* dst, const char* src, size_t n) noexcept:
+cdef inline uint32_t _lower_copy_hash(
+    char* dst,
+    const char* src,
+    size_t n,
+) noexcept:
     cdef size_t i
-    cdef unsigned char c
+    cdef uint8_t c
+    cdef uint32_t value = <uint32_t>2166136261
     for i in range(n):
-        c = <unsigned char>src[i]
+        c = <uint8_t>src[i]
         if 65 <= c <= 90:
-            dst[i] = <char>(c + 32)
-        else:
-            dst[i] = <char>c
+            c += 32
+        dst[i] = <char>c
+        value = (value ^ c) * <uint32_t>16777619
+    return value
 
 
 cdef inline bint _token_equals(
@@ -201,15 +225,21 @@ cdef int _parse_qvalue(
 cdef object _intern_name(const char* src, size_t n):
     cdef char buf[NAME_STACK]
     cdef const char* p
+    cdef uint32_t slot
+    cdef uint8_t entry
     cdef int i
     if n >= NAME_STACK:
         raise ValueError("Invalid header name: too long")
-    _lower_copy(buf, src, n)
+    slot = _lower_copy_hash(buf, src, n) & (INTERN_TABLE_SIZE - 1)
     p = buf
-    for i in range(_INTERN_COUNT):
+    while True:
+        entry = _INTERN_SLOT[slot]
+        if entry == 0:
+            return PyBytes_FromStringAndSize(p, <Py_ssize_t>n)
+        i = <int>entry - 1
         if _INTERN_N[i] == <Py_ssize_t>n and memcmp(_INTERN_C[i], p, n) == 0:
             return _INTERN_PY[i]
-    return PyBytes_FromStringAndSize(p, <Py_ssize_t>n)
+        slot = (slot + 1) & (INTERN_TABLE_SIZE - 1)
 
 
 cdef object _encode_name(str name):

--- a/src/stario_cython/headers.pyx
+++ b/src/stario_cython/headers.pyx
@@ -145,6 +145,59 @@ cdef bint _contains_token(
     return False
 
 
+cdef int _parse_qvalue(
+    const char* value,
+    size_t start,
+    size_t end,
+) noexcept:
+    cdef int q = 0
+    cdef int digits = 0
+    cdef unsigned char c
+    while start < end and (
+        value[start] == <char>32 or value[start] == <char>9
+    ):
+        start += 1
+    while end > start and (
+        value[end - 1] == <char>32 or value[end - 1] == <char>9
+    ):
+        end -= 1
+    if start >= end:
+        return 0
+    if value[start] == <char>49:
+        start += 1
+        if start == end:
+            return 1000
+        if value[start] != <char>46:
+            return 0
+        start += 1
+        while start < end:
+            if value[start] != <char>48:
+                return 0
+            start += 1
+        return 1000
+    if value[start] != <char>48:
+        return 0
+    start += 1
+    if start == end:
+        return 0
+    if value[start] != <char>46:
+        return 0
+    start += 1
+    while start < end and digits < 3:
+        c = <unsigned char>value[start]
+        if c < 48 or c > 57:
+            return 0
+        q = q * 10 + c - 48
+        digits += 1
+        start += 1
+    if start != end:
+        return 0
+    while digits < 3:
+        q *= 10
+        digits += 1
+    return q
+
+
 cdef object _intern_name(const char* src, size_t n):
     cdef char buf[NAME_STACK]
     cdef const char* p
@@ -186,9 +239,13 @@ cdef object _encode_value(str value):
 cdef class Headers:
     def __init__(self, raw_header_data=None):
         self._data = raw_header_data if raw_header_data is not None else {}
-        self._request_accept_encoding = None
         self._request_connection_close = False
         self._request_expect_continue = False
+        self._request_accept_present = False
+        self._request_br_q = -1
+        self._request_gzip_q = -1
+        self._request_wildcard_q = -1
+        self._request_identity_q = -1
 
     cdef void add_raw(self, const char* name, size_t nlen, const char* value, size_t vlen):
         cdef object key = _intern_name(name, nlen)
@@ -199,18 +256,124 @@ cdef class Headers:
         elif key is _EXPECT_NAME:
             if _contains_token(value, vlen, "100-continue", 12):
                 self._request_expect_continue = True
-        elif key is _ACCEPT_ENCODING_NAME and self._request_accept_encoding is None:
-            self._request_accept_encoding = val
+        elif key is _ACCEPT_ENCODING_NAME:
+            self._scan_request_accept_encoding(value, vlen)
         self.c_add(key, val)
 
-    cdef object c_request_accept_encoding(self):
-        return self._request_accept_encoding
+    cdef void _scan_request_accept_encoding(
+        self,
+        const char* value,
+        size_t length,
+    ) noexcept:
+        cdef size_t start = 0
+        cdef size_t segment_end
+        cdef size_t separator
+        cdef size_t token_end
+        cdef size_t param_start
+        cdef size_t param_end
+        cdef size_t equals
+        cdef size_t key_start
+        cdef size_t key_end
+        cdef int q
+        self._request_accept_present = True
+        while start < length:
+            segment_end = start
+            while segment_end < length and value[segment_end] != <char>44:
+                segment_end += 1
+            while start < segment_end and (
+                value[start] == <char>32 or value[start] == <char>9
+            ):
+                start += 1
+            separator = start
+            while separator < segment_end and value[separator] != <char>59:
+                separator += 1
+            token_end = separator
+            while token_end > start and (
+                value[token_end - 1] == <char>32
+                or value[token_end - 1] == <char>9
+            ):
+                token_end -= 1
+            q = 1000
+            param_start = separator
+            while param_start < segment_end:
+                param_start += 1
+                param_end = param_start
+                while param_end < segment_end and value[param_end] != <char>59:
+                    param_end += 1
+                equals = param_start
+                while equals < param_end and value[equals] != <char>61:
+                    equals += 1
+                key_start = param_start
+                while key_start < equals and (
+                    value[key_start] == <char>32
+                    or value[key_start] == <char>9
+                ):
+                    key_start += 1
+                key_end = equals
+                while key_end > key_start and (
+                    value[key_end - 1] == <char>32
+                    or value[key_end - 1] == <char>9
+                ):
+                    key_end -= 1
+                if (
+                    equals < param_end
+                    and key_end - key_start == 1
+                    and (
+                        value[key_start] == <char>113
+                        or value[key_start] == <char>81
+                    )
+                ):
+                    q = _parse_qvalue(value, equals + 1, param_end)
+                    break
+                param_start = param_end
+            if _token_equals(value, start, token_end, "br", 2):
+                self._request_br_q = q
+            elif _token_equals(value, start, token_end, "gzip", 4):
+                self._request_gzip_q = q
+            elif _token_equals(value, start, token_end, "*", 1):
+                self._request_wildcard_q = q
+            elif _token_equals(value, start, token_end, "identity", 8):
+                self._request_identity_q = q
+            start = segment_end + 1
 
     cdef bint c_request_connection_close(self) noexcept:
         return self._request_connection_close
 
     cdef bint c_request_expect_continue(self) noexcept:
         return self._request_expect_continue
+
+    cdef int c_select_request_encoding(
+        self,
+        bint brotli_enabled,
+        bint gzip_enabled,
+    ) noexcept:
+        cdef int wildcard
+        cdef int br_q
+        cdef int gzip_q
+        cdef int best_q = 0
+        cdef int selected = 0
+        if not self._request_accept_present:
+            return 0
+        wildcard = (
+            self._request_wildcard_q
+            if self._request_wildcard_q >= 0
+            else 0
+        )
+        br_q = self._request_br_q if self._request_br_q >= 0 else wildcard
+        gzip_q = (
+            self._request_gzip_q
+            if self._request_gzip_q >= 0
+            else wildcard
+        )
+        if brotli_enabled and br_q > best_q:
+            best_q = br_q
+            selected = 1
+        if gzip_enabled and gzip_q > best_q:
+            best_q = gzip_q
+            selected = 2
+        if self._request_identity_q >= best_q:
+            return 0
+        return selected
 
     cdef object c_get(self, object name):
         cdef object value = self._data.get(name)
@@ -239,9 +402,13 @@ cdef class Headers:
 
     cdef void c_clear(self):
         self._data.clear()
-        self._request_accept_encoding = None
         self._request_connection_close = False
         self._request_expect_continue = False
+        self._request_accept_present = False
+        self._request_br_q = -1
+        self._request_gzip_q = -1
+        self._request_wildcard_q = -1
+        self._request_identity_q = -1
 
     cdef bint c_empty(self):
         return not self._data

--- a/src/stario_cython/headers.pyx
+++ b/src/stario_cython/headers.pyx
@@ -2,6 +2,7 @@
 """Bytes-backed headers. Parser lowercases and interns names in C."""
 
 from libc.string cimport memcmp, memcpy
+from libc.stdlib cimport free, realloc
 from libc.stdint cimport uint8_t, uint32_t
 from cpython.bytearray cimport (
     PyByteArray_AS_STRING,
@@ -273,8 +274,18 @@ cdef object _encode_value(str value):
 
 
 cdef class Headers:
+    def __cinit__(self):
+        self._raw_arena = NULL
+        self._raw_len = 0
+        self._raw_cap = 0
+        self._raw_headers = NULL
+        self._raw_count = 0
+        self._raw_headers_cap = 0
+        self._request_host_index = -1
+
     def __init__(self, raw_header_data=None):
         self._data = raw_header_data if raw_header_data is not None else {}
+        self._materialized = raw_header_data is not None
         self._request_connection_close = False
         self._request_expect_continue = False
         self._request_accept_present = False
@@ -283,18 +294,108 @@ cdef class Headers:
         self._request_wildcard_q = -1
         self._request_identity_q = -1
 
+    def __dealloc__(self):
+        if self._raw_arena != NULL:
+            free(self._raw_arena)
+        if self._raw_headers != NULL:
+            free(self._raw_headers)
+
+    cdef int _reserve_raw(self, Py_ssize_t bytes_needed) except -1:
+        cdef Py_ssize_t need = self._raw_len + bytes_needed
+        cdef Py_ssize_t cap
+        cdef char* arena
+        if need <= self._raw_cap:
+            return 0
+        cap = 256 if self._raw_cap == 0 else self._raw_cap * 2
+        if cap < need:
+            cap = need
+        arena = <char*>realloc(self._raw_arena, <size_t>cap)
+        if arena == NULL:
+            raise MemoryError()
+        self._raw_arena = arena
+        self._raw_cap = cap
+        return 0
+
+    cdef int _reserve_raw_headers(self) except -1:
+        cdef Py_ssize_t cap
+        cdef RawHeader* headers
+        if self._raw_count < self._raw_headers_cap:
+            return 0
+        cap = 16 if self._raw_headers_cap == 0 else self._raw_headers_cap * 2
+        headers = <RawHeader*>realloc(
+            self._raw_headers,
+            <size_t>cap * sizeof(RawHeader),
+        )
+        if headers == NULL:
+            raise MemoryError()
+        self._raw_headers = headers
+        self._raw_headers_cap = cap
+        return 0
+
     cdef void add_raw(self, const char* name, size_t nlen, const char* value, size_t vlen):
-        cdef object key = _intern_name(name, nlen)
-        cdef object val = PyBytes_FromStringAndSize(value, <Py_ssize_t>vlen)
-        if key is _CONNECTION_NAME:
+        cdef RawHeader* header
+        cdef Py_ssize_t name_offset
+        cdef Py_ssize_t value_offset
+        if nlen >= NAME_STACK:
+            raise ValueError("Invalid header name: too long")
+        self._reserve_raw(<Py_ssize_t>(nlen + vlen))
+        self._reserve_raw_headers()
+        name_offset = self._raw_len
+        _lower_copy(self._raw_arena + name_offset, name, nlen)
+        self._raw_len += <Py_ssize_t>nlen
+        value_offset = self._raw_len
+        if vlen:
+            memcpy(self._raw_arena + value_offset, value, vlen)
+        self._raw_len += <Py_ssize_t>vlen
+        header = &self._raw_headers[self._raw_count]
+        header.name_offset = <uint32_t>name_offset
+        header.name_length = <uint32_t>nlen
+        header.value_offset = <uint32_t>value_offset
+        header.value_length = <uint32_t>vlen
+        if _token_equals(name, 0, nlen, "host", 4):
+            if self._request_host_index < 0:
+                self._request_host_index = self._raw_count
+        elif _token_equals(name, 0, nlen, "connection", 10):
             if _contains_token(value, vlen, "close", 5):
                 self._request_connection_close = True
-        elif key is _EXPECT_NAME:
+        elif _token_equals(name, 0, nlen, "expect", 6):
             if _contains_token(value, vlen, "100-continue", 12):
                 self._request_expect_continue = True
-        elif key is _ACCEPT_ENCODING_NAME:
+        elif _token_equals(name, 0, nlen, "accept-encoding", 15):
             self._scan_request_accept_encoding(value, vlen)
-        self.c_add(key, val)
+        self._raw_count += 1
+
+    cdef void _materialize(self):
+        cdef Py_ssize_t i
+        cdef RawHeader* header
+        cdef object key
+        cdef object value
+        if self._materialized:
+            return
+        self._materialized = True
+        for i in range(self._raw_count):
+            header = &self._raw_headers[i]
+            key = _intern_name(
+                self._raw_arena + header.name_offset,
+                header.name_length,
+            )
+            value = PyBytes_FromStringAndSize(
+                self._raw_arena + header.value_offset,
+                header.value_length,
+            )
+            self.c_add(key, value)
+
+    cdef object c_request_host(self):
+        cdef RawHeader* header
+        if self._materialized:
+            return self.c_get(b"host")
+        if self._request_host_index < 0:
+            return None
+        header = &self._raw_headers[self._request_host_index]
+        return PyBytes_FromStringAndSize(
+            self._raw_arena + header.value_offset,
+            header.value_length,
+        )
 
     cdef void _scan_request_accept_encoding(
         self,
@@ -417,7 +518,9 @@ cdef class Headers:
         return selected
 
     cdef object c_get(self, object name):
-        cdef object value = self._data.get(name)
+        cdef object value
+        self._materialize()
+        value = self._data.get(name)
         if value is None:
             return None
         if type(value) is bytes:
@@ -425,10 +528,12 @@ cdef class Headers:
         return value[0]
 
     cdef void c_set(self, object name, object value):
+        self._materialize()
         self._data[name] = value
 
     cdef void c_add(self, object name, object value):
         cdef object existing
+        self._materialize()
         if name not in self._data:
             self._data[name] = value
             return
@@ -439,16 +544,21 @@ cdef class Headers:
             self._data[name] = [existing, value]
 
     cdef void c_remove(self, object name):
+        self._materialize()
         self._data.pop(name, None)
 
     cdef void c_clear(self):
         self._data.clear()
+        self._raw_len = 0
+        self._raw_count = 0
+        self._request_host_index = -1
+        self._materialized = False
         self._request_connection_close = False
         self._request_expect_continue = False
         self._request_accept_present = False
 
     cdef bint c_empty(self):
-        return not self._data
+        return self._raw_count == 0 and not self._data
 
     cdef void c_merge_vary(self, object token):
         cdef object existing = self.c_get(b"vary")
@@ -502,6 +612,7 @@ cdef class Headers:
         cdef object header_value
         cdef const char* p
         cdef Py_ssize_t n
+        self._materialize()
         for name, value in self._data.items():
             if type(value) is bytes:
                 p = name
@@ -558,7 +669,9 @@ cdef class Headers:
         return [v.decode("latin-1") for v in self.unsafe_getlist(_encode_name(name))]
 
     def unsafe_getlist(self, name):
-        cdef object value = self._data.get(name)
+        cdef object value
+        self._materialize()
+        value = self._data.get(name)
         if value is None:
             return []
         if type(value) is bytes:
@@ -582,6 +695,7 @@ cdef class Headers:
         cdef object name
         cdef object value
         cdef object v
+        self._materialize()
         for name, value in self._data.items():
             if type(value) is list:
                 for v in value:
@@ -592,12 +706,15 @@ cdef class Headers:
 
     def __contains__(self, name):
         try:
+            self._materialize()
             return _encode_name(name) in self._data
         except ValueError:
             return False
 
     def __len__(self):
+        self._materialize()
         return len(self._data)
 
     def __repr__(self):
+        self._materialize()
         return f"Headers({self._data!r})"

--- a/src/stario_cython/headers.pyx
+++ b/src/stario_cython/headers.pyx
@@ -275,7 +275,12 @@ cdef class Headers:
         cdef size_t key_start
         cdef size_t key_end
         cdef int q
-        self._request_accept_present = True
+        if not self._request_accept_present:
+            self._request_accept_present = True
+            self._request_br_q = -1
+            self._request_gzip_q = -1
+            self._request_wildcard_q = -1
+            self._request_identity_q = -1
         while start < length:
             segment_end = start
             while segment_end < length and value[segment_end] != <char>44:
@@ -405,10 +410,6 @@ cdef class Headers:
         self._request_connection_close = False
         self._request_expect_continue = False
         self._request_accept_present = False
-        self._request_br_q = -1
-        self._request_gzip_q = -1
-        self._request_wildcard_q = -1
-        self._request_identity_q = -1
 
     cdef bint c_empty(self):
         return not self._data

--- a/src/stario_cython/headers.pyx
+++ b/src/stario_cython/headers.pyx
@@ -83,7 +83,7 @@ _init_intern()
 
 cdef object _CONNECTION_NAME = _INTERN_PY[1]
 cdef object _ACCEPT_ENCODING_NAME = _INTERN_PY[13]
-cdef object _EXPECT_NAME = _INTERN_PY[26]
+cdef object _EXPECT_NAME = _INTERN_PY[27]
 
 
 cdef inline void _lower_copy(char* dst, const char* src, size_t n) noexcept:

--- a/src/stario_cython/headers.pyx
+++ b/src/stario_cython/headers.pyx
@@ -2,7 +2,7 @@
 """Bytes-backed headers. Parser lowercases and interns names in C."""
 
 from libc.string cimport memcmp, memcpy
-from libc.stdlib cimport free, realloc
+from libc.stdlib cimport free, malloc, realloc
 from libc.stdint cimport uint8_t, uint32_t
 from cpython.bytearray cimport (
     PyByteArray_AS_STRING,
@@ -275,12 +275,13 @@ cdef object _encode_value(str value):
 
 cdef class Headers:
     def __cinit__(self):
-        self._raw_arena = NULL
+        self._raw_arena = &self._raw_inline[0]
         self._raw_len = 0
-        self._raw_cap = 0
-        self._raw_headers = NULL
+        self._raw_cap = 2048
+        self._raw_headers = &self._raw_headers_inline[0]
         self._raw_count = 0
-        self._raw_headers_cap = 0
+        self._raw_headers_cap = 16
+        self._pending_header = False
         self._request_host_index = -1
 
     def __init__(self, raw_header_data=None):
@@ -295,9 +296,9 @@ cdef class Headers:
         self._request_identity_q = -1
 
     def __dealloc__(self):
-        if self._raw_arena != NULL:
+        if self._raw_arena != &self._raw_inline[0]:
             free(self._raw_arena)
-        if self._raw_headers != NULL:
+        if self._raw_headers != &self._raw_headers_inline[0]:
             free(self._raw_headers)
 
     cdef int _reserve_raw(self, Py_ssize_t bytes_needed) except -1:
@@ -309,7 +310,12 @@ cdef class Headers:
         cap = 256 if self._raw_cap == 0 else self._raw_cap * 2
         if cap < need:
             cap = need
-        arena = <char*>realloc(self._raw_arena, <size_t>cap)
+        if self._raw_arena == &self._raw_inline[0]:
+            arena = <char*>malloc(<size_t>cap)
+            if arena != NULL and self._raw_len:
+                memcpy(arena, self._raw_arena, <size_t>self._raw_len)
+        else:
+            arena = <char*>realloc(self._raw_arena, <size_t>cap)
         if arena == NULL:
             raise MemoryError()
         self._raw_arena = arena
@@ -322,10 +328,19 @@ cdef class Headers:
         if self._raw_count < self._raw_headers_cap:
             return 0
         cap = 16 if self._raw_headers_cap == 0 else self._raw_headers_cap * 2
-        headers = <RawHeader*>realloc(
-            self._raw_headers,
-            <size_t>cap * sizeof(RawHeader),
-        )
+        if self._raw_headers == &self._raw_headers_inline[0]:
+            headers = <RawHeader*>malloc(<size_t>cap * sizeof(RawHeader))
+            if headers != NULL and self._raw_count:
+                memcpy(
+                    headers,
+                    self._raw_headers,
+                    <size_t>self._raw_count * sizeof(RawHeader),
+                )
+        else:
+            headers = <RawHeader*>realloc(
+                self._raw_headers,
+                <size_t>cap * sizeof(RawHeader),
+            )
         if headers == NULL:
             raise MemoryError()
         self._raw_headers = headers
@@ -333,24 +348,64 @@ cdef class Headers:
         return 0
 
     cdef void add_raw(self, const char* name, size_t nlen, const char* value, size_t vlen):
-        cdef RawHeader* header
-        cdef Py_ssize_t name_offset
-        cdef Py_ssize_t value_offset
-        if nlen >= NAME_STACK:
+        self.start_raw_header()
+        self.append_raw_name(name, nlen)
+        self.append_raw_value(value, vlen)
+        self.finish_raw_header()
+
+    cdef void start_raw_header(self):
+        if self._pending_header:
+            self.finish_raw_header()
+        self._pending_header = True
+        self._pending_name_offset = self._raw_len
+        self._pending_name_length = 0
+        self._pending_value_offset = -1
+        self._pending_value_length = 0
+
+    cdef void append_raw_name(self, const char* data, size_t length):
+        if not self._pending_header:
+            self.start_raw_header()
+        if self._pending_value_offset >= 0:
+            raise ValueError("Invalid fragmented header field")
+        if self._pending_name_length + <Py_ssize_t>length >= NAME_STACK:
             raise ValueError("Invalid header name: too long")
-        self._reserve_raw(<Py_ssize_t>(nlen + vlen))
+        self._reserve_raw(<Py_ssize_t>length)
+        _lower_copy(self._raw_arena + self._raw_len, data, length)
+        self._raw_len += <Py_ssize_t>length
+        self._pending_name_length += <Py_ssize_t>length
+
+    cdef void append_raw_value(self, const char* data, size_t length):
+        if not self._pending_header:
+            raise ValueError("Invalid header value without field")
+        if self._pending_value_offset < 0:
+            self._pending_value_offset = self._raw_len
+        self._reserve_raw(<Py_ssize_t>length)
+        if length:
+            memcpy(self._raw_arena + self._raw_len, data, length)
+        self._raw_len += <Py_ssize_t>length
+        self._pending_value_length += <Py_ssize_t>length
+
+    cdef void finish_raw_header(self):
+        cdef RawHeader* header
+        cdef const char* name
+        cdef const char* value
+        cdef size_t nlen
+        cdef size_t vlen
+        if not self._pending_header:
+            return
+        if self._pending_name_length == 0:
+            raise ValueError("Invalid header name: empty")
+        if self._pending_value_offset < 0:
+            self._pending_value_offset = self._raw_len
+        name = self._raw_arena + self._pending_name_offset
+        value = self._raw_arena + self._pending_value_offset
+        nlen = <size_t>self._pending_name_length
+        vlen = <size_t>self._pending_value_length
         self._reserve_raw_headers()
-        name_offset = self._raw_len
-        _lower_copy(self._raw_arena + name_offset, name, nlen)
-        self._raw_len += <Py_ssize_t>nlen
-        value_offset = self._raw_len
-        if vlen:
-            memcpy(self._raw_arena + value_offset, value, vlen)
-        self._raw_len += <Py_ssize_t>vlen
         header = &self._raw_headers[self._raw_count]
-        header.name_offset = <uint32_t>name_offset
+        header.name_offset = <uint32_t>self._pending_name_offset
         header.name_length = <uint32_t>nlen
-        header.value_offset = <uint32_t>value_offset
+        header.value_offset = <uint32_t>self._pending_value_offset
         header.value_length = <uint32_t>vlen
         if _token_equals(name, 0, nlen, "host", 4):
             if self._request_host_index < 0:
@@ -364,6 +419,7 @@ cdef class Headers:
         elif _token_equals(name, 0, nlen, "accept-encoding", 15):
             self._scan_request_accept_encoding(value, vlen)
         self._raw_count += 1
+        self._pending_header = False
 
     cdef void _materialize(self):
         cdef Py_ssize_t i
@@ -549,8 +605,20 @@ cdef class Headers:
 
     cdef void c_clear(self):
         self._data.clear()
+        if self._raw_arena != &self._raw_inline[0] and self._raw_cap > 8192:
+            free(self._raw_arena)
+            self._raw_arena = &self._raw_inline[0]
+            self._raw_cap = 2048
+        if (
+            self._raw_headers != &self._raw_headers_inline[0]
+            and self._raw_headers_cap > 64
+        ):
+            free(self._raw_headers)
+            self._raw_headers = &self._raw_headers_inline[0]
+            self._raw_headers_cap = 16
         self._raw_len = 0
         self._raw_count = 0
+        self._pending_header = False
         self._request_host_index = -1
         self._materialized = False
         self._request_connection_close = False

--- a/src/stario_cython/headers.pyx
+++ b/src/stario_cython/headers.pyx
@@ -2,7 +2,7 @@
 """Bytes-backed headers. Parser lowercases and interns names in C."""
 
 from libc.string cimport memcmp, memcpy
-from libc.stdlib cimport free, malloc, realloc
+from libc.stdlib cimport free, realloc
 from libc.stdint cimport uint8_t, uint32_t
 from cpython.bytearray cimport (
     PyByteArray_AS_STRING,
@@ -275,12 +275,12 @@ cdef object _encode_value(str value):
 
 cdef class Headers:
     def __cinit__(self):
-        self._raw_arena = &self._raw_inline[0]
+        self._raw_arena = NULL
         self._raw_len = 0
-        self._raw_cap = 2048
-        self._raw_headers = &self._raw_headers_inline[0]
+        self._raw_cap = 0
+        self._raw_headers = NULL
         self._raw_count = 0
-        self._raw_headers_cap = 16
+        self._raw_headers_cap = 0
         self._pending_header = False
         self._request_host_index = -1
 
@@ -296,9 +296,9 @@ cdef class Headers:
         self._request_identity_q = -1
 
     def __dealloc__(self):
-        if self._raw_arena != &self._raw_inline[0]:
+        if self._raw_arena != NULL:
             free(self._raw_arena)
-        if self._raw_headers != &self._raw_headers_inline[0]:
+        if self._raw_headers != NULL:
             free(self._raw_headers)
 
     cdef int _reserve_raw(self, Py_ssize_t bytes_needed) except -1:
@@ -310,12 +310,7 @@ cdef class Headers:
         cap = 256 if self._raw_cap == 0 else self._raw_cap * 2
         if cap < need:
             cap = need
-        if self._raw_arena == &self._raw_inline[0]:
-            arena = <char*>malloc(<size_t>cap)
-            if arena != NULL and self._raw_len:
-                memcpy(arena, self._raw_arena, <size_t>self._raw_len)
-        else:
-            arena = <char*>realloc(self._raw_arena, <size_t>cap)
+        arena = <char*>realloc(self._raw_arena, <size_t>cap)
         if arena == NULL:
             raise MemoryError()
         self._raw_arena = arena
@@ -328,19 +323,10 @@ cdef class Headers:
         if self._raw_count < self._raw_headers_cap:
             return 0
         cap = 16 if self._raw_headers_cap == 0 else self._raw_headers_cap * 2
-        if self._raw_headers == &self._raw_headers_inline[0]:
-            headers = <RawHeader*>malloc(<size_t>cap * sizeof(RawHeader))
-            if headers != NULL and self._raw_count:
-                memcpy(
-                    headers,
-                    self._raw_headers,
-                    <size_t>self._raw_count * sizeof(RawHeader),
-                )
-        else:
-            headers = <RawHeader*>realloc(
-                self._raw_headers,
-                <size_t>cap * sizeof(RawHeader),
-            )
+        headers = <RawHeader*>realloc(
+            self._raw_headers,
+            <size_t>cap * sizeof(RawHeader),
+        )
         if headers == NULL:
             raise MemoryError()
         self._raw_headers = headers
@@ -605,17 +591,17 @@ cdef class Headers:
 
     cdef void c_clear(self):
         self._data.clear()
-        if self._raw_arena != &self._raw_inline[0] and self._raw_cap > 8192:
+        if self._raw_arena != NULL and self._raw_cap > 8192:
             free(self._raw_arena)
-            self._raw_arena = &self._raw_inline[0]
-            self._raw_cap = 2048
+            self._raw_arena = NULL
+            self._raw_cap = 0
         if (
-            self._raw_headers != &self._raw_headers_inline[0]
+            self._raw_headers != NULL
             and self._raw_headers_cap > 64
         ):
             free(self._raw_headers)
-            self._raw_headers = &self._raw_headers_inline[0]
-            self._raw_headers_cap = 16
+            self._raw_headers = NULL
+            self._raw_headers_cap = 0
         self._raw_len = 0
         self._raw_count = 0
         self._pending_header = False

--- a/src/stario_cython/headers.pyx
+++ b/src/stario_cython/headers.pyx
@@ -104,21 +104,18 @@ cdef object _ACCEPT_ENCODING_NAME = _INTERN_PY[13]
 cdef object _EXPECT_NAME = _INTERN_PY[27]
 
 
-cdef inline uint32_t _lower_copy_hash(
+cdef inline void _lower_copy(
     char* dst,
     const char* src,
     size_t n,
 ) noexcept:
     cdef size_t i
     cdef uint8_t c
-    cdef uint32_t value = <uint32_t>2166136261
     for i in range(n):
         c = <uint8_t>src[i]
         if 65 <= c <= 90:
             c += 32
         dst[i] = <char>c
-        value = (value ^ c) * <uint32_t>16777619
-    return value
 
 
 cdef inline bint _token_equals(
@@ -230,8 +227,17 @@ cdef object _intern_name(const char* src, size_t n):
     cdef int i
     if n >= NAME_STACK:
         raise ValueError("Invalid header name: too long")
-    slot = _lower_copy_hash(buf, src, n) & (INTERN_TABLE_SIZE - 1)
+    _lower_copy(buf, src, n)
     p = buf
+    if n == 4 and memcmp(p, "host", 4) == 0:
+        return _INTERN_PY[0]
+    if n == 10 and memcmp(p, "connection", 10) == 0:
+        return _INTERN_PY[1]
+    if n == 15 and memcmp(p, "accept-encoding", 15) == 0:
+        return _INTERN_PY[13]
+    if n == 6 and memcmp(p, "expect", 6) == 0:
+        return _INTERN_PY[27]
+    slot = _hash_bytes(p, n) & (INTERN_TABLE_SIZE - 1)
     while True:
         entry = _INTERN_SLOT[slot]
         if entry == 0:

--- a/src/stario_cython/headers.pyx
+++ b/src/stario_cython/headers.pyx
@@ -631,6 +631,36 @@ cdef class Headers:
                 self._add_ba(buf, length, <const char*>b"\r\n", 2)
         return 0
 
+    cdef int c_write_response_wire_ba(
+        self,
+        object buf,
+        Py_ssize_t* length,
+    ) except -1:
+        cdef object name
+        cdef object value
+        cdef object header_value
+        cdef const char* p
+        self._materialize()
+        for name, value in self._data.items():
+            if name == b"content-type" or name == b"content-length":
+                continue
+            if type(value) is bytes:
+                p = name
+                self._add_ba(buf, length, p, <Py_ssize_t>len(name))
+                self._add_ba(buf, length, <const char*>b": ", 2)
+                p = value
+                self._add_ba(buf, length, p, <Py_ssize_t>len(value))
+                self._add_ba(buf, length, <const char*>b"\r\n", 2)
+                continue
+            for header_value in value:
+                p = name
+                self._add_ba(buf, length, p, <Py_ssize_t>len(name))
+                self._add_ba(buf, length, <const char*>b": ", 2)
+                p = header_value
+                self._add_ba(buf, length, p, <Py_ssize_t>len(header_value))
+                self._add_ba(buf, length, <const char*>b"\r\n", 2)
+        return 0
+
     def add(self, str name, str value):
         self.c_add(_encode_name(name), _encode_value(value))
 

--- a/src/stario_cython/llhttp.pxd
+++ b/src/stario_cython/llhttp.pxd
@@ -46,6 +46,8 @@ cdef extern from "llhttp.h":
 
     void llhttp_init(llhttp_t* parser, llhttp_type type, const llhttp_settings_t* settings)
     int llhttp_execute(llhttp_t* parser, const char* data, size_t len)
+    void llhttp_resume(llhttp_t* parser)
+    const char* llhttp_get_error_pos(const llhttp_t* parser)
     int llhttp_should_keep_alive(const llhttp_t* parser)
     uint8_t llhttp_get_method(llhttp_t* parser)
     uint8_t llhttp_get_http_major(llhttp_t* parser)

--- a/src/stario_cython/llhttp.pxd
+++ b/src/stario_cython/llhttp.pxd
@@ -46,8 +46,6 @@ cdef extern from "llhttp.h":
 
     void llhttp_init(llhttp_t* parser, llhttp_type type, const llhttp_settings_t* settings)
     int llhttp_execute(llhttp_t* parser, const char* data, size_t len)
-    void llhttp_resume(llhttp_t* parser)
-    const char* llhttp_get_error_pos(const llhttp_t* parser)
     int llhttp_should_keep_alive(const llhttp_t* parser)
     uint8_t llhttp_get_method(llhttp_t* parser)
     uint8_t llhttp_get_http_major(llhttp_t* parser)

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -442,6 +442,8 @@ cdef class HttpProtocol:
                 and not exchange._req_connection_close
             )
         )
+        if flags & F_CONTENT_LENGTH:
+            exchange.prepare_body_capacity(<Py_ssize_t>content_length)
         self.complete_headers(exchange._req_expect_continue)
 
     cdef void _on_body(self, const char* at, size_t length):

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -18,6 +18,7 @@ cdef int PAUSE_WRITE = 1
 cdef int PAUSE_PIPELINE = 2
 cdef int PAUSE_BODY = 4
 cdef int PARSER_QUANTUM = 512 * 1024
+cdef int MAX_PENDING_EXCHANGES = 64
 # Handlers always start at headers-complete. Body bytes accumulate on the exchange;
 # body() awaits one completion Event, stream() drains with backpressure.
 
@@ -127,9 +128,10 @@ cdef int _cb_header_value_complete(llhttp_t* parser) noexcept:
 
 cdef int _cb_headers_complete(llhttp_t* parser) noexcept:
     try:
-        return _proto(parser)._on_headers_complete()
+        _proto(parser)._on_headers_complete()
     except Exception:
         return -1
+    return 0
 
 
 cdef int _cb_body(llhttp_t* parser, const char* at, size_t length) noexcept:
@@ -197,7 +199,6 @@ cdef class HttpProtocol:
     cdef object held_data
     cdef Py_ssize_t held_offset
     cdef bint pump_scheduled
-    cdef bint parser_paused
 
     def __cinit__(self):
         _bind_settings()
@@ -219,7 +220,6 @@ cdef class HttpProtocol:
         self.held_data = None
         self.held_offset = 0
         self.pump_scheduled = False
-        self.parser_paused = False
 
     def __dealloc__(self):
         if self.parser != NULL:
@@ -268,7 +268,6 @@ cdef class HttpProtocol:
         self.held_data = None
         self.held_offset = 0
         self.pump_scheduled = False
-        self.parser_paused = False
         self.connections.add(self)
 
     def ensure_disconnect(self):
@@ -304,7 +303,6 @@ cdef class HttpProtocol:
         self.held_data = None
         self.held_offset = 0
         self.pump_scheduled = False
-        self.parser_paused = False
         self.transport = None
 
     def recycle_exchange(self, RequestExchange exchange):
@@ -335,26 +333,10 @@ cdef class HttpProtocol:
         cdef Py_ssize_t n
         cdef Py_ssize_t end
         cdef int err
-        cdef const char* error_pos
         n = len(data)
         ptr = <const char*>data
         if n <= PARSER_QUANTUM:
             err = llhttp_execute(self.parser, ptr + offset, <size_t>(n - offset))
-            if err == HPE_PAUSED:
-                error_pos = llhttp_get_error_pos(self.parser)
-                self.parser_paused = True
-                self.held_data = data
-                self.held_offset = (
-                    <Py_ssize_t>(error_pos - ptr) + 1
-                    if error_pos != NULL
-                    else n
-                )
-                if self.held_offset > n:
-                    self.held_offset = n
-                if self.pause_reasons == 0 and not self.pump_scheduled:
-                    self.pump_scheduled = True
-                    self.loop.call_soon(self._resume_held_input)
-                return
             if err != HPE_OK:
                 self._close_error(400, "Invalid HTTP request")
             return
@@ -367,21 +349,6 @@ cdef class HttpProtocol:
                 ptr + offset,
                 <size_t>(end - offset),
             )
-            if err == HPE_PAUSED:
-                error_pos = llhttp_get_error_pos(self.parser)
-                self.parser_paused = True
-                self.held_data = data
-                self.held_offset = (
-                    <Py_ssize_t>(error_pos - ptr) + 1
-                    if error_pos != NULL
-                    else end
-                )
-                if self.held_offset > n:
-                    self.held_offset = n
-                if self.pause_reasons == 0 and not self.pump_scheduled:
-                    self.pump_scheduled = True
-                    self.loop.call_soon(self._resume_held_input)
-                return
             if err != HPE_OK:
                 self._close_error(400, "Invalid HTTP request")
                 return
@@ -426,9 +393,6 @@ cdef class HttpProtocol:
         offset = self.held_offset
         self.held_data = None
         self.held_offset = 0
-        if self.parser_paused:
-            llhttp_resume(self.parser)
-            self.parser_paused = False
         self._pump_data(data, offset)
         if self.pause_reasons == 0 and self.held_data is None:
             transport = self.transport
@@ -457,6 +421,8 @@ cdef class HttpProtocol:
         return 0
 
     cdef void _on_message_begin(self):
+        if self.rejected:
+            return
         self.url_len = 0
         if self.idle_exchange is not None:
             self.reading_exchange = self.idle_exchange
@@ -484,6 +450,8 @@ cdef class HttpProtocol:
         self.url = b""
 
     cdef void _on_url(self, const char* at, size_t length):
+        if self.rejected:
+            return
         self.head_bytes += <int>length
         if self.head_bytes > self.max_header_bytes:
             self._close_error(431, "Request header fields too large")
@@ -492,6 +460,8 @@ cdef class HttpProtocol:
             self._close_error(431, "Request header fields too large")
 
     cdef void _on_header_field(self, const char* at, size_t length):
+        if self.rejected or self.reading_exchange is None:
+            return
         self.head_bytes += <int>length
         if self.head_bytes > self.max_header_bytes:
             self._close_error(431, "Request header fields too large")
@@ -499,6 +469,8 @@ cdef class HttpProtocol:
         self.reading_exchange.request_headers.append_raw_name(at, length)
 
     cdef void _on_header_value(self, const char* at, size_t length):
+        if self.rejected or self.reading_exchange is None:
+            return
         self.head_bytes += <int>length
         if self.head_bytes > self.max_header_bytes:
             self._close_error(431, "Request header fields too large")
@@ -509,7 +481,7 @@ cdef class HttpProtocol:
         if self.reading_exchange is not None:
             self.reading_exchange.request_headers.finish_raw_header()
 
-    cdef int _on_headers_complete(self):
+    cdef void _on_headers_complete(self):
         cdef RequestExchange exchange
         cdef uint16_t flags
         cdef uint64_t content_length
@@ -518,17 +490,17 @@ cdef class HttpProtocol:
         else:
             self.url = b""
         if self.rejected or self.reading_exchange is None:
-            return 0
+            return
         exchange = self.reading_exchange
         exchange.request_headers.finish_raw_header()
         if llhttp_get_upgrade(self.parser):
             self._close_error(400, "Upgrade not supported")
-            return 0
+            return
         flags = stario_parser_flags(self.parser)
         content_length = stario_parser_content_length(self.parser)
         if flags & F_CONTENT_LENGTH and content_length > <uint64_t>self.max_body_bytes:
             self._close_error(413, "Request body too large")
-            return 0
+            return
         # Snapshot keep-alive / expect / accept-encoding into exchange slots.
         exchange.cache_hot_request_headers()
         self.request_keep_alive = (
@@ -543,12 +515,10 @@ cdef class HttpProtocol:
             exchange._req_expect_continue,
             <Py_ssize_t>content_length if flags & F_CONTENT_LENGTH else -1,
         )
-        if self.pause_reasons & PAUSE_PIPELINE:
-            return HPE_PAUSED
-        return 0
 
     cdef void _on_body(self, const char* at, size_t length):
-        self.reading_exchange.c_feed(at, length)
+        if not self.rejected and self.reading_exchange is not None:
+            self.reading_exchange.c_feed(at, length)
 
     cdef void _on_message_complete(self):
         cdef RequestExchange exchange
@@ -614,6 +584,9 @@ cdef class HttpProtocol:
         if self.active_exchange is None:
             self._start_exchange(exchange, True)
         else:
+            if len(self.pending_exchanges) >= MAX_PENDING_EXCHANGES:
+                self._close_error(429, "Too many pipelined requests")
+                return
             self.pending_exchanges.append(exchange)
             self._set_pause_reason(PAUSE_PIPELINE, True)
 

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -349,6 +349,9 @@ cdef class HttpProtocol:
                     if error_pos != NULL
                     else n
                 )
+                if self.pause_reasons == 0 and not self.pump_scheduled:
+                    self.pump_scheduled = True
+                    self.loop.call_soon(self._resume_held_input)
                 return
             if err != HPE_OK:
                 self._close_error(400, "Invalid HTTP request")
@@ -371,6 +374,9 @@ cdef class HttpProtocol:
                     if error_pos != NULL
                     else end
                 )
+                if self.pause_reasons == 0 and not self.pump_scheduled:
+                    self.pump_scheduled = True
+                    self.loop.call_soon(self._resume_held_input)
                 return
             if err != HPE_OK:
                 self._close_error(400, "Invalid HTTP request")

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -442,9 +442,10 @@ cdef class HttpProtocol:
                 and not exchange._req_connection_close
             )
         )
-        if flags & F_CONTENT_LENGTH:
-            exchange.prepare_body_capacity(<Py_ssize_t>content_length)
-        self.complete_headers(exchange._req_expect_continue)
+        self.complete_headers(
+            exchange._req_expect_continue,
+            <Py_ssize_t>content_length if flags & F_CONTENT_LENGTH else -1,
+        )
 
     cdef void _on_body(self, const char* at, size_t length):
         self.reading_exchange.c_feed(at, length)
@@ -486,7 +487,11 @@ cdef class HttpProtocol:
         )
         return request
 
-    cdef void complete_headers(self, bint expect_continue):
+    cdef void complete_headers(
+        self,
+        bint expect_continue,
+        Py_ssize_t expected_body,
+    ):
         cdef RequestExchange exchange
         cdef Request request
         if self.request_dispatched or self.rejected:
@@ -495,7 +500,7 @@ cdef class HttpProtocol:
             return
         exchange = self.reading_exchange
         request = self._build_request(exchange, exchange)
-        exchange.reset_body(expect_continue)
+        exchange.reset_body(expect_continue, expected_body)
         self._dispatch(exchange, request)
 
     cdef void _dispatch(self, RequestExchange exchange, Request request):

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -348,6 +348,11 @@ cdef class HttpProtocol:
         cdef int err
         n = len(data)
         ptr = <const char*>data
+        if n <= PARSER_QUANTUM:
+            err = llhttp_execute(self.parser, ptr + offset, <size_t>(n - offset))
+            if err != HPE_OK:
+                self._close_error(400, "Invalid HTTP request")
+            return
         while offset < n:
             end = offset + PARSER_QUANTUM
             if end > n:

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -20,7 +20,7 @@ cdef int F_CONTENT_LENGTH = 0x20
 cdef int PAUSE_WRITE = 1
 cdef int PAUSE_PIPELINE = 2
 cdef int PAUSE_BODY = 4
-cdef int PARSER_QUANTUM = 64 * 1024
+cdef int PARSER_QUANTUM = 512 * 1024
 # Handlers always start at headers-complete. Body bytes accumulate on the exchange;
 # body() awaits one completion Event, stream() drains with backpressure.
 

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -1,8 +1,6 @@
 # cython: language_level=3
 """uvloop connection protocol; each request runs in a pooled RequestExchange."""
 
-import asyncio
-
 from libc.stdlib cimport realloc, free
 from libc.string cimport memcpy
 from cpython.bytes cimport PyBytes_FromStringAndSize
@@ -12,7 +10,6 @@ from stario.http.writer import get_status_line
 from stario.telemetry.noop import NoOpTracer
 
 from stario_cython.exchange cimport RequestExchange, acquire_exchange
-from stario_cython.headers cimport Headers
 from stario_cython.llhttp cimport *
 from stario_cython.request cimport Request
 
@@ -130,10 +127,9 @@ cdef int _cb_header_value_complete(llhttp_t* parser) noexcept:
 
 cdef int _cb_headers_complete(llhttp_t* parser) noexcept:
     try:
-        _proto(parser)._on_headers_complete()
+        return _proto(parser)._on_headers_complete()
     except Exception:
         return -1
-    return 0
 
 
 cdef int _cb_body(llhttp_t* parser, const char* at, size_t length) noexcept:
@@ -201,6 +197,7 @@ cdef class HttpProtocol:
     cdef object held_data
     cdef Py_ssize_t held_offset
     cdef bint pump_scheduled
+    cdef bint parser_paused
 
     def __cinit__(self):
         _bind_settings()
@@ -222,6 +219,7 @@ cdef class HttpProtocol:
         self.held_data = None
         self.held_offset = 0
         self.pump_scheduled = False
+        self.parser_paused = False
 
     def __dealloc__(self):
         if self.parser != NULL:
@@ -270,6 +268,7 @@ cdef class HttpProtocol:
         self.held_data = None
         self.held_offset = 0
         self.pump_scheduled = False
+        self.parser_paused = False
         self.connections.add(self)
 
     def ensure_disconnect(self):
@@ -305,6 +304,7 @@ cdef class HttpProtocol:
         self.held_data = None
         self.held_offset = 0
         self.pump_scheduled = False
+        self.parser_paused = False
         self.transport = None
 
     def recycle_exchange(self, RequestExchange exchange):
@@ -335,10 +335,21 @@ cdef class HttpProtocol:
         cdef Py_ssize_t n
         cdef Py_ssize_t end
         cdef int err
+        cdef const char* error_pos
         n = len(data)
         ptr = <const char*>data
         if n <= PARSER_QUANTUM:
             err = llhttp_execute(self.parser, ptr + offset, <size_t>(n - offset))
+            if err == HPE_PAUSED:
+                error_pos = llhttp_get_error_pos(self.parser)
+                self.parser_paused = True
+                self.held_data = data
+                self.held_offset = (
+                    <Py_ssize_t>(error_pos - ptr)
+                    if error_pos != NULL
+                    else n
+                )
+                return
             if err != HPE_OK:
                 self._close_error(400, "Invalid HTTP request")
             return
@@ -351,6 +362,16 @@ cdef class HttpProtocol:
                 ptr + offset,
                 <size_t>(end - offset),
             )
+            if err == HPE_PAUSED:
+                error_pos = llhttp_get_error_pos(self.parser)
+                self.parser_paused = True
+                self.held_data = data
+                self.held_offset = (
+                    <Py_ssize_t>(error_pos - ptr)
+                    if error_pos != NULL
+                    else end
+                )
+                return
             if err != HPE_OK:
                 self._close_error(400, "Invalid HTTP request")
                 return
@@ -395,6 +416,9 @@ cdef class HttpProtocol:
         offset = self.held_offset
         self.held_data = None
         self.held_offset = 0
+        if self.parser_paused:
+            llhttp_resume(self.parser)
+            self.parser_paused = False
         self._pump_data(data, offset)
         if self.pause_reasons == 0 and self.held_data is None:
             transport = self.transport
@@ -475,7 +499,7 @@ cdef class HttpProtocol:
         if self.reading_exchange is not None:
             self.reading_exchange.request_headers.finish_raw_header()
 
-    cdef void _on_headers_complete(self):
+    cdef int _on_headers_complete(self):
         cdef RequestExchange exchange
         cdef uint16_t flags
         cdef uint64_t content_length
@@ -484,17 +508,17 @@ cdef class HttpProtocol:
         else:
             self.url = b""
         if self.rejected or self.reading_exchange is None:
-            return
+            return 0
         exchange = self.reading_exchange
         exchange.request_headers.finish_raw_header()
         if llhttp_get_upgrade(self.parser):
             self._close_error(400, "Upgrade not supported")
-            return
+            return 0
         flags = stario_parser_flags(self.parser)
         content_length = stario_parser_content_length(self.parser)
         if flags & F_CONTENT_LENGTH and content_length > <uint64_t>self.max_body_bytes:
             self._close_error(413, "Request body too large")
-            return
+            return 0
         # Snapshot keep-alive / expect / accept-encoding into exchange slots.
         exchange.cache_hot_request_headers()
         self.request_keep_alive = (
@@ -509,6 +533,9 @@ cdef class HttpProtocol:
             exchange._req_expect_continue,
             <Py_ssize_t>content_length if flags & F_CONTENT_LENGTH else -1,
         )
+        if self.pause_reasons & PAUSE_PIPELINE:
+            return HPE_PAUSED
+        return 0
 
     cdef void _on_body(self, const char* at, size_t length):
         self.reading_exchange.c_feed(at, length)

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -345,10 +345,12 @@ cdef class HttpProtocol:
                 self.parser_paused = True
                 self.held_data = data
                 self.held_offset = (
-                    <Py_ssize_t>(error_pos - ptr)
+                    <Py_ssize_t>(error_pos - ptr) + 1
                     if error_pos != NULL
                     else n
                 )
+                if self.held_offset > n:
+                    self.held_offset = n
                 if self.pause_reasons == 0 and not self.pump_scheduled:
                     self.pump_scheduled = True
                     self.loop.call_soon(self._resume_held_input)
@@ -370,10 +372,12 @@ cdef class HttpProtocol:
                 self.parser_paused = True
                 self.held_data = data
                 self.held_offset = (
-                    <Py_ssize_t>(error_pos - ptr)
+                    <Py_ssize_t>(error_pos - ptr) + 1
                     if error_pos != NULL
                     else end
                 )
+                if self.held_offset > n:
+                    self.held_offset = n
                 if self.pause_reasons == 0 and not self.pump_scheduled:
                     self.pump_scheduled = True
                     self.loop.call_soon(self._resume_held_input)

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -16,7 +16,6 @@ from stario_cython.headers cimport Headers
 from stario_cython.llhttp cimport *
 from stario_cython.request cimport Request
 
-cdef int F_CHUNKED = 0x8
 cdef int F_CONTENT_LENGTH = 0x20
 # Handlers always start at headers-complete. Body bytes accumulate on the exchange;
 # body() awaits one completion Event, stream() drains with backpressure.
@@ -443,14 +442,7 @@ cdef class HttpProtocol:
                 and not exchange._req_connection_close
             )
         )
-        # Always start the handler at headers-complete. Pre-size _acc when the
-        # Content-Length is known so body() can materialize without realloc churn.
-        if flags & F_CONTENT_LENGTH:
-            self.complete_headers(
-                exchange._req_expect_continue, <Py_ssize_t>content_length
-            )
-        else:
-            self.complete_headers(exchange._req_expect_continue, -1)
+        self.complete_headers(exchange._req_expect_continue)
 
     cdef void _on_body(self, const char* at, size_t length):
         self.reading_exchange.c_feed(at, length)
@@ -492,7 +484,7 @@ cdef class HttpProtocol:
         )
         return request
 
-    cdef void complete_headers(self, bint expect_continue, Py_ssize_t expected_body):
+    cdef void complete_headers(self, bint expect_continue):
         cdef RequestExchange exchange
         cdef Request request
         if self.request_dispatched or self.rejected:
@@ -502,8 +494,6 @@ cdef class HttpProtocol:
         exchange = self.reading_exchange
         request = self._build_request(exchange, exchange)
         exchange.reset_body(expect_continue)
-        if expected_body > 0:
-            exchange.prepare_body_capacity(expected_body)
         self._dispatch(exchange, request)
 
     cdef void _dispatch(self, RequestExchange exchange, Request request):

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -78,6 +78,7 @@ cdef void _bind_settings() noexcept:
     _SETTINGS.on_url = _cb_url
     _SETTINGS.on_header_field = _cb_header_field
     _SETTINGS.on_header_value = _cb_header_value
+    _SETTINGS.on_header_value_complete = _cb_header_value_complete
     _SETTINGS.on_headers_complete = _cb_headers_complete
     _SETTINGS.on_body = _cb_body
     _SETTINGS.on_message_complete = _cb_message_complete
@@ -114,6 +115,14 @@ cdef int _cb_header_field(llhttp_t* parser, const char* at, size_t length) noexc
 cdef int _cb_header_value(llhttp_t* parser, const char* at, size_t length) noexcept:
     try:
         _proto(parser)._on_header_value(at, length)
+    except Exception:
+        return -1
+    return 0
+
+
+cdef int _cb_header_value_complete(llhttp_t* parser) noexcept:
+    try:
+        _proto(parser)._on_header_value_complete()
     except Exception:
         return -1
     return 0
@@ -178,19 +187,12 @@ cdef class HttpProtocol:
     cdef RequestExchange idle_exchange
     cdef object pending_exchanges
     cdef bytes url
-    cdef char* name_buf
-    cdef char* value_buf
     cdef char* url_buf
-    cdef Py_ssize_t name_len
-    cdef Py_ssize_t name_cap
-    cdef Py_ssize_t value_len
-    cdef Py_ssize_t value_cap
     cdef Py_ssize_t url_len
     cdef Py_ssize_t url_cap
     cdef int head_bytes
     cdef int max_header_bytes
     cdef int max_body_bytes
-    cdef bint have_value
     cdef bint rejected
     cdef bint request_dispatched
     cdef bint request_keep_alive
@@ -207,13 +209,7 @@ cdef class HttpProtocol:
             raise MemoryError()
         llhttp_init(self.parser, HTTP_REQUEST, _SETTINGS)
         stario_parser_set_data(self.parser, <void*>self)
-        self.name_buf = NULL
-        self.value_buf = NULL
         self.url_buf = NULL
-        self.name_len = 0
-        self.name_cap = 0
-        self.value_len = 0
-        self.value_cap = 0
         self.url_len = 0
         self.url_cap = 0
         self.closed = False
@@ -231,12 +227,6 @@ cdef class HttpProtocol:
         if self.parser != NULL:
             stario_parser_del(self.parser)
             self.parser = NULL
-        if self.name_buf != NULL:
-            free(self.name_buf)
-            self.name_buf = NULL
-        if self.value_buf != NULL:
-            free(self.value_buf)
-            self.value_buf = NULL
         if self.url_buf != NULL:
             free(self.url_buf)
             self.url_buf = NULL
@@ -267,7 +257,6 @@ cdef class HttpProtocol:
         self.head_bytes = 0
         self.max_header_bytes = max_header_bytes
         self.max_body_bytes = max_body_bytes
-        self.have_value = False
         self.rejected = False
         self.request_dispatched = False
         self.request_keep_alive = True
@@ -433,32 +422,8 @@ cdef class HttpProtocol:
         length[0] += <Py_ssize_t>n
         return 0
 
-    cdef void _flush_header(self):
-        cdef Headers headers
-        if self.reading_exchange is None or self.name_len == 0:
-            self.name_len = 0
-            self.value_len = 0
-            self.have_value = False
-            return
-        headers = self.reading_exchange.request_headers
-        if self.value_buf == NULL:
-            headers.add_raw(self.name_buf, <size_t>self.name_len, "", 0)
-        else:
-            headers.add_raw(
-                self.name_buf,
-                <size_t>self.name_len,
-                self.value_buf,
-                <size_t>self.value_len,
-            )
-        self.name_len = 0
-        self.value_len = 0
-        self.have_value = False
-
     cdef void _on_message_begin(self):
         self.url_len = 0
-        self.name_len = 0
-        self.value_len = 0
-        self.have_value = False
         if self.idle_exchange is not None:
             self.reading_exchange = self.idle_exchange
             self.idle_exchange = None
@@ -493,24 +458,22 @@ cdef class HttpProtocol:
             self._close_error(431, "Request header fields too large")
 
     cdef void _on_header_field(self, const char* at, size_t length):
-        if self.have_value:
-            self._flush_header()
         self.head_bytes += <int>length
         if self.head_bytes > self.max_header_bytes:
             self._close_error(431, "Request header fields too large")
             return
-        if self._append(&self.name_buf, &self.name_len, &self.name_cap, at, length) != 0:
-            self._close_error(431, "Request header fields too large")
+        self.reading_exchange.request_headers.append_raw_name(at, length)
 
     cdef void _on_header_value(self, const char* at, size_t length):
         self.head_bytes += <int>length
         if self.head_bytes > self.max_header_bytes:
             self._close_error(431, "Request header fields too large")
             return
-        if self._append(&self.value_buf, &self.value_len, &self.value_cap, at, length) != 0:
-            self._close_error(431, "Request header fields too large")
-            return
-        self.have_value = True
+        self.reading_exchange.request_headers.append_raw_value(at, length)
+
+    cdef void _on_header_value_complete(self):
+        if self.reading_exchange is not None:
+            self.reading_exchange.request_headers.finish_raw_header()
 
     cdef void _on_headers_complete(self):
         cdef RequestExchange exchange
@@ -520,10 +483,10 @@ cdef class HttpProtocol:
             self.url = PyBytes_FromStringAndSize(self.url_buf, self.url_len)
         else:
             self.url = b""
-        self._flush_header()
         if self.rejected or self.reading_exchange is None:
             return
         exchange = self.reading_exchange
+        exchange.request_headers.finish_raw_header()
         if llhttp_get_upgrade(self.parser):
             self._close_error(400, "Upgrade not supported")
             return

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -513,16 +513,14 @@ cdef class HttpProtocol:
             if self.transport is not None:
                 self.transport.pause_reading()
 
-    cdef void _start_exchange(self, RequestExchange exchange, bint eager):
-        cdef object task
+    cdef void _start_exchange(self, RequestExchange exchange, bint eager_start):
         self.active_exchange = exchange
         exchange.start_response()
-        if eager:
-            self.app.create_task(self._run(exchange), loop=self.loop)
-            return
-        task = asyncio.Task(self._run(exchange), loop=self.loop)
-        self.app.tasks.add(task)
-        task.add_done_callback(self.app.tasks.discard)
+        self.app.create_task(
+            self._run(exchange),
+            loop=self.loop,
+            eager_start=eager_start,
+        )
 
     async def _run(self, RequestExchange exchange):
         try:

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -17,6 +17,10 @@ from stario_cython.llhttp cimport *
 from stario_cython.request cimport Request
 
 cdef int F_CONTENT_LENGTH = 0x20
+cdef int PAUSE_WRITE = 1
+cdef int PAUSE_PIPELINE = 2
+cdef int PAUSE_BODY = 4
+cdef int PARSER_QUANTUM = 64 * 1024
 # Handlers always start at headers-complete. Body bytes accumulate on the exchange;
 # body() awaits one completion Event, stream() drains with backpressure.
 
@@ -190,6 +194,11 @@ cdef class HttpProtocol:
     cdef bint rejected
     cdef bint request_dispatched
     cdef bint request_keep_alive
+    cdef int pause_reasons
+    cdef object body_pause_owner
+    cdef object held_data
+    cdef Py_ssize_t held_offset
+    cdef bint pump_scheduled
 
     def __cinit__(self):
         _bind_settings()
@@ -212,6 +221,11 @@ cdef class HttpProtocol:
         self.reading_exchange = None
         self.active_exchange = None
         self.idle_exchange = None
+        self.pause_reasons = 0
+        self.body_pause_owner = None
+        self.held_data = None
+        self.held_offset = 0
+        self.pump_scheduled = False
 
     def __dealloc__(self):
         if self.parser != NULL:
@@ -262,6 +276,11 @@ cdef class HttpProtocol:
         self.transport = transport
         self.closed = False
         self.disconnect = None
+        self.pause_reasons = 0
+        self.body_pause_owner = None
+        self.held_data = None
+        self.held_offset = 0
+        self.pump_scheduled = False
         self.connections.add(self)
 
     def ensure_disconnect(self):
@@ -292,6 +311,11 @@ cdef class HttpProtocol:
             self.active_exchange.c_abort()
         if self.disconnect is not None and not self.disconnect.done():
             self.disconnect.set_result(None)
+        self.pause_reasons = 0
+        self.body_pause_owner = None
+        self.held_data = None
+        self.held_offset = 0
+        self.pump_scheduled = False
         self.transport = None
 
     def recycle_exchange(self, RequestExchange exchange):
@@ -305,26 +329,97 @@ cdef class HttpProtocol:
         return False
 
     def data_received(self, data):
+        if self.rejected or self.parser == NULL or not data:
+            return
+        if self.held_data is not None:
+            self.held_data = self.held_data[self.held_offset :] + data
+            self.held_offset = 0
+            return
+        if self.pause_reasons:
+            self.held_data = data
+            self.held_offset = 0
+            return
+        self._pump_data(data, 0)
+
+    cdef void _pump_data(self, object data, Py_ssize_t offset):
         cdef const char* ptr
         cdef Py_ssize_t n
+        cdef Py_ssize_t end
         cdef int err
-        if self.rejected or self.parser == NULL:
-            return
         n = len(data)
-        if n == 0:
-            return
         ptr = <const char*>data
-        err = llhttp_execute(self.parser, ptr, <size_t>n)
-        if err != HPE_OK:
-            self._close_error(400, "Invalid HTTP request")
+        while offset < n:
+            end = offset + PARSER_QUANTUM
+            if end > n:
+                end = n
+            err = llhttp_execute(
+                self.parser,
+                ptr + offset,
+                <size_t>(end - offset),
+            )
+            if err != HPE_OK:
+                self._close_error(400, "Invalid HTTP request")
+                return
+            offset = end
+            if self.pause_reasons:
+                if offset < n:
+                    self.held_data = data
+                    self.held_offset = offset
+                return
+
+    cdef void _set_pause_reason(self, int reason, bint paused):
+        cdef int previous = self.pause_reasons
+        cdef object transport = self.transport
+        if paused:
+            self.pause_reasons |= reason
+        else:
+            self.pause_reasons &= ~reason
+        if previous == self.pause_reasons:
+            return
+        if previous == 0:
+            if transport is not None and not transport.is_closing():
+                transport.pause_reading()
+            return
+        if self.pause_reasons != 0:
+            return
+        if self.held_data is not None:
+            if not self.pump_scheduled:
+                self.pump_scheduled = True
+                self.loop.call_soon(self._resume_held_input)
+            return
+        if transport is not None and not transport.is_closing():
+            transport.resume_reading()
+
+    def _resume_held_input(self):
+        cdef object data
+        cdef Py_ssize_t offset
+        cdef object transport
+        self.pump_scheduled = False
+        if self.pause_reasons or self.held_data is None:
+            return
+        data = self.held_data
+        offset = self.held_offset
+        self.held_data = None
+        self.held_offset = 0
+        self._pump_data(data, offset)
+        if self.pause_reasons == 0 and self.held_data is None:
+            transport = self.transport
+            if transport is not None and not transport.is_closing():
+                transport.resume_reading()
+
+    def set_body_paused(self, exchange, paused):
+        if paused:
+            self.body_pause_owner = exchange
+            self._set_pause_reason(PAUSE_BODY, True)
+        elif self.body_pause_owner is exchange:
+            self.body_pause_owner = None
+            self._set_pause_reason(PAUSE_BODY, False)
 
     def pause_writing(self):
-        if self.transport is not None and not self.transport.is_closing():
-            self.transport.pause_reading()
+        self._set_pause_reason(PAUSE_WRITE, True)
 
     def resume_writing(self):
-        if self.transport is not None and not self.transport.is_closing():
-            self.transport.resume_reading()
+        self._set_pause_reason(PAUSE_WRITE, False)
 
     cdef int _append(self, char** buf, Py_ssize_t* length, Py_ssize_t* cap, const char* at, size_t n):
         if _grow(buf, cap, length[0] + <Py_ssize_t>n) != 0:
@@ -515,8 +610,7 @@ cdef class HttpProtocol:
             self._start_exchange(exchange, True)
         else:
             self.pending_exchanges.append(exchange)
-            if self.transport is not None:
-                self.transport.pause_reading()
+            self._set_pause_reason(PAUSE_PIPELINE, True)
 
     cdef void _start_exchange(self, RequestExchange exchange, bint eager_start):
         self.active_exchange = exchange
@@ -569,8 +663,10 @@ cdef class HttpProtocol:
         if self.pending_exchanges:
             next_exchange = self.pending_exchanges.pop(0)
             self._start_exchange(next_exchange, False)
+            if not self.pending_exchanges:
+                self._set_pause_reason(PAUSE_PIPELINE, False)
             return
-        transport.resume_reading()
+        self._set_pause_reason(PAUSE_PIPELINE, False)
 
     cdef void _close_error(self, int status, object message):
         cdef object transport

--- a/src/stario_cython/request.pyx
+++ b/src/stario_cython/request.pyx
@@ -7,6 +7,8 @@ from stario import cookies as cookie_helpers
 from stario.exceptions import HttpException
 from stario.http.query import ParsedQuery
 
+from stario_cython.headers cimport Headers
+
 
 cdef class Request:
     def __init__(
@@ -49,13 +51,22 @@ cdef class Request:
     def host(self):
         cdef object host_str
         cdef object host
+        cdef object host_wire
         cdef object rest
         cdef object host_part
         cdef object port_part
         cdef Py_ssize_t bracket_end
         if self._host is not None:
             return self._host
-        host_str = (self.headers.get("host") or "").strip()
+        if isinstance(self.headers, Headers):
+            host_wire = (<Headers>self.headers).c_request_host()
+            host_str = (
+                host_wire.decode("latin-1").strip()
+                if host_wire is not None
+                else ""
+            )
+        else:
+            host_str = (self.headers.get("host") or "").strip()
         if not host_str:
             self._host = ""
         elif host_str.startswith("["):

--- a/tests/cython/test_headers_writer.py
+++ b/tests/cython/test_headers_writer.py
@@ -148,6 +148,58 @@ async def test_exchange_respond_native_compression_round_trip(
             await writer.wait_closed()
 
 
+@pytest.mark.parametrize(
+    ("accept_encoding", "expected"),
+    [
+        (b"gzip;q=1, br;q=0.5", b"gzip"),
+        (b"gzip;q=0.5, br;q=0.5", b"br"),
+        (b"BR;Q=1", b"br"),
+        (b"*;q=0.8, identity;q=1", None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_native_compression_qvalue_negotiation(
+    accept_encoding: bytes,
+    expected: bytes | None,
+) -> None:
+    app = App()
+    body = b"compression negotiation " * 32
+
+    async def compressed(_c, w):
+        w.respond(body, b"text/plain")
+
+    app.get("/", compressed)
+    async with _running_server(
+        app,
+        date=b"date: now\r\n",
+        compression=CompressionConfig(
+            min_size=0,
+            brotli_level=4,
+            zstd_level=-1,
+            gzip_level=6,
+        ),
+    ) as port:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            writer.write(
+                b"GET / HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"Accept-Encoding: "
+                + accept_encoding
+                + b"\r\nConnection: keep-alive, CLOSE\r\n\r\n"
+            )
+            await writer.drain()
+            payload = await _read_response(reader)
+            header = payload.split(b"\r\n\r\n", 1)[0] + b"\r\n"
+            if expected is None:
+                assert b"content-encoding:" not in header
+            else:
+                assert b"content-encoding: " + expected + b"\r\n" in header
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+
 @pytest.mark.asyncio
 async def test_exchange_sse_gzip_flushes_each_write() -> None:
     app = App()

--- a/tests/cython/test_headers_writer.py
+++ b/tests/cython/test_headers_writer.py
@@ -200,6 +200,52 @@ async def test_native_compression_qvalue_negotiation(
             await writer.wait_closed()
 
 
+@pytest.mark.parametrize(
+    ("content_type", "compressed"),
+    [
+        (b" Text/Plain ; charset=utf-8", True),
+        (b"IMAGE/PNG; charset=binary", False),
+        (b"application/zip", False),
+        (b"; charset=utf-8", False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_native_content_type_compression_check(
+    content_type: bytes,
+    compressed: bool,
+) -> None:
+    app = App()
+
+    async def respond(_c, w):
+        w.respond(b"x" * 1024, content_type)
+
+    app.get("/", respond)
+    async with _running_server(
+        app,
+        date=b"date: now\r\n",
+        compression=CompressionConfig(
+            min_size=0,
+            brotli_level=-1,
+            zstd_level=-1,
+            gzip_level=6,
+        ),
+    ) as port:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            writer.write(
+                b"GET / HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"Accept-Encoding: gzip\r\n"
+                b"Connection: close\r\n\r\n"
+            )
+            await writer.drain()
+            header = (await _read_response(reader)).split(b"\r\n\r\n", 1)[0]
+            assert (b"content-encoding: gzip\r\n" in header + b"\r\n") is compressed
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+
 @pytest.mark.asyncio
 async def test_exchange_sse_gzip_flushes_each_write() -> None:
     app = App()

--- a/tests/cython/test_protocol.py
+++ b/tests/cython/test_protocol.py
@@ -103,6 +103,52 @@ async def test_plaintext_and_post_and_keepalive() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fragmented_headers_materialize_correctly() -> None:
+    loop = asyncio.get_running_loop()
+    app = App()
+
+    async def inspect(c, w):
+        assert c.req.host == "example.com"
+        assert c.req.headers.getlist("x-test") == ["one", "two"]
+        responses.text(w, "ok")
+
+    app.get("/", inspect)
+    connections: set[HttpProtocol] = set()
+    server = await loop.create_server(
+        lambda: HttpProtocol(
+            loop,
+            app,
+            NoOpTracer(),
+            [b"date: Tue, 18 Aug 2026 00:00:00 GMT\r\n"],
+            CompressionConfig(),
+            connections,
+        ),
+        "127.0.0.1",
+        _free_port(),
+    )
+    port = server.sockets[0].getsockname()[1]
+    request = (
+        b"GET / HTTP/1.1\r\n"
+        b"Host: Example.COM:80\r\n"
+        b"X-Test: one\r\n"
+        b"x-test: two\r\n"
+        b"Connection: close\r\n\r\n"
+    )
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        for byte in request:
+            writer.write(bytes((byte,)))
+            await writer.drain()
+            await asyncio.sleep(0)
+        assert b"ok" in await _read_response(reader)
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
 async def test_stream_large_and_chunked_upload() -> None:
     loop = asyncio.get_running_loop()
     app = App()

--- a/tests/cython/test_protocol.py
+++ b/tests/cython/test_protocol.py
@@ -621,13 +621,13 @@ async def test_next_request_starts_after_respond_before_handler_returns() -> Non
 async def test_stream_max_chunk_must_be_below_high_water() -> None:
     loop = asyncio.get_running_loop()
     app = App()
-    errors: list[BaseException] = []
+    errors: list[ValueError] = []
 
     async def upload(c, w):
         try:
             async for _ in c.req.stream(max_chunk=256 * 1024):
                 pass
-        except BaseException as exc:
+        except ValueError as exc:
             errors.append(exc)
             raise
         w.respond(b"ok", b"text/plain")
@@ -657,9 +657,8 @@ async def test_stream_max_chunk_must_be_below_high_water() -> None:
         )
         await writer.drain()
         response = await _read_response(reader)
-        assert b"500" in response.split(b"\r\n", 1)[0] or errors
+        assert b"500" in response.split(b"\r\n", 1)[0]
         assert errors
-        assert isinstance(errors[0], ValueError)
         assert "high water" in str(errors[0])
         writer.close()
         await writer.wait_closed()

--- a/tests/cython/test_protocol.py
+++ b/tests/cython/test_protocol.py
@@ -475,7 +475,7 @@ async def test_pipeline_waits_for_handler_and_uses_each_request_keepalive() -> N
 
 
 @pytest.mark.asyncio
-async def test_large_single_read_pipeline_resumes_without_losing_bytes() -> None:
+async def test_large_single_read_pipeline_is_bounded() -> None:
     loop = asyncio.get_running_loop()
     app = App()
     release = asyncio.Event()
@@ -503,29 +503,24 @@ async def test_large_single_read_pipeline_resumes_without_losing_bytes() -> None
         _free_port(),
     )
     port = server.sockets[0].getsockname()[1]
-    request_count = 64
+    request_count = 128
     requests = []
     for index in range(request_count):
-        connection = b"Connection: close\r\n" if index == request_count - 1 else b""
         requests.append(
             b"GET /?"
             + str(index).encode("ascii")
             + b" HTTP/1.1\r\nHost: localhost\r\n"
-            + connection
             + b"\r\n"
         )
     try:
         reader, writer = await asyncio.open_connection("127.0.0.1", port)
         writer.write(b"".join(requests))
         await writer.drain()
-        await asyncio.sleep(0)
-        assert handled == [0]
+        response = await _read_response(reader)
+        assert response.startswith(b"HTTP/1.1 429")
         release.set()
-        for index in range(request_count):
-            async with asyncio.timeout(2):
-                response = await _read_response(reader)
-            assert response.endswith(str(index).encode("ascii"))
-        assert handled == list(range(request_count))
+        assert handled == [0]
+        assert await reader.read() == b""
         writer.close()
         await writer.wait_closed()
     finally:

--- a/tests/cython/test_protocol.py
+++ b/tests/cython/test_protocol.py
@@ -475,6 +475,64 @@ async def test_pipeline_waits_for_handler_and_uses_each_request_keepalive() -> N
 
 
 @pytest.mark.asyncio
+async def test_large_single_read_pipeline_resumes_without_losing_bytes() -> None:
+    loop = asyncio.get_running_loop()
+    app = App()
+    release = asyncio.Event()
+    handled: list[int] = []
+
+    async def endpoint(c, w):
+        index = int(c.req.query_bytes)
+        handled.append(index)
+        if index == 0:
+            await release.wait()
+        w.respond(str(index).encode("ascii"), b"text/plain")
+
+    app.get("/", endpoint)
+    connections: set[HttpProtocol] = set()
+    server = await loop.create_server(
+        lambda: HttpProtocol(
+            loop,
+            app,
+            NoOpTracer(),
+            [b"date: Tue, 18 Aug 2026 00:00:00 GMT\r\n"],
+            CompressionConfig(),
+            connections,
+        ),
+        "127.0.0.1",
+        _free_port(),
+    )
+    port = server.sockets[0].getsockname()[1]
+    request_count = 64
+    requests = []
+    for index in range(request_count):
+        connection = b"Connection: close\r\n" if index == request_count - 1 else b""
+        requests.append(
+            b"GET /?"
+            + str(index).encode("ascii")
+            + b" HTTP/1.1\r\nHost: localhost\r\n"
+            + connection
+            + b"\r\n"
+        )
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(b"".join(requests))
+        await writer.drain()
+        await asyncio.sleep(0)
+        assert handled == [0]
+        release.set()
+        for index in range(request_count):
+            response = await _read_response(reader)
+            assert response.endswith(str(index).encode("ascii"))
+        assert handled == list(range(request_count))
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
 async def test_pipelined_streaming_bodies_are_request_owned() -> None:
     loop = asyncio.get_running_loop()
     app = App()
@@ -728,7 +786,7 @@ async def test_next_request_starts_after_respond_before_handler_returns() -> Non
 
 
 @pytest.mark.asyncio
-async def test_stream_max_chunk_must_be_below_high_water() -> None:
+async def test_stream_max_chunk_must_be_below_limit() -> None:
     loop = asyncio.get_running_loop()
     app = App()
     errors: list[ValueError] = []
@@ -769,7 +827,7 @@ async def test_stream_max_chunk_must_be_below_high_water() -> None:
         response = await _read_response(reader)
         assert b"500" in response.split(b"\r\n", 1)[0]
         assert errors
-        assert "high water" in str(errors[0])
+        assert "stream chunk limit" in str(errors[0])
         writer.close()
         await writer.wait_closed()
     finally:

--- a/tests/cython/test_protocol.py
+++ b/tests/cython/test_protocol.py
@@ -522,7 +522,8 @@ async def test_large_single_read_pipeline_resumes_without_losing_bytes() -> None
         assert handled == [0]
         release.set()
         for index in range(request_count):
-            response = await _read_response(reader)
+            async with asyncio.timeout(2):
+                response = await _read_response(reader)
             assert response.endswith(str(index).encode("ascii"))
         assert handled == list(range(request_count))
         writer.close()

--- a/tests/cython/test_protocol.py
+++ b/tests/cython/test_protocol.py
@@ -224,6 +224,59 @@ async def test_ignored_slow_body_stays_owned_until_message_complete() -> None:
 
 
 @pytest.mark.asyncio
+async def test_abandoned_stream_discards_remainder_and_advances_pipeline() -> None:
+    loop = asyncio.get_running_loop()
+    app = App()
+
+    async def partial(c, w):
+        async for _ in c.req.stream():
+            break
+        responses.text(w, "partial")
+
+    async def next_request(_c, w):
+        responses.text(w, "next")
+
+    app.post("/partial", partial)
+    app.get("/next", next_request)
+    connections: set[HttpProtocol] = set()
+    server = await loop.create_server(
+        lambda: HttpProtocol(
+            loop,
+            app,
+            NoOpTracer(),
+            [b"date: Tue, 18 Aug 2026 00:00:00 GMT\r\n"],
+            CompressionConfig(),
+            connections,
+        ),
+        "127.0.0.1",
+        _free_port(),
+    )
+    port = server.sockets[0].getsockname()[1]
+    payload = b"x" * (2 * 1024 * 1024)
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(
+            b"POST /partial HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Content-Length: "
+            + str(len(payload)).encode("ascii")
+            + b"\r\n\r\n"
+            + payload
+            + b"GET /next HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Connection: close\r\n\r\n"
+        )
+        await writer.drain()
+        assert b"partial" in await _read_response(reader)
+        assert b"next" in await _read_response(reader)
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
 async def test_small_expect_continue_is_sent_before_body() -> None:
     loop = asyncio.get_running_loop()
     app = App()

--- a/tests/cython/test_protocol.py
+++ b/tests/cython/test_protocol.py
@@ -12,6 +12,16 @@ from stario.telemetry.noop import NoOpTracer
 from stario_cython.protocol import HttpProtocol
 
 
+class TrackingApp(App):
+    def __init__(self) -> None:
+        super().__init__()
+        self.eager_starts: list[bool] = []
+
+    def create_task(self, coro, **kwargs):
+        self.eager_starts.append(kwargs.get("eager_start", False))
+        return super().create_task(coro, **kwargs)
+
+
 def _free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
@@ -33,7 +43,7 @@ async def _read_response(reader: asyncio.StreamReader) -> bytes:
 @pytest.mark.asyncio
 async def test_plaintext_and_post_and_keepalive() -> None:
     loop = asyncio.get_running_loop()
-    app = App()
+    app = TrackingApp()
     writers = []
 
     async def plaintext(_c, w):
@@ -83,6 +93,7 @@ async def test_plaintext_and_post_and_keepalive() -> None:
         await writer.drain()
         second = await _read_response(reader)
         assert b"abcde" in second
+        assert app.eager_starts == [True, True]
         assert writers[0] is writers[1]
         writer.close()
         await writer.wait_closed()

--- a/tests/cython/test_protocol.py
+++ b/tests/cython/test_protocol.py
@@ -704,7 +704,7 @@ async def test_stream_respects_max_chunk_batches() -> None:
         _free_port(),
     )
     port = server.sockets[0].getsockname()[1]
-    payload = b"z" * (40 * 1024)
+    payload = b"z" * (2 * 1024 * 1024)
     try:
         reader, writer = await asyncio.open_connection("127.0.0.1", port)
         writer.write(
@@ -716,7 +716,7 @@ async def test_stream_respects_max_chunk_batches() -> None:
             + payload
         )
         await writer.drain()
-        assert b"40960" in await _read_response(reader)
+        assert b"2097152" in await _read_response(reader)
         assert sizes
         assert all(size <= 8 * 1024 for size in sizes)
         assert any(size == 8 * 1024 for size in sizes[:-1] or sizes)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -44,7 +44,7 @@ class TestContextCreateTask:
         assert not context.app.tasks
 
     async def test_eager_task_completes_without_registration(self) -> None:
-        context = make_context()
+        context = make_context(loop=asyncio.get_running_loop())
         started = False
 
         async def worker() -> int:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -43,6 +43,22 @@ class TestContextCreateTask:
         await asyncio.sleep(0)
         assert not context.app.tasks
 
+    async def test_eager_task_completes_without_registration(self) -> None:
+        context = make_context()
+        started = False
+
+        async def worker() -> int:
+            nonlocal started
+            started = True
+            return 42
+
+        task = context.app.create_task(worker(), eager_start=True)
+
+        assert started
+        assert task.done()
+        assert task.result() == 42
+        assert task not in context.app.tasks
+
 
 class TestServerConstructorValidation:
     def test_header_limit_below_minimum_raises(self) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -59,6 +59,27 @@ class TestContextCreateTask:
         assert task.result() == 42
         assert task not in context.app.tasks
 
+    async def test_eager_task_uses_loop_task_factory(self) -> None:
+        loop = asyncio.get_running_loop()
+        context = make_context(loop=loop)
+        calls: list[bool] = []
+        previous = loop.get_task_factory()
+
+        def factory(loop, coro, **kwargs):
+            calls.append(kwargs.get("eager_start", False))
+            return asyncio.Task(coro, loop=loop, **kwargs)
+
+        async def worker() -> int:
+            return 42
+
+        loop.set_task_factory(factory)
+        try:
+            task = context.app.create_task(worker(), eager_start=True)
+            assert task.result() == 42
+            assert calls == [True]
+        finally:
+            loop.set_task_factory(previous)
+
 
 class TestServerConstructorValidation:
     def test_header_limit_below_minimum_raises(self) -> None:

--- a/vendor/compression_buf.c
+++ b/vendor/compression_buf.c
@@ -391,11 +391,6 @@ void stario_gzip_release(StarioGzip* gzip) {
         return;
     }
     trim_output(&gzip->out, &gzip->out_cap);
-    if (deflateReset(&gzip->strm) != Z_OK) {
-        stario_gzip_free(gzip);
-        return;
-    }
-    gzip->finished = 0;
     if (gzip_pool_count < STARIO_CODEC_POOL_MAX) {
         gzip_pool[gzip_pool_count++] = gzip;
     } else {

--- a/vendor/compression_buf.c
+++ b/vendor/compression_buf.c
@@ -15,6 +15,8 @@ struct StarioBrotli {
     unsigned char* out;
     size_t out_cap;
     int finished;
+    int level;
+    int window_log;
 };
 
 struct StarioGzip {
@@ -22,7 +24,25 @@ struct StarioGzip {
     unsigned char* out;
     size_t out_cap;
     int finished;
+    int level;
+    int window_bits;
 };
+
+#define STARIO_CODEC_POOL_MAX 32
+#define STARIO_RETAINED_OUTPUT_MAX (64 * 1024)
+
+static StarioBrotli* brotli_pool[STARIO_CODEC_POOL_MAX];
+static size_t brotli_pool_count = 0;
+static StarioGzip* gzip_pool[STARIO_CODEC_POOL_MAX];
+static size_t gzip_pool_count = 0;
+
+static void trim_output(unsigned char** out, size_t* cap) {
+    if (*cap > STARIO_RETAINED_OUTPUT_MAX) {
+        free(*out);
+        *out = NULL;
+        *cap = 0;
+    }
+}
 
 static int grow_buffer(unsigned char** buf, size_t* cap, size_t used) {
     size_t next_cap;
@@ -135,20 +155,12 @@ static int brotli_emit(
     return 0;
 }
 
-StarioBrotli* stario_brotli_new(int level, int window_log) {
-    StarioBrotli* brotli = (StarioBrotli*)malloc(sizeof(StarioBrotli));
+static int brotli_start(StarioBrotli* brotli, int level, int window_log) {
     uint32_t lgwin;
-
-    if (brotli == NULL) {
-        return NULL;
-    }
     brotli->state = BrotliEncoderCreateInstance(NULL, NULL, NULL);
-    brotli->out = NULL;
-    brotli->out_cap = 0;
     brotli->finished = 0;
     if (brotli->state == NULL) {
-        free(brotli);
-        return NULL;
+        return -1;
     }
     lgwin = window_log > 0 ? (uint32_t)window_log : STARIO_BROTLI_HTTP_WINDOW;
     if (
@@ -158,10 +170,39 @@ StarioBrotli* stario_brotli_new(int level, int window_log) {
         !BrotliEncoderSetParameter(brotli->state, BROTLI_PARAM_LGWIN, lgwin)
     ) {
         BrotliEncoderDestroyInstance(brotli->state);
+        brotli->state = NULL;
+        return -1;
+    }
+    brotli->level = level;
+    brotli->window_log = (int)lgwin;
+    return 0;
+}
+
+StarioBrotli* stario_brotli_new(int level, int window_log) {
+    StarioBrotli* brotli = (StarioBrotli*)calloc(1, sizeof(StarioBrotli));
+    if (brotli == NULL || brotli_start(brotli, level, window_log) != 0) {
         free(brotli);
         return NULL;
     }
     return brotli;
+}
+
+StarioBrotli* stario_brotli_acquire(int level, int window_log) {
+    StarioBrotli* brotli;
+    int resolved_window = window_log > 0 ? window_log : STARIO_BROTLI_HTTP_WINDOW;
+    size_t i;
+    for (i = 0; i < brotli_pool_count; i++) {
+        brotli = brotli_pool[i];
+        if (brotli->level == level && brotli->window_log == resolved_window) {
+            brotli_pool[i] = brotli_pool[--brotli_pool_count];
+            if (brotli_start(brotli, level, resolved_window) == 0) {
+                return brotli;
+            }
+            stario_brotli_free(brotli);
+            return NULL;
+        }
+    }
+    return stario_brotli_new(level, resolved_window);
 }
 
 int stario_brotli_block_borrowed(
@@ -209,6 +250,23 @@ void stario_brotli_free(StarioBrotli* brotli) {
     }
     free(brotli->out);
     free(brotli);
+}
+
+void stario_brotli_release(StarioBrotli* brotli) {
+    if (brotli == NULL) {
+        return;
+    }
+    if (brotli->state != NULL) {
+        BrotliEncoderDestroyInstance(brotli->state);
+        brotli->state = NULL;
+    }
+    brotli->finished = 0;
+    trim_output(&brotli->out, &brotli->out_cap);
+    if (brotli_pool_count < STARIO_CODEC_POOL_MAX) {
+        brotli_pool[brotli_pool_count++] = brotli;
+    } else {
+        stario_brotli_free(brotli);
+    }
 }
 
 static int gzip_deflate(
@@ -260,7 +318,7 @@ static int gzip_deflate(
     return 0;
 }
 
-StarioGzip* stario_gzip_new(int level) {
+StarioGzip* stario_gzip_new(int level, int window_bits) {
     StarioGzip* gzip = (StarioGzip*)malloc(sizeof(StarioGzip));
 
     if (gzip == NULL) {
@@ -268,7 +326,7 @@ StarioGzip* stario_gzip_new(int level) {
     }
     memset(&gzip->strm, 0, sizeof(gzip->strm));
     if (deflateInit2(
-        &gzip->strm, level, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY
+        &gzip->strm, level, Z_DEFLATED, 16 + window_bits, 8, Z_DEFAULT_STRATEGY
     ) != Z_OK) {
         free(gzip);
         return NULL;
@@ -276,7 +334,27 @@ StarioGzip* stario_gzip_new(int level) {
     gzip->out = NULL;
     gzip->out_cap = 0;
     gzip->finished = 0;
+    gzip->level = level;
+    gzip->window_bits = window_bits;
     return gzip;
+}
+
+StarioGzip* stario_gzip_acquire(int level, int window_bits) {
+    StarioGzip* gzip;
+    size_t i;
+    for (i = 0; i < gzip_pool_count; i++) {
+        gzip = gzip_pool[i];
+        if (gzip->level == level && gzip->window_bits == window_bits) {
+            gzip_pool[i] = gzip_pool[--gzip_pool_count];
+            if (deflateReset(&gzip->strm) != Z_OK) {
+                stario_gzip_free(gzip);
+                return NULL;
+            }
+            gzip->finished = 0;
+            return gzip;
+        }
+    }
+    return stario_gzip_new(level, window_bits);
 }
 
 int stario_gzip_block_borrowed(
@@ -306,4 +384,21 @@ void stario_gzip_free(StarioGzip* gzip) {
     deflateEnd(&gzip->strm);
     free(gzip->out);
     free(gzip);
+}
+
+void stario_gzip_release(StarioGzip* gzip) {
+    if (gzip == NULL) {
+        return;
+    }
+    trim_output(&gzip->out, &gzip->out_cap);
+    if (deflateReset(&gzip->strm) != Z_OK) {
+        stario_gzip_free(gzip);
+        return;
+    }
+    gzip->finished = 0;
+    if (gzip_pool_count < STARIO_CODEC_POOL_MAX) {
+        gzip_pool[gzip_pool_count++] = gzip;
+    } else {
+        stario_gzip_free(gzip);
+    }
 }

--- a/vendor/compression_buf.h
+++ b/vendor/compression_buf.h
@@ -9,6 +9,7 @@ typedef struct StarioGzip StarioGzip;
 /* Borrowed output is valid until the next call on the same encoder, or free. */
 
 StarioBrotli* stario_brotli_new(int level, int window_log);
+StarioBrotli* stario_brotli_acquire(int level, int window_log);
 int stario_brotli_block_borrowed(
     StarioBrotli* brotli,
     const unsigned char* in,
@@ -24,8 +25,10 @@ int stario_brotli_finish_borrowed(
     size_t* out_len
 );
 void stario_brotli_free(StarioBrotli* brotli);
+void stario_brotli_release(StarioBrotli* brotli);
 
-StarioGzip* stario_gzip_new(int level);
+StarioGzip* stario_gzip_new(int level, int window_bits);
+StarioGzip* stario_gzip_acquire(int level, int window_bits);
 int stario_gzip_block_borrowed(
     StarioGzip* gzip,
     const unsigned char* in,
@@ -41,5 +44,6 @@ int stario_gzip_finish_borrowed(
     size_t* out_len
 );
 void stario_gzip_free(StarioGzip* gzip);
+void stario_gzip_release(StarioGzip* gzip);
 
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- eagerly start active handlers while preserving custom event-loop task factories
- replace monolithic request accumulation with owned segments
  - exact allocation for known buffered bodies
  - direct stream segment yields
  - discard ignored or abandoned payload storage while preserving framing and limits
- lazily materialize request headers from reusable native arenas
  - parse llhttp fragments directly into offset-based storage
  - selectively materialize Host
  - preserve arbitrary names, duplicates, trailers, mutation, ordering, and public Headers behavior
- direct-dispatch ubiquitous names and hash remaining interned names
- cache native Accept-Encoding negotiation and media-type checks
- reuse gzip/Brotli wrappers and bounded output storage through 32-entry pools
- serialize writer-derived identity headers natively while retaining uvloop scatter/gather
- unify transport pause reasons and cap pending pipelined exchanges at 64
- trim oversized request arenas, body storage, response bytearrays, and compressor outputs before pooling

## Merge-prep decisions
- Removed the contiguous response serializer after it regressed throughput by 4–9% from entity-body copying.
- Removed 2 KiB inline header arenas after they enlarged pooled exchanges and regressed minimal requests by ~2.3%.
- Kept retained heap arenas: after warm-up they allocate zero times while preserving a compact exchange layout.
- Replaced experimental exact llhttp callback pausing with an explicit 64-exchange pipeline bound; this prevents single-read memory amplification without fragile parser resume offsets.
- Removed dead imports, request-header constants, parser buffers, helper declarations, and stale backpressure terminology.

## Verification
- Cython extensions build successfully with Python 3.14
- `PYTHONPATH=src .venv/bin/python -m pytest -q` — 692 passed
- targeted Pyright — 0 errors
- targeted Ruff — clean
- branch diff and whitespace checks — clean
- coverage includes fragmented headers, lazy materialization, trailers, abandoned bodies, multi-quantum uploads, pipeline limits, task factories, compression q-values, media types, and codec reuse

## Performance
Pinned-CPU adjacent comparisons on the shared VM showed directional improvements without common-path regressions:
- eager handler startup: plaintext +9.8%, JSON +5.9%
- latest lazy-header batch: plaintext +3.5%, JSON +3.2%, gzip +4.8%
- direct parser-to-arena: minimal headers +2.3%, browser-like headers +1.2%
- body-path comparisons: buffered 2 MiB about +10%, streamed 2 MiB about +8%

Small differences should be interpreted as parity because the shared VM is noisy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8434fade-4758-4baa-a99f-42f0661c8b06?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8434fade-4758-4baa-a99f-42f0661c8b06&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

