### PR TITLE
Add Go ports of the Cython server benchmark apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## Unreleased
 
+### Added
+
+- `STARIO_REUSE_PORT` — TCP `SO_REUSEPORT` so several Stario processes can
+  share one listen port. Off by default. Set `1` and start multiple
+  `stario serve` (or `python -m stario_cython`) processes on the same host/port.
+
 ## 4.1.0 - 2026-08-17
 
 ### Added

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,4 +1,5 @@
 .venvs/
+.bin/
 results/
 fixtures/*.bin
 fixtures/*.json

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -3,3 +3,5 @@
 results/
 fixtures/*.bin
 fixtures/*.json
+server/fixtures/*.bin
+server/fixtures/*.json

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -127,6 +127,7 @@ Measured numbers (this machine vs `baseline-20260824.md`) live in
 framework” without fighting Granian/Socketify on hello-world:
 `benchmarks/server/positioning.md`. HttpArena’s #1 Python (aiohttp)
 vs what our suite can and cannot say: `benchmarks/server/httparena-aiohttp.md`.
+Pyronova (Rust core, experimental+tuned): `benchmarks/server/httparena-pyronova.md`.
 
 ### Benchmark shape
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -99,9 +99,9 @@ paths, status codes, and per-request JSON/validation work as the Python apps.
 | `blacksheep-granian` | BlackSheep + Granian ASGI |
 | `blacksheep-uvicorn` | BlackSheep + Uvicorn |
 | `fastapi` | FastAPI + Uvicorn + Pydantic |
-| `aiohttp-n` | aiohttp + uvloop, `$BENCH_PROCS` processes, `SO_REUSEPORT` |
-| `litestar-n` | Litestar + Uvicorn, `$BENCH_PROCS` workers, uvloop/httptools |
-| `pyronova-n` | [Pyronova](https://github.com/leocaolab/pyronova), `$BENCH_PROCS` sub-interpreters |
+| `aiohttp` / `aiohttp-n` | aiohttp + uvloop; 1 process or `$BENCH_PROCS` + `SO_REUSEPORT` |
+| `litestar` / `litestar-n` | Litestar + Uvicorn uvloop/httptools; 1 or `$BENCH_PROCS` workers |
+| `pyronova` / `pyronova-n` | [Pyronova](https://github.com/leocaolab/pyronova); 1 or `$BENCH_PROCS` sub-interpreters |
 
 ### Comparing Go to Python
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -120,6 +120,9 @@ Pinning Go to one process with `GOMAXPROCS=1` is the right match for the
 committed one-worker baselines. Scaling Python to N processes is the right
 match for "run Go normally". Use `BENCH_PROCS` (default `nproc`) for both.
 
+Measured numbers (this machine vs `baseline-20260824.md`) live in
+`benchmarks/server/go-comparison.md`.
+
 ### Benchmark shape
 
 - One worker/process per target unless the name ends in `-n`.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -123,7 +123,10 @@ committed one-worker baselines. Scaling Python to N processes is the right
 match for "run Go normally". Use `BENCH_PROCS` (default `nproc`) for both.
 
 Measured numbers (this machine vs `baseline-20260824.md`) live in
-`benchmarks/server/go-comparison.md`.
+`benchmarks/server/go-comparison.md`. How to claim “fastest Python
+framework” without fighting Granian/Socketify on hello-world:
+`benchmarks/server/positioning.md`. HttpArena’s #1 Python (aiohttp)
+vs what our suite can and cannot say: `benchmarks/server/httparena-aiohttp.md`.
 
 ### Benchmark shape
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -67,6 +67,18 @@ server cannot be reused by accident.
 | `stario` | Python httptools protocol |
 | `stario-cython` | Cython llhttp protocol (`cython-core`) |
 
+**Go (same routes as `apps/stario_app.py`)**
+
+| Target | Server |
+| --- | --- |
+| `go-nethttp` | Go `net/http`, `GOMAXPROCS=1` |
+| `go-nethttp-n` | Go `net/http`, `GOMAXPROCS=$BENCH_PROCS` (default: `nproc`) |
+| `go-fasthttp` | [fasthttp](https://github.com/valyala/fasthttp), `GOMAXPROCS=1` |
+
+The Go servers live in `benchmarks/server/apps/go/` and implement the same
+paths, status codes, and per-request JSON/validation work as the Python apps.
+`encoding/json` is used on every response (no pre-serialized buffers).
+
 **Native HTTP servers**
 
 | Target | Server |
@@ -74,6 +86,7 @@ server cannot be reused by accident.
 | `socketify` | [Socketify.py](https://github.com/cirospaciari/socketify.py) (uWebSockets + libuv) |
 | `robyn` | [Robyn](https://github.com/sparckles/Robyn) (Rust/Actix) |
 | `granian-rsgi` | [Granian](https://github.com/emmett-framework/granian) RSGI (Rust, no framework) |
+| `granian-rsgi-n` | Granian RSGI with `$BENCH_PROCS` workers |
 | `sanic` | [Sanic](https://sanic.dev/) (uvloop) |
 | `django-bolt` | [Django-Bolt](https://bolt.farhana.li/) (Actix/Tokio) |
 
@@ -85,9 +98,31 @@ server cannot be reused by accident.
 | `blacksheep-uvicorn` | BlackSheep + Uvicorn |
 | `fastapi` | FastAPI + Uvicorn + Pydantic |
 
+### Comparing Go to Python
+
+A Go process is not the same unit of work as a Python process.
+
+- One **Go** process schedules goroutines on `GOMAXPROCS` OS threads (default:
+  every CPU). That is the normal way to run Go.
+- One **CPython** process is limited by the GIL for bytecode. Native bits
+  (Cython, uvloop, Rust servers) can use more than one core, but the usual
+  way to fill a box is still **N worker processes**.
+
+Do **not** compare default Go (`GOMAXPROCS=nCPU`) to one Python/Cython worker
+and call it a language result — that is cores vs one core. Two fair setups:
+
+| Question | Go | Python / Cython / Granian |
+| --- | --- | --- |
+| How fast is the code path? | `go-nethttp` or `go-fasthttp` (`GOMAXPROCS=1`) | existing 1-worker rows |
+| How much can this box do? | `go-nethttp-n` (one process, all cores) | `granian-rsgi-n` (N workers). Stario is still 1 process. |
+
+Pinning Go to one process with `GOMAXPROCS=1` is the right match for the
+committed one-worker baselines. Scaling Python to N processes is the right
+match for "run Go normally". Use `BENCH_PROCS` (default `nproc`) for both.
+
 ### Benchmark shape
 
-- One worker/process per target.
+- One worker/process per target unless the name ends in `-n`.
 - Same read paths: `/plaintext`, `/json`, `/user/42`.
 - Same upload/body paths (see **Endpoint tiers** below).
 - Same `wrk` settings per tier; large uploads use fewer connections
@@ -168,6 +203,7 @@ wire throughput of prebuilt buffers.
 
 - `uv`
 - `wrk`
+- `go` 1.22+ for the `go-*` targets
 - Python compatible with Stario (3.14+)
 - `libbrotli-dev` (or set `BROTLI_PKG_CONFIG`) for `stario-cython`
 
@@ -197,7 +233,7 @@ The default run benchmarks every target above.
 - `RUNS=7` measured samples per endpoint (plus `WARMUP=2` discarded warmup runs)
 - `ENDPOINT_TIER=all|read|upload` (default `all`)
 - `PORT=3000` as the base port
-- one process or worker per target
+- one process or worker per target (`go-nethttp-n` / `granian-rsgi-n` use `BENCH_PROCS`)
 
 Use those defaults when you want numbers that are easiest to compare with
 other local runs. The generated `config.txt` records the exact settings for
@@ -208,6 +244,7 @@ Common options:
 
 ```bash
 DURATION=30s THREADS=2 CONNECTIONS=128 RUNS=9 WARMUP=2 benchmarks/server/run.sh
+benchmarks/server/run.sh stario stario-cython go-nethttp go-nethttp-n go-fasthttp granian-rsgi granian-rsgi-n
 benchmarks/server/run.sh stario stario-cython socketify robyn granian-rsgi
 ENDPOINT_TIER=upload benchmarks/server/run.sh
 ENDPOINTS=validate,post-form,post-json-1k benchmarks/server/run.sh stario

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -99,6 +99,9 @@ paths, status codes, and per-request JSON/validation work as the Python apps.
 | `blacksheep-granian` | BlackSheep + Granian ASGI |
 | `blacksheep-uvicorn` | BlackSheep + Uvicorn |
 | `fastapi` | FastAPI + Uvicorn + Pydantic |
+| `aiohttp-n` | aiohttp + uvloop, `$BENCH_PROCS` processes, `SO_REUSEPORT` |
+| `litestar-n` | Litestar + Uvicorn, `$BENCH_PROCS` workers, uvloop/httptools |
+| `pyronova-n` | [Pyronova](https://github.com/leocaolab/pyronova), `$BENCH_PROCS` sub-interpreters |
 
 ### Comparing Go to Python
 
@@ -116,7 +119,7 @@ and call it a language result — that is cores vs one core. Two fair setups:
 | Question | Go | Python / Cython / Granian |
 | --- | --- | --- |
 | How fast is the code path? | `go-nethttp` or `go-fasthttp` (`GOMAXPROCS=1`) | existing 1-worker rows |
-| How much can this box do? | `go-nethttp-n` (one process, all cores) | `stario-n` / `stario-cython-n` (N processes, `STARIO_REUSE_PORT=1`) or `granian-rsgi-n` |
+| How much can this box do? | `go-nethttp-n` (one process, all cores) | `stario-n` / `stario-cython-n` / `aiohttp-n` (N processes, `SO_REUSEPORT`), `litestar-n` / `granian-rsgi-n` (N workers), or `pyronova-n` (N sub-interpreters) |
 
 Pinning Go to one process with `GOMAXPROCS=1` is the right match for the
 committed one-worker baselines. Scaling Python to N processes is the right

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -249,7 +249,7 @@ Common options:
 
 ```bash
 DURATION=30s THREADS=2 CONNECTIONS=128 RUNS=9 WARMUP=2 benchmarks/server/run.sh
-benchmarks/server/run.sh stario stario-cython go-nethttp go-nethttp-n go-fasthttp granian-rsgi granian-rsgi-n
+benchmarks/server/run.sh stario stario-cython stario-n stario-cython-n go-nethttp go-nethttp-n go-fasthttp granian-rsgi granian-rsgi-n
 benchmarks/server/run.sh stario stario-cython socketify robyn granian-rsgi
 ENDPOINT_TIER=upload benchmarks/server/run.sh
 ENDPOINTS=validate,post-form,post-json-1k benchmarks/server/run.sh stario

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -66,6 +66,8 @@ server cannot be reused by accident.
 | --- | --- |
 | `stario` | Python httptools protocol |
 | `stario-cython` | Cython llhttp protocol (`cython-core`) |
+| `stario-n` | `$BENCH_PROCS` Python processes, `STARIO_REUSE_PORT=1` |
+| `stario-cython-n` | `$BENCH_PROCS` Cython processes, `STARIO_REUSE_PORT=1` |
 
 **Go (same routes as `apps/stario_app.py`)**
 
@@ -114,7 +116,7 @@ and call it a language result — that is cores vs one core. Two fair setups:
 | Question | Go | Python / Cython / Granian |
 | --- | --- | --- |
 | How fast is the code path? | `go-nethttp` or `go-fasthttp` (`GOMAXPROCS=1`) | existing 1-worker rows |
-| How much can this box do? | `go-nethttp-n` (one process, all cores) | `granian-rsgi-n` (N workers). Stario is still 1 process. |
+| How much can this box do? | `go-nethttp-n` (one process, all cores) | `stario-n` / `stario-cython-n` (N processes, `STARIO_REUSE_PORT=1`) or `granian-rsgi-n` |
 
 Pinning Go to one process with `GOMAXPROCS=1` is the right match for the
 committed one-worker baselines. Scaling Python to N processes is the right
@@ -236,7 +238,7 @@ The default run benchmarks every target above.
 - `RUNS=7` measured samples per endpoint (plus `WARMUP=2` discarded warmup runs)
 - `ENDPOINT_TIER=all|read|upload` (default `all`)
 - `PORT=3000` as the base port
-- one process or worker per target (`go-nethttp-n` / `granian-rsgi-n` use `BENCH_PROCS`)
+- one process or worker per target (`*-n` uses `BENCH_PROCS`; Stario `-n` shares the listen socket with `STARIO_REUSE_PORT=1`)
 
 Use those defaults when you want numbers that are easiest to compare with
 other local runs. The generated `config.txt` records the exact settings for

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -131,6 +131,8 @@ framework” without fighting Granian/Socketify on hello-world:
 `benchmarks/server/positioning.md`. HttpArena’s #1 Python (aiohttp)
 vs what our suite can and cannot say: `benchmarks/server/httparena-aiohttp.md`.
 Pyronova (Rust core, experimental+tuned): `benchmarks/server/httparena-pyronova.md`.
+Same-machine production + 1-worker numbers vs aiohttp / Litestar /
+Pyronova: `benchmarks/server/production-peers.md`.
 
 ### Benchmark shape
 

--- a/benchmarks/server/apps/aiohttp_app.py
+++ b/benchmarks/server/apps/aiohttp_app.py
@@ -1,0 +1,120 @@
+# pyright: reportMissingImports=false
+
+"""aiohttp production bench: uvloop + SO_REUSEPORT.
+
+The runner starts ``BENCH_PROCS`` processes of this file. Each process binds
+the same port with ``reuse_port=True`` (HttpArena / production aiohttp).
+"""
+
+import argparse
+import asyncio
+import os
+
+import ujson
+import uvloop
+from aiohttp import web
+
+from apps.common import validate_fields
+
+HELLO = "Hello, World!"
+JSON_CONTENT_TYPE = "application/json"
+MAX_BODY = 4 * 1024 * 1024
+
+
+def json_response(value: object, status: int = 200) -> web.Response:
+    return web.Response(
+        body=ujson.dumps(value).encode("utf-8"),
+        status=status,
+        content_type=JSON_CONTENT_TYPE,
+    )
+
+
+async def plaintext(_request: web.Request) -> web.Response:
+    return web.Response(text=HELLO, content_type="text/plain")
+
+
+async def json_endpoint(_request: web.Request) -> web.Response:
+    return json_response({"message": HELLO})
+
+
+async def get_user(request: web.Request) -> web.Response:
+    user_id = request.match_info["user_id"]
+    return json_response({"id": user_id, "name": f"User {user_id}"})
+
+
+async def validate(request: web.Request) -> web.Response:
+    payload, status = validate_fields(ujson.loads(await request.read()))
+    return json_response(payload, status)
+
+
+async def post_form(request: web.Request) -> web.Response:
+    await request.read()
+    return web.Response(status=204)
+
+
+async def post_echo_json(request: web.Request) -> web.Response:
+    body = await request.read()
+    return json_response({"bytes": len(body)})
+
+
+async def ingest_buffer(request: web.Request) -> web.Response:
+    body = await request.read()
+    return json_response({"bytes": len(body)})
+
+
+async def ingest_stream(request: web.Request) -> web.Response:
+    total = 0
+    async for chunk in request.content.iter_any():
+        total += len(chunk)
+    return json_response({"bytes": total})
+
+
+async def upload(request: web.Request) -> web.Response:
+    body = await request.read()
+    return json_response({"bytes": len(body)})
+
+
+def build_app() -> web.Application:
+    app = web.Application(client_max_size=MAX_BODY)
+    app.router.add_get("/plaintext", plaintext)
+    app.router.add_get("/json", json_endpoint)
+    app.router.add_get("/user/{user_id}", get_user)
+    app.router.add_post("/validate", validate)
+    app.router.add_post("/form", post_form)
+    app.router.add_post("/echo/json", post_echo_json)
+    app.router.add_post("/ingest/64k", ingest_buffer)
+    app.router.add_post("/ingest/2m", ingest_buffer)
+    app.router.add_post("/ingest/stream/2m", ingest_stream)
+    app.router.add_post("/upload", upload)
+    return app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default=os.environ.get("BENCH_HOST", "127.0.0.1"))
+    parser.add_argument("--port", type=int, default=int(os.environ.get("BENCH_PORT", "3000")))
+    args = parser.parse_args()
+    reuse_port = os.environ.get("AIOHTTP_REUSE_PORT", "1") == "1"
+
+    uvloop.install()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    runner = web.AppRunner(build_app(), access_log=None)
+    loop.run_until_complete(runner.setup())
+    site = web.TCPSite(
+        runner,
+        args.host,
+        args.port,
+        reuse_port=reuse_port,
+        backlog=4096,
+        shutdown_timeout=1.0,
+    )
+    loop.run_until_complete(site.start())
+    try:
+        loop.run_forever()
+    finally:
+        loop.run_until_complete(runner.cleanup())
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/server/apps/go/fasthttp.go
+++ b/benchmarks/server/apps/go/fasthttp.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+
+	"github.com/valyala/fasthttp"
+)
+
+func serveFastHTTP(addr string) error {
+	server := &fasthttp.Server{
+		Handler:            fastHTTPHandler,
+		Name:               "",
+		ReadTimeout:        0,
+		WriteTimeout:       0,
+		IdleTimeout:        0,
+		MaxRequestBodySize:           4 * 1024 * 1024,
+		StreamRequestBody:            true,
+		DisablePreParseMultipartForm: true,
+		DisableKeepalive:             false,
+		ReduceMemoryUsage:  false,
+		// Keep Date. Python targets also emit Date; stripping it is a
+		// TechEmpower trick, not route-parity.
+		NoDefaultServerHeader: true,
+	}
+	return server.ListenAndServe(addr)
+}
+
+func fastHTTPHandler(ctx *fasthttp.RequestCtx) {
+	path := string(ctx.Path())
+	method := string(ctx.Method())
+
+	switch {
+	case method == fasthttp.MethodGet && path == "/plaintext":
+		ctx.SetContentType(textContentType)
+		ctx.SetStatusCode(fasthttp.StatusOK)
+		_, _ = ctx.WriteString(hello)
+	case method == fasthttp.MethodGet && path == "/json":
+		writeFastJSON(ctx, fasthttp.StatusOK, helloJSON())
+	case method == fasthttp.MethodGet && bytes.HasPrefix(ctx.Path(), []byte("/user/")):
+		writeFastJSON(ctx, fasthttp.StatusOK, userJSON(userIDFromPath(path)))
+	case method == fasthttp.MethodPost && path == "/validate":
+		body, err := fastReadBuffer(ctx)
+		if err != nil {
+			ctx.SetStatusCode(fasthttp.StatusBadRequest)
+			return
+		}
+		data, err := decodeObject(body)
+		if err != nil {
+			writeFastJSON(ctx, fasthttp.StatusBadRequest, marshalJSON(validateErr{Error: "invalid json"}))
+			return
+		}
+		payload, status := validateFields(data)
+		writeFastJSON(ctx, status, marshalJSON(payload))
+	case method == fasthttp.MethodPost && path == "/form":
+		_, _ = fastReadBuffer(ctx)
+		ctx.SetStatusCode(fasthttp.StatusNoContent)
+	case method == fasthttp.MethodPost && (path == "/echo/json" || path == "/ingest/64k" || path == "/ingest/2m" || path == "/upload"):
+		body, err := fastReadBuffer(ctx)
+		if err != nil {
+			ctx.SetStatusCode(fasthttp.StatusBadRequest)
+			return
+		}
+		writeFastJSON(ctx, fasthttp.StatusOK, bytesJSON(len(body)))
+	case method == fasthttp.MethodPost && path == "/ingest/stream/2m":
+		n, err := fastCountStream(ctx)
+		if err != nil {
+			ctx.SetStatusCode(fasthttp.StatusBadRequest)
+			return
+		}
+		writeFastJSON(ctx, fasthttp.StatusOK, bytesJSON(n))
+	default:
+		ctx.SetStatusCode(fasthttp.StatusNotFound)
+		_, _ = ctx.WriteString("Not Found")
+	}
+}
+
+func writeFastJSON(ctx *fasthttp.RequestCtx, status int, body []byte) {
+	ctx.SetContentType(jsonContentType)
+	ctx.SetStatusCode(status)
+	_, _ = ctx.Write(body)
+}
+
+func fastReadBuffer(ctx *fasthttp.RequestCtx) ([]byte, error) {
+	if ctx.IsBodyStream() {
+		return readAll(ctx.RequestBodyStream())
+	}
+	return append([]byte(nil), ctx.PostBody()...), nil
+}
+
+func fastCountStream(ctx *fasthttp.RequestCtx) (int, error) {
+	if ctx.IsBodyStream() {
+		return countStream(ctx.RequestBodyStream())
+	}
+	return countStream(bytes.NewReader(ctx.PostBody()))
+}

--- a/benchmarks/server/apps/go/go.mod
+++ b/benchmarks/server/apps/go/go.mod
@@ -1,0 +1,11 @@
+module stario/benchmarks/go
+
+go 1.22
+
+require github.com/valyala/fasthttp v1.58.0
+
+require (
+	github.com/andybalholm/brotli v1.1.1 // indirect
+	github.com/klauspost/compress v1.17.11 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+)

--- a/benchmarks/server/apps/go/go.sum
+++ b/benchmarks/server/apps/go/go.sum
@@ -1,0 +1,10 @@
+github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
+github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
+github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
+github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasthttp v1.58.0 h1:GGB2dWxSbEprU9j0iMJHgdKYJVDyjrOwF9RE59PbRuE=
+github.com/valyala/fasthttp v1.58.0/go.mod h1:SYXvHHaFp7QZHGKSHmoMipInhrI5StHrhDTYVEjK/Kw=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=

--- a/benchmarks/server/apps/go/handlers.go
+++ b/benchmarks/server/apps/go/handlers.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"math"
+	"strconv"
+)
+
+const (
+	hello           = "Hello, World!"
+	jsonContentType = "application/json"
+	textContentType = "text/plain; charset=utf-8"
+)
+
+type jsonMessage struct {
+	Message string `json:"message"`
+}
+
+type userMessage struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type byteCount struct {
+	Bytes int `json:"bytes"`
+}
+
+type validateOK struct {
+	Name  string `json:"name"`
+	Age   int    `json:"age"`
+	Valid bool   `json:"valid"`
+}
+
+type validateErr struct {
+	Error string `json:"error"`
+}
+
+func marshalJSON(value any) []byte {
+	// encoding/json each request — no cached response bytes (handler policy).
+	payload, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return payload
+}
+
+func helloJSON() []byte {
+	return marshalJSON(jsonMessage{Message: hello})
+}
+
+func userJSON(userID string) []byte {
+	return marshalJSON(userMessage{ID: userID, Name: "User " + userID})
+}
+
+func bytesJSON(n int) []byte {
+	return marshalJSON(byteCount{Bytes: n})
+}
+
+func validateFields(data map[string]any) (any, int) {
+	name, ok := data["name"].(string)
+	if !ok || name == "" {
+		return validateErr{Error: "name must be a non-empty string"}, 400
+	}
+	age, ok := asInt(data["age"])
+	if !ok || age < 0 || age > 150 {
+		return validateErr{Error: "age must be an integer between 0 and 150"}, 400
+	}
+	return validateOK{Name: name, Age: age, Valid: true}, 200
+}
+
+func asInt(value any) (int, bool) {
+	switch n := value.(type) {
+	case json.Number:
+		i, err := n.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(i), true
+	case float64:
+		if n != math.Trunc(n) {
+			return 0, false
+		}
+		return int(n), true
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	default:
+		return 0, false
+	}
+}
+
+func decodeObject(body []byte) (map[string]any, error) {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+	var data map[string]any
+	if err := dec.Decode(&data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func readAll(r io.Reader) ([]byte, error) {
+	return io.ReadAll(r)
+}
+
+func countStream(r io.Reader) (int, error) {
+	n, err := io.Copy(io.Discard, r)
+	return int(n), err
+}
+
+func userIDFromPath(path string) string {
+	const prefix = "/user/"
+	if len(path) <= len(prefix) || path[:len(prefix)] != prefix {
+		return ""
+	}
+	return path[len(prefix):]
+}
+
+func atoiDefault(s string, fallback int) int {
+	if s == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return fallback
+	}
+	return n
+}

--- a/benchmarks/server/apps/go/handlers_test.go
+++ b/benchmarks/server/apps/go/handlers_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/fasthttputil"
+)
+
+func TestValidateFields(t *testing.T) {
+	payload, status := validateFields(map[string]any{"name": "Ada", "age": json.Number("42")})
+	if status != 200 {
+		t.Fatalf("status=%d payload=%v", status, payload)
+	}
+	ok := payload.(validateOK)
+	if !ok.Valid || ok.Name != "Ada" || ok.Age != 42 {
+		t.Fatalf("unexpected payload %#v", ok)
+	}
+
+	_, status = validateFields(map[string]any{"name": "", "age": json.Number("42")})
+	if status != 400 {
+		t.Fatalf("empty name status=%d", status)
+	}
+	_, status = validateFields(map[string]any{"name": "Ada", "age": json.Number("999")})
+	if status != 400 {
+		t.Fatalf("bad age status=%d", status)
+	}
+	_, status = validateFields(map[string]any{"name": "Ada", "age": 42.5})
+	if status != 400 {
+		t.Fatalf("float age status=%d", status)
+	}
+}
+
+func TestNetHTTPRoutes(t *testing.T) {
+	server := httptest.NewServer(netHTTPHandler())
+	defer server.Close()
+	assertRouteParity(t, server.URL)
+}
+
+func TestFastHTTPRoutes(t *testing.T) {
+	ln := fasthttputil.NewInmemoryListener()
+	go func() {
+		_ = fasthttp.Serve(ln, fastHTTPHandler)
+	}()
+	t.Cleanup(func() { _ = ln.Close() })
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Dial: func(network, addr string) (net.Conn, error) {
+				return ln.Dial()
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+	assertRouteParityWithClient(t, "http://bench", client)
+}
+
+func assertRouteParity(t *testing.T, base string) {
+	t.Helper()
+	assertRouteParityWithClient(t, base, http.DefaultClient)
+}
+
+func assertRouteParityWithClient(t *testing.T, base string, client *http.Client) {
+	t.Helper()
+
+	res := mustDo(t, client, http.MethodGet, base+"/plaintext", "", nil)
+	if res.status != 200 || res.body != hello {
+		t.Fatalf("plaintext: status=%d body=%q", res.status, res.body)
+	}
+	if !strings.HasPrefix(res.contentType, "text/plain") {
+		t.Fatalf("plaintext content-type %q", res.contentType)
+	}
+
+	res = mustDo(t, client, http.MethodGet, base+"/json", "", nil)
+	assertJSON(t, res, 200, map[string]any{"message": hello})
+
+	res = mustDo(t, client, http.MethodGet, base+"/user/42", "", nil)
+	assertJSON(t, res, 200, map[string]any{"id": "42", "name": "User 42"})
+
+	res = mustDo(t, client, http.MethodPost, base+"/validate", "application/json", []byte(`{"name":"Ada","age":42}`))
+	assertJSON(t, res, 200, map[string]any{"name": "Ada", "age": float64(42), "valid": true})
+
+	res = mustDo(t, client, http.MethodPost, base+"/validate", "application/json", []byte(`{"name":"","age":42}`))
+	if res.status != 400 {
+		t.Fatalf("validate invalid: status=%d body=%s", res.status, res.body)
+	}
+
+	res = mustDo(t, client, http.MethodPost, base+"/form", "application/x-www-form-urlencoded", []byte("name=Ada&age=42&source=benchmark"))
+	if res.status != 204 {
+		t.Fatalf("form: status=%d", res.status)
+	}
+
+	payload := bytes.Repeat([]byte("x"), 1024)
+	res = mustDo(t, client, http.MethodPost, base+"/echo/json", "application/json", payload)
+	assertJSON(t, res, 200, map[string]any{"bytes": float64(1024)})
+
+	res = mustDo(t, client, http.MethodPost, base+"/ingest/64k", "application/octet-stream", bytes.Repeat([]byte{1}, 64))
+	assertJSON(t, res, 200, map[string]any{"bytes": float64(64)})
+
+	res = mustDo(t, client, http.MethodPost, base+"/ingest/2m", "application/octet-stream", bytes.Repeat([]byte{2}, 128))
+	assertJSON(t, res, 200, map[string]any{"bytes": float64(128)})
+
+	res = mustDo(t, client, http.MethodPost, base+"/ingest/stream/2m", "application/octet-stream", bytes.Repeat([]byte{3}, 256))
+	assertJSON(t, res, 200, map[string]any{"bytes": float64(256)})
+
+	multipart := []byte("--x\r\nContent-Disposition: form-data; name=\"file\"; filename=\"a.bin\"\r\nContent-Type: application/octet-stream\r\n\r\nxxxx\r\n--x--\r\n")
+	res = mustDo(t, client, http.MethodPost, base+"/upload", "multipart/form-data; boundary=x", multipart)
+	assertJSON(t, res, 200, map[string]any{"bytes": float64(len(multipart))})
+}
+
+type httpResult struct {
+	status      int
+	body        string
+	contentType string
+}
+
+func mustDo(t *testing.T, client *http.Client, method, url, contentType string, body []byte) httpResult {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return httpResult{status: resp.StatusCode, body: string(raw), contentType: resp.Header.Get("Content-Type")}
+}
+
+func assertJSON(t *testing.T, res httpResult, status int, want map[string]any) {
+	t.Helper()
+	if res.status != status {
+		t.Fatalf("status=%d want=%d body=%s", res.status, status, res.body)
+	}
+	if !strings.HasPrefix(res.contentType, jsonContentType) {
+		t.Fatalf("content-type %q", res.contentType)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(res.body), &got); err != nil {
+		t.Fatalf("json: %v body=%s", err, res.body)
+	}
+	for key, value := range want {
+		if got[key] != value {
+			t.Fatalf("json[%q]=%v want=%v body=%s", key, got[key], value, res.body)
+		}
+	}
+}

--- a/benchmarks/server/apps/go/main.go
+++ b/benchmarks/server/apps/go/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"runtime"
+)
+
+func main() {
+	impl := flag.String("impl", envOr("BENCH_IMPL", "nethttp"), "http stack: nethttp or fasthttp")
+	host := flag.String("host", envOr("BENCH_HOST", "127.0.0.1"), "bind host")
+	port := flag.Int("port", atoiDefault(os.Getenv("BENCH_PORT"), 3000), "bind port")
+	flag.Parse()
+
+	if n := os.Getenv("GOMAXPROCS"); n != "" {
+		log.Printf("go %s impl=%s GOMAXPROCS=%s (runtime=%d)", runtime.Version(), *impl, n, runtime.GOMAXPROCS(0))
+	} else {
+		log.Printf("go %s impl=%s GOMAXPROCS=%d", runtime.Version(), *impl, runtime.GOMAXPROCS(0))
+	}
+
+	addr := fmt.Sprintf("%s:%d", *host, *port)
+	var err error
+	switch *impl {
+	case "nethttp", "net/http", "stdlib":
+		err = serveNetHTTP(addr)
+	case "fasthttp":
+		err = serveFastHTTP(addr)
+	default:
+		log.Fatalf("unknown -impl %q (use nethttp or fasthttp)", *impl)
+	}
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func envOr(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/benchmarks/server/apps/go/nethttp.go
+++ b/benchmarks/server/apps/go/nethttp.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"time"
+)
+
+func netHTTPHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /plaintext", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", textContentType)
+		_, _ = io.WriteString(w, hello)
+	})
+	mux.HandleFunc("GET /json", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, helloJSON())
+	})
+	mux.HandleFunc("GET /user/{id}", func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+		writeJSON(w, http.StatusOK, userJSON(id))
+	})
+	mux.HandleFunc("POST /validate", func(w http.ResponseWriter, r *http.Request) {
+		body, err := readAll(r.Body)
+		if err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		data, err := decodeObject(body)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, marshalJSON(validateErr{Error: "invalid json"}))
+			return
+		}
+		payload, status := validateFields(data)
+		writeJSON(w, status, marshalJSON(payload))
+	})
+	mux.HandleFunc("POST /form", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = readAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("POST /echo/json", bufferedBytes(muxWriteJSON))
+	mux.HandleFunc("POST /ingest/64k", bufferedBytes(muxWriteJSON))
+	mux.HandleFunc("POST /ingest/2m", bufferedBytes(muxWriteJSON))
+	mux.HandleFunc("POST /ingest/stream/2m", func(w http.ResponseWriter, r *http.Request) {
+		n, err := countStream(r.Body)
+		if err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, bytesJSON(n))
+	})
+	mux.HandleFunc("POST /upload", bufferedBytes(muxWriteJSON))
+	return mux
+}
+
+type jsonWriter func(http.ResponseWriter, int, []byte)
+
+func muxWriteJSON(w http.ResponseWriter, status int, body []byte) {
+	writeJSON(w, status, body)
+}
+
+func bufferedBytes(write jsonWriter) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, err := readAll(r.Body)
+		if err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		write(w, http.StatusOK, bytesJSON(len(body)))
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, body []byte) {
+	w.Header().Set("Content-Type", jsonContentType)
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+}
+
+func serveNetHTTP(addr string) error {
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           netHTTPHandler(),
+		ReadHeaderTimeout: 30 * time.Second,
+		ReadTimeout:       120 * time.Second,
+		WriteTimeout:      120 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		MaxHeaderBytes:    1 << 16,
+	}
+	return server.ListenAndServe()
+}

--- a/benchmarks/server/apps/litestar_app.py
+++ b/benchmarks/server/apps/litestar_app.py
@@ -1,0 +1,92 @@
+# pyright: reportMissingImports=false
+
+"""Litestar production bench: uvicorn --workers N --loop uvloop --http httptools.
+
+Handlers return fresh values every request. JSON uses Litestar's default
+msgspec path (HttpArena / production). OpenAPI and compression stay off so
+the comparison matches our other framework rows.
+"""
+
+from litestar import Litestar, MediaType, Request, Response, get, post
+from litestar.status_codes import HTTP_204_NO_CONTENT
+
+from apps.common import validate_fields
+
+HELLO = "Hello, World!"
+MAX_BODY = 4 * 1024 * 1024
+
+
+@get("/plaintext", media_type=MediaType.TEXT, sync_to_thread=False)
+def plaintext() -> str:
+    return HELLO
+
+
+@get("/json", sync_to_thread=False)
+def json_endpoint() -> dict:
+    return {"message": HELLO}
+
+
+@get("/user/{user_id:str}", sync_to_thread=False)
+def get_user(user_id: str) -> dict:
+    return {"id": user_id, "name": f"User {user_id}"}
+
+
+@post("/validate")
+async def validate(request: Request) -> Response:
+    payload, status = validate_fields((await request.json()) or {})
+    return Response(payload, status_code=status)
+
+
+@post("/form", status_code=HTTP_204_NO_CONTENT)
+async def post_form(request: Request) -> None:
+    await request.body()
+
+
+@post("/echo/json")
+async def post_echo_json(request: Request) -> dict:
+    body = await request.body()
+    return {"bytes": len(body)}
+
+
+@post("/ingest/64k")
+async def ingest_64k(request: Request) -> dict:
+    body = await request.body()
+    return {"bytes": len(body)}
+
+
+@post("/ingest/2m")
+async def ingest_2m(request: Request) -> dict:
+    body = await request.body()
+    return {"bytes": len(body)}
+
+
+@post("/ingest/stream/2m")
+async def ingest_stream(request: Request) -> dict:
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+    return {"bytes": total}
+
+
+@post("/upload")
+async def upload(request: Request) -> dict:
+    body = await request.body()
+    return {"bytes": len(body)}
+
+
+app = Litestar(
+    route_handlers=[
+        plaintext,
+        json_endpoint,
+        get_user,
+        validate,
+        post_form,
+        post_echo_json,
+        ingest_64k,
+        ingest_2m,
+        ingest_stream,
+        upload,
+    ],
+    request_max_body_size=MAX_BODY,
+    openapi_config=None,
+)

--- a/benchmarks/server/apps/pyronova_app.py
+++ b/benchmarks/server/apps/pyronova_app.py
@@ -1,0 +1,89 @@
+# pyright: reportMissingImports=false
+
+"""Pyronova production bench: one process, PYRONOVA_WORKERS sub-interpreters.
+
+Honest handlers only — no ``add_fast_response``, no JSON byte cache, no
+``drain_count()``. JSON is a fresh dict each request (framework serde).
+Validate uses the stdlib decoder so the route can stay on a sub-interpreter
+(orjson / ujson need ``gil=True`` under PEP 684).
+"""
+
+import json
+import os
+
+from pyronova import Pyronova, Request, Response
+
+from apps.common import validate_fields
+
+HELLO = "Hello, World!"
+MAX_BODY = 4 * 1024 * 1024
+
+app = Pyronova()
+app.max_body_size = MAX_BODY
+
+
+@app.get("/plaintext")
+def plaintext(_req: Request):
+    return Response(HELLO, content_type="text/plain")
+
+
+@app.get("/json")
+def json_endpoint(_req: Request):
+    return {"message": HELLO}
+
+
+@app.get("/user/{user_id}")
+def get_user(req: Request):
+    user_id = req.params["user_id"]
+    return {"id": user_id, "name": f"User {user_id}"}
+
+
+@app.post("/validate")
+def validate(req: Request):
+    raw = req.body or b""
+    payload, status = validate_fields(json.loads(raw) if raw else {})
+    return Response(
+        json.dumps(payload),
+        status_code=status,
+        content_type="application/json",
+    )
+
+
+@app.post("/form")
+def post_form(req: Request):
+    _ = req.body
+    return Response("", status_code=204)
+
+
+@app.post("/echo/json")
+def post_echo_json(req: Request):
+    return {"bytes": len(req.body or b"")}
+
+
+@app.post("/ingest/64k")
+def ingest_64k(req: Request):
+    return {"bytes": len(req.body or b"")}
+
+
+@app.post("/ingest/2m")
+def ingest_2m(req: Request):
+    return {"bytes": len(req.body or b"")}
+
+
+@app.post("/ingest/stream/2m", stream=True)
+def ingest_stream(req: Request):
+    total = 0
+    for chunk in req.stream:
+        total += len(chunk)
+    return {"bytes": total}
+
+
+@app.post("/upload")
+def upload(req: Request):
+    return {"bytes": len(req.body or b"")}
+
+
+if __name__ == "__main__":
+    host = os.environ.get("BENCH_HOST", "127.0.0.1")
+    port = int(os.environ.get("BENCH_PORT", "3000"))
+    app.run(host=host, port=port)

--- a/benchmarks/server/apps/pyronova_app.py
+++ b/benchmarks/server/apps/pyronova_app.py
@@ -70,6 +70,7 @@ def ingest_2m(req: Request):
     return {"bytes": len(req.body or b"")}
 
 
+# stream=True requires gil=True on Pyronova 2.7 (engine limitation).
 @app.post("/ingest/stream/2m", gil=True, stream=True)
 def ingest_stream(req: Request):
     total = 0

--- a/benchmarks/server/apps/pyronova_app.py
+++ b/benchmarks/server/apps/pyronova_app.py
@@ -70,7 +70,7 @@ def ingest_2m(req: Request):
     return {"bytes": len(req.body or b"")}
 
 
-@app.post("/ingest/stream/2m", stream=True)
+@app.post("/ingest/stream/2m", gil=True, stream=True)
 def ingest_stream(req: Request):
     total = 0
     for chunk in req.stream:
@@ -84,6 +84,8 @@ def upload(req: Request):
 
 
 if __name__ == "__main__":
-    host = os.environ.get("BENCH_HOST", "127.0.0.1")
-    port = int(os.environ.get("BENCH_PORT", "3000"))
-    app.run(host=host, port=port)
+    host = os.environ.get("BENCH_HOST", os.environ.get("PYRONOVA_HOST", "127.0.0.1"))
+    port = int(os.environ.get("BENCH_PORT", os.environ.get("PYRONOVA_PORT", "3000")))
+    workers = int(os.environ.get("PYRONOVA_WORKERS") or (os.cpu_count() or 1))
+    io_workers = int(os.environ.get("PYRONOVA_IO_WORKERS") or workers)
+    app.run(host=host, port=port, workers=workers, io_workers=io_workers)

--- a/benchmarks/server/baseline-20260824.md
+++ b/benchmarks/server/baseline-20260824.md
@@ -3,6 +3,9 @@
 Reference for comparing **Stario Cython** (and Python) against native HTTP servers
 and ASGI stacks. Relative comparisons on one machine — not lab-grade absolutes.
 
+Go ports of the same app (`go-nethttp`, `go-fasthttp`, plus a 4-core /
+4-worker pairing) are in `go-comparison.md`.
+
 **Going forward:** treat the Stario Cython row as the baseline for Cython protocol
 work. Re-run the same suite after changes and compare median ± stdev to these numbers.
 

--- a/benchmarks/server/go-comparison.md
+++ b/benchmarks/server/go-comparison.md
@@ -77,10 +77,16 @@ on **one core** is the fastest 1-worker row — above 1-worker Granian and
 well above Cython. Stario Python remains ~1.2× behind 1-core `net/http` and
 ~2.5× behind 1-core fasthttp on plaintext.
 
-This-run Cython plaintext (97k) is below the committed primary (120k ± 25k)
-and closer to the confirmatory refresh (125k). Treat ratios against
-**this-run** Cython; the committed table is the historical anchor, not a
-second clock.
+The long-suite Cython plaintext median (97k) is **not** a different case
+and is **not** a real drop from the published ~120–125k. Same app, same
+`GET /plaintext`, same `wrk -t2 -c128`, one worker. That 97k window was
+three noisy 10s samples (93k / 101k / 97k) in a busy suite — params in
+the same run swung 74k–116k. An isolated re-run on this box
+(`20260825T191938Z`, 10s × 5 + 2 warmup) is **118,189 ± 3,338** (samples
+118–125k), matching the committed primary **120,378 ± 24,710** and the
+5s refresh **125,436 ± 4,971** (the ~130k figure). Use 118–125k as the
+1-worker Cython plaintext anchor; keep the 97k row only as “what that
+noisy suite printed.”
 
 ## Large-body (1-core)
 
@@ -118,7 +124,7 @@ Scaling (plaintext, 1 unit → 4 units):
 
 | | 1 → 4 | Notes |
 | --- | ---: | --- |
-| Stario Cython | 97k → 294k (**3.05×**) | 4 processes, `STARIO_REUSE_PORT=1` |
+| Stario Cython | 97k suite / 118k isolated → 294k (**~2.5–3.0×**) | 4 processes, `STARIO_REUSE_PORT=1` |
 | Stario Python | 71k → 212k (**2.97×**) | same |
 | Go net/http | 86k → 200k (**2.33×**) | one process, `GOMAXPROCS` 1→4 |
 | Granian | 147k → 224k (**1.52×**) | 1→4 workers |

--- a/benchmarks/server/go-comparison.md
+++ b/benchmarks/server/go-comparison.md
@@ -1,0 +1,135 @@
+# Go vs Stario Cython / Python (2026-08-25)
+
+Same 10-route app as `apps/stario_app.py`, measured with the existing `wrk`
+runner. Answers two questions:
+
+1. How do the Go ports compare to the committed one-worker baselines?
+2. Should we pin Go to one core, or run Go normally and scale Python?
+
+## How to compare Go to Python
+
+A Go process is not the same unit of work as a CPython process.
+
+| | Go | CPython / Cython / Granian |
+| --- | --- | --- |
+| Normal deploy | **One process**, goroutines on `GOMAXPROCS` OS threads (default: all CPUs) | **N processes** (one worker ≈ one core for bytecode; native extensions can use more) |
+| Fair “code path” test | One process, `GOMAXPROCS=1` | One worker (the existing suite) |
+| Fair “fill the box” test | One process, `GOMAXPROCS=nCPU` | N workers (`granian-rsgi-n`, uvicorn `--workers N`, …) |
+
+**Do not** compare default Go (`GOMAXPROCS=4` on this box) to one Stario
+worker and call that a language result. That is four cores vs one.
+
+**Do not** start extra Go processes to “match” Python. Go is already
+multi-threaded inside one process. The knob is `GOMAXPROCS`, not process
+count.
+
+**Do** scale Python to N processes when you want the deploy-shaped
+comparison. Stario has no worker pool today; Granian does, which is why
+`granian-rsgi-n` exists.
+
+```bash
+# same 1-core budget as baseline-20260824.md
+benchmarks/server/run.sh stario stario-cython go-nethttp go-fasthttp granian-rsgi
+
+# fill a 4-vCPU box
+BENCH_PROCS=4 benchmarks/server/run.sh go-nethttp-n granian-rsgi-n
+```
+
+## This run
+
+| | |
+|---|---|
+| Host | Intel Xeon (KVM), 4 vCPUs, 15 GiB — same class as `baseline-20260824.md` |
+| Client | wrk 4.1.0, `-t2 -c128` (read/small upload), `-c32` (64KB/2MB) |
+| Samples | 10s × 3 measured + 1 warmup, IQR trim |
+| Topology | wrk + server on `127.0.0.1` |
+| Commit | `6a1c075` (`cursor/go-benchmark-apps-f638`) |
+| Raw | `benchmarks/server/results/20260825T175710Z/` (gitignored) |
+
+Handlers compute JSON and validation **per request** (`encoding/json` in Go,
+`ujson` in Python). No cached response bytes.
+
+## 1-core / 1-worker (language comparison)
+
+This is the row that belongs next to the published Cython baseline.
+
+| Server | Plaintext | JSON | Params | Validate |
+| --- | ---: | ---: | ---: | ---: |
+| Go fasthttp (`GOMAXPROCS=1`) | 177,185 ± 219 | 170,949 ± 5,180 | 154,793 ± 5,753 | 123,353 ± 2,135 |
+| Granian RSGI (1 worker) | 147,367 ± 2,543 | 135,630 ± 6,862 | 145,077 ± 3,100 | 107,832 ± 1,288 |
+| Stario Cython (this run) | 96,506 ± 3,149 | 104,528 ± 8,428 | 101,712 ± 21,262 | 81,124 ± 3,552 |
+| Stario Cython (committed baseline, 10s × 5) | 120,378 ± 24,710 | 117,556 ± 10,384 | 104,519 ± 7,598 | 82,402 ± 1,389 |
+| Go net/http (`GOMAXPROCS=1`) | 85,768 ± 8,554 | 85,219 ± 3,482 | 81,707 ± 2,271 | 65,837 ± 7,883 |
+| Stario Python httptools | 71,343 ± 294 | 69,287 ± 433 | 63,607 ± 1,911 | 53,098 ± 1,202 |
+
+vs **this-run Cython** (same machine, same wrk settings):
+
+| | net/http P=1 | fasthttp P=1 | Granian 1w |
+| --- | ---: | ---: | ---: |
+| Plaintext | 0.89× | **1.84×** | 1.53× |
+| JSON | 0.82× | **1.64×** | 1.30× |
+| Params | 0.80× | **1.52×** | 1.43× |
+| Validate | 0.81× | **1.52×** | 1.33× |
+
+stdlib Go sits in the Stario Cython band (a bit under on this run). fasthttp
+on **one core** is the fastest 1-worker row — above 1-worker Granian and
+well above Cython. Stario Python remains ~1.2× behind 1-core `net/http` and
+~2.5× behind 1-core fasthttp on plaintext.
+
+This-run Cython plaintext (97k) is below the committed primary (120k ± 25k)
+and closer to the confirmatory refresh (125k). Treat ratios against
+**this-run** Cython; the committed table is the historical anchor, not a
+second clock.
+
+## Large-body (1-core)
+
+| Server | Form | JSON 1KB | 64KB | 2MB buf | 2MB stream | Multipart |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Go fasthttp P=1 | 162,327 | 145,474 | **42,652** | **3,736** | **6,094** | **3,694** |
+| Granian 1w | 117,754 | 112,913 | 30,194 | 1,180 | 2,868 | 3,139 |
+| Stario Cython | 94,432 | 83,782 | 31,403 | 2,566 | 2,467 | 2,260 |
+| Go net/http P=1 | 97,476 | 80,365 | 14,945 | 536 | 3,928 | 542 |
+| Stario Python | 55,311 | 54,114 | 28,303 | 2,023 | 2,898 | 1,980 |
+
+`net/http` `io.ReadAll` (the honest analog of `await req.body()`) is weak on
+64KB+ buffered uploads. The streaming path is fine — faster than Cython.
+fasthttp is ahead on every body size.
+
+## Fill the box (4 vCPUs)
+
+Go still uses **one process**. Granian uses **4 worker processes**.
+
+| Server | Plaintext | JSON | Params | Validate |
+| --- | ---: | ---: | ---: | ---: |
+| Granian RSGI (4 workers) | **221,079 ± 2,600** | **214,319 ± 2,980** | **208,552 ± 4,399** | 153,364 ± 6,225 |
+| Go net/http (`GOMAXPROCS=4`) | 198,547 ± 458 | 187,731 ± 2,253 | 187,846 ± 5,123 | 144,093 ± 174 |
+| Go fasthttp (`GOMAXPROCS=1`) | 177,185 ± 219 | 170,949 ± 5,180 | 154,793 ± 5,753 | 123,353 ± 2,135 |
+| Granian RSGI (1 worker) | 147,367 ± 2,543 | 135,630 ± 6,862 | 145,077 ± 3,100 | 107,832 ± 1,288 |
+| Stario Cython (1 worker) | 96,506 ± 3,149 | 104,528 ± 8,428 | 101,712 ± 21,262 | 81,124 ± 3,552 |
+
+Scaling:
+
+| | 1 unit → 4 units | Notes |
+| --- | ---: | --- |
+| Go net/http plaintext | 86k → 199k (**2.31×**) | one process, `GOMAXPROCS` 1→4 |
+| Granian plaintext | 147k → 221k (**1.50×**) | 1→4 processes |
+| fasthttp | 177k on **1** core | already near 4-worker Granian |
+
+On uploads, 4-worker Granian wins 64KB (67k vs fasthttp 43k / nethttp-n 12k).
+4-core `net/http` still trails on buffered 2MB (1.3k vs Granian-n 3.5k /
+fasthttp 3.7k) and leads on the stream path (7.9k).
+
+If you only compared `go-nethttp-n` (199k) to 1-worker Cython (97k) you would
+report “Go is 2×.” That 2× is mostly the extra cores. The 1-core table is
+the language comparison; this table is the deploy comparison.
+
+## Recommendation
+
+- Keep the default suite at **1 worker / `GOMAXPROCS=1`** so new Go rows stay
+  comparable to `baseline-20260824.md`.
+- Use `go-nethttp-n` + `granian-rsgi-n` when you want hardware-saturation
+  numbers. Stario would need a process supervisor (or `SO_REUSEPORT` workers)
+  before it can join that row.
+- Prefer **fasthttp** as the “how fast is a Go HTTP stack” target. Prefer
+  **net/http** as the “idiomatic Go stdlib” target. They are different
+  questions; both apps implement the same routes.

--- a/benchmarks/server/go-comparison.md
+++ b/benchmarks/server/go-comparison.md
@@ -127,9 +127,9 @@ the language comparison; this table is the deploy comparison.
 
 - Keep the default suite at **1 worker / `GOMAXPROCS=1`** so new Go rows stay
   comparable to `baseline-20260824.md`.
-- Use `go-nethttp-n` + `granian-rsgi-n` when you want hardware-saturation
-  numbers. Stario would need a process supervisor (or `SO_REUSEPORT` workers)
-  before it can join that row.
+- Use `go-nethttp-n` + `stario-n` / `stario-cython-n` + `granian-rsgi-n` when
+  you want hardware-saturation numbers. Stario `-n` starts N processes on one
+  port with `STARIO_REUSE_PORT=1` (`SO_REUSEPORT`).
 - Prefer **fasthttp** as the “how fast is a Go HTTP stack” target. Prefer
   **net/http** as the “idiomatic Go stdlib” target. They are different
   questions; both apps implement the same routes.

--- a/benchmarks/server/go-comparison.md
+++ b/benchmarks/server/go-comparison.md
@@ -14,7 +14,7 @@ A Go process is not the same unit of work as a CPython process.
 | --- | --- | --- |
 | Normal deploy | **One process**, goroutines on `GOMAXPROCS` OS threads (default: all CPUs) | **N processes** (one worker ≈ one core for bytecode; native extensions can use more) |
 | Fair “code path” test | One process, `GOMAXPROCS=1` | One worker (the existing suite) |
-| Fair “fill the box” test | One process, `GOMAXPROCS=nCPU` | N workers (`granian-rsgi-n`, uvicorn `--workers N`, …) |
+| Fair “fill the box” test | One process, `GOMAXPROCS=nCPU` | N processes on one port (`stario-n` / `stario-cython-n` with `STARIO_REUSE_PORT=1`, or `granian-rsgi-n`) |
 
 **Do not** compare default Go (`GOMAXPROCS=4` on this box) to one Stario
 worker and call that a language result. That is four cores vs one.
@@ -24,15 +24,16 @@ multi-threaded inside one process. The knob is `GOMAXPROCS`, not process
 count.
 
 **Do** scale Python to N processes when you want the deploy-shaped
-comparison. Stario has no worker pool today; Granian does, which is why
-`granian-rsgi-n` exists.
+comparison. Set `STARIO_REUSE_PORT=1` and start several `stario serve`
+processes on the same host/port (`stario-n` / `stario-cython-n` in the
+runner). Granian’s `--workers` is the same idea.
 
 ```bash
 # same 1-core budget as baseline-20260824.md
 benchmarks/server/run.sh stario stario-cython go-nethttp go-fasthttp granian-rsgi
 
-# fill a 4-vCPU box
-BENCH_PROCS=4 benchmarks/server/run.sh go-nethttp-n granian-rsgi-n
+# fill a 4-vCPU box — Stario starts N processes on one SO_REUSEPORT socket
+BENCH_PROCS=4 benchmarks/server/run.sh stario-n stario-cython-n go-nethttp-n granian-rsgi-n
 ```
 
 ## This run
@@ -43,8 +44,8 @@ BENCH_PROCS=4 benchmarks/server/run.sh go-nethttp-n granian-rsgi-n
 | Client | wrk 4.1.0, `-t2 -c128` (read/small upload), `-c32` (64KB/2MB) |
 | Samples | 10s × 3 measured + 1 warmup, IQR trim |
 | Topology | wrk + server on `127.0.0.1` |
-| Commit | `6a1c075` (`cursor/go-benchmark-apps-f638`) |
-| Raw | `benchmarks/server/results/20260825T175710Z/` (gitignored) |
+| Commit | `df931cb` (`cursor/go-benchmark-apps-f638`) |
+| Raw | `20260825T175710Z` (1-worker), `20260825T185107Z` (`*-n`, gitignored) |
 
 Handlers compute JSON and validation **per request** (`encoding/json` in Go,
 `ujson` in Python). No cached response bytes.
@@ -97,31 +98,46 @@ fasthttp is ahead on every body size.
 
 ## Fill the box (4 vCPUs)
 
-Go still uses **one process**. Granian uses **4 worker processes**.
+Go still uses **one process**. Stario and Granian use **4 processes** sharing
+one port (`STARIO_REUSE_PORT=1` / Granian `--workers`). Run
+`20260825T185107Z` for the `-n` rows; 1-worker rows are from the earlier
+same-machine suite.
 
 | Server | Plaintext | JSON | Params | Validate |
 | --- | ---: | ---: | ---: | ---: |
-| Granian RSGI (4 workers) | **221,079 ± 2,600** | **214,319 ± 2,980** | **208,552 ± 4,399** | 153,364 ± 6,225 |
-| Go net/http (`GOMAXPROCS=4`) | 198,547 ± 458 | 187,731 ± 2,253 | 187,846 ± 5,123 | 144,093 ± 174 |
+| Stario Cython (4 processes, `SO_REUSEPORT`) | **293,998 ± 7,025** | **283,780 ± 7,127** | **272,658 ± 5,467** | **252,150 ± 8,106** |
+| Granian RSGI (4 workers) | 223,691 ± 1,873 | 212,601 ± 27,200 | 208,766 ± 1,719 | 144,139 ± 2,036 |
+| Stario Python (4 processes, `SO_REUSEPORT`) | 211,540 ± 1,382 | 207,714 ± 803 | 211,574 ± 2,007 | 170,263 ± 4,424 |
+| Go net/http (`GOMAXPROCS=4`) | 199,980 ± 1,407 | 195,180 ± 315 | 189,863 ± 529 | 145,315 ± 143 |
 | Go fasthttp (`GOMAXPROCS=1`) | 177,185 ± 219 | 170,949 ± 5,180 | 154,793 ± 5,753 | 123,353 ± 2,135 |
 | Granian RSGI (1 worker) | 147,367 ± 2,543 | 135,630 ± 6,862 | 145,077 ± 3,100 | 107,832 ± 1,288 |
 | Stario Cython (1 worker) | 96,506 ± 3,149 | 104,528 ± 8,428 | 101,712 ± 21,262 | 81,124 ± 3,552 |
+| Stario Python (1 worker) | 71,343 ± 294 | 69,287 ± 433 | 63,607 ± 1,911 | 53,098 ± 1,202 |
 
-Scaling:
+Scaling (plaintext, 1 unit → 4 units):
 
-| | 1 unit → 4 units | Notes |
+| | 1 → 4 | Notes |
 | --- | ---: | --- |
-| Go net/http plaintext | 86k → 199k (**2.31×**) | one process, `GOMAXPROCS` 1→4 |
-| Granian plaintext | 147k → 221k (**1.50×**) | 1→4 processes |
-| fasthttp | 177k on **1** core | already near 4-worker Granian |
+| Stario Cython | 97k → 294k (**3.05×**) | 4 processes, `STARIO_REUSE_PORT=1` |
+| Stario Python | 71k → 212k (**2.97×**) | same |
+| Go net/http | 86k → 200k (**2.33×**) | one process, `GOMAXPROCS` 1→4 |
+| Granian | 147k → 224k (**1.52×**) | 1→4 workers |
 
-On uploads, 4-worker Granian wins 64KB (67k vs fasthttp 43k / nethttp-n 12k).
-4-core `net/http` still trails on buffered 2MB (1.3k vs Granian-n 3.5k /
-fasthttp 3.7k) and leads on the stream path (7.9k).
+Uploads on the 4-unit rows:
 
-If you only compared `go-nethttp-n` (199k) to 1-worker Cython (97k) you would
-report “Go is 2×.” That 2× is mostly the extra cores. The 1-core table is
-the language comparison; this table is the deploy comparison.
+| Server | Form | JSON 1KB | 64KB | 2MB buf | 2MB stream | Multipart |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Stario Cython ×4 | **287,489** | **255,842** | **92,789** | **5,433** | 6,232 | **6,382** |
+| Stario Python ×4 | 182,492 | 172,915 | 64,172 | 3,112 | 4,126 | 3,197 |
+| Granian ×4 | 149,775 | 119,738 | 69,120 | 3,964 | 4,627 | 3,740 |
+| Go net/http P=4 | 195,733 | 143,730 | 12,292 | 1,334 | **7,795** | 1,321 |
+
+`net/http` still lags on buffered 64KB+; it keeps the stream-path lead.
+Shared-socket Stario Cython is the fastest fill-the-box stack on this box.
+
+If you only compared `go-nethttp-n` (200k) to 1-worker Cython (97k) you would
+report “Go is 2×.” That 2× is mostly the extra cores. Four Cython processes
+on one `SO_REUSEPORT` socket are **1.47×** 4-core `net/http` on plaintext.
 
 ## Recommendation
 

--- a/benchmarks/server/httparena-aiohttp.md
+++ b/benchmarks/server/httparena-aiohttp.md
@@ -1,0 +1,189 @@
+# Stario vs aiohttp on HttpArena
+
+HttpArena ([http-arena.com](https://www.http-arena.com/), Alpha Round,
+results dated 2026-08-25) is the live public league table now that
+TechEmpower Framework Benchmarks has shut down. **aiohttp is #1 Python
+on the HTTP/1.1 composite.** Stario is not on the board. This note
+says what that ranking actually measures, and what our own suite can
+and cannot say about beating it.
+
+Sources: [aiohttp entry](https://www.http-arena.com/frameworks/aiohttp/),
+[implementation](https://github.com/MDA2AV/HttpArena/tree/main/frameworks/aiohttp),
+our `baseline-20260824.md` / `positioning.md` / `go-comparison.md`.
+
+## What “#1 Python” means
+
+It is **not** “highest plaintext RPS.” HttpArena scores a **composite**:
+each HTTP/1.1 profile is worth 100 to the field leader, the entry sums
+those normalized scores, then loses **2.5% per missing** framework
+surface (routing, middleware, request object, response builder).
+Incomplete suites score zero on the profiles they skip.
+
+aiohttp’s page: **composite 240**, HTTP/1.1 rank **29 of 61** frameworks
+overall (same number as Spring Boot), **gold “within Python HTTP/1.1”
+(1 of 8)**. Completeness **4/4**, standard configuration, flagship.
+
+The Python HTTP/1.1 board (Alpha Round):
+
+| Entry | Composite | Notes |
+| --- | ---: | --- |
+| **aiohttp** | **240** | own server + uvloop, 1 fork/core, `SO_REUSEPORT` |
+| litestar | 236 | uvicorn + msgspec |
+| starlette | 225 | uvicorn |
+| mq-bridge-py | 222 | Class A: Rust HTTP, Python dispatch, completeness 2/4 |
+| fastapi | 190 | uvicorn |
+| sanic | 158 | **faster than aiohttp on the profiles it ran**; incomplete + tuned |
+| flask | 106 | |
+| bottle | 98 | |
+| slimeweb | 96 | |
+| robyn | 59 | incomplete; pipelined looks broken (~16M) |
+| django | 44 | |
+
+Sanic’s own server + ujson + httptools **beats aiohttp on raw
+connection and JSON**, then drops the composite because it skipped
+TLS, static, DB, CRUD, and the API-4/API-16 cliffs:
+
+| Profile (best conn count) | aiohttp | sanic | starlette | fastapi |
+| --- | ---: | ---: | ---: | ---: |
+| Baseline 4,096 | 590,654 | **611,737** | 399,413 | 298,664 |
+| Pipelined 512 (not scored) | 1,171,337 | **1,461,670** | 492,899 | 344,457 |
+| JSON 4,096 | 286,695 | **344,340** | 225,181 | 155,615 |
+| JSON + gzip 4,096 | 101,899 | **172,836** | 130,650 | 101,178 |
+| Upload 32 (20 MB) | 1,610 | 1,814 | **2,132** | 2,117 |
+| Static 1,024 | **94,209** | — | 23,668 | 23,482 |
+| Async DB 1,024 | **102,119** | — | 88,740 | 75,930 |
+| Memory (baseline 512) | **539 MiB** | 1.6 GiB | 3.5 GiB | 4.9 GiB |
+
+aiohttp wins Python by **shipping the whole standard-mode suite** and
+by being cheap (half a gig at 64 workers). It does not win every
+profile.
+
+## Their aiohttp entry is the same deploy we already use
+
+From `frameworks/aiohttp/app.py`: aiohttp 3.14, uvloop, **one forked
+worker per container CPU**, each bind with **`reuse_port=True`**,
+routing through `app.router`, JSON through `web.json_response`, gzip
+through `response.enable_compression()`, uploads via
+`request.content.iter_any()`, static via `web.FileResponse` (disk
+every request), TLS on 8081 when `/certs` is mounted, Postgres/Redis
+only when the harness injects them.
+
+That is the same shape as `stario-n` / `stario-cython-n`
+(`STARIO_REUSE_PORT=1`, N processes). aiohttp is a **Class B**
+framework in `positioning.md` terms — real router, request/response,
+middleware, compression — not Granian-with-`if path`.
+
+The scored HTTP/1.1 work is heavier than our 10 routes:
+
+| Profile | What it does |
+| --- | --- |
+| baseline | mixed GET/POST, query ints summed, optional POST body int |
+| short-lived | same, connection closed after 10 requests |
+| json | slice a dataset, multiply fields, serialize |
+| json-comp / json-tls | same + gzip/br and/or TLS |
+| upload | 20 MB body, return byte count |
+| static / static-tls | 20 files off disk |
+| async-db | async Postgres range scan |
+| crud | REST + optional Redis cache-aside |
+| api-4 / api-16 | mixed baseline+JSON+db pinned to 4 / 16 CPUs |
+
+Hardware: **64-core Threadripper PRO 3995WX**, container pinned to
+dedicated cores, Docker host net, **gcannon** (not wrk), best of 3,
+default 5s. **Do not compare their 591k baseline to our 294k
+4-vCPU plaintext.** Different iron, client, payload, and duration.
+
+## What our suite can say
+
+We have never run aiohttp. We *have* run three stacks that also sit
+on HttpArena: FastAPI, Sanic, Robyn (plus Django-Bolt locally, Django
+on their board).
+
+### Shared peers, two machines
+
+| Stack | Our 1-worker plaintext | HttpArena baseline 4,096 |
+| --- | ---: | ---: |
+| Stario Cython | **120,378** | not entered |
+| Sanic | 52,746 | **611,737** (tuned, own server) |
+| FastAPI + Uvicorn | 47,533 | 298,664 |
+| Robyn | 25,416 | 430,749 |
+
+Locally Sanic is only **~1.1×** FastAPI. On HttpArena, tuned Sanic is
+**~2.0×** FastAPI — the same ratio as **our Cython vs FastAPI
+(~2.5×)**. aiohttp is **~2.0×** FastAPI on their baseline.
+
+So the honest transfer is:
+
+- **Against FastAPI/Starlette/Uvicorn:** we should still look clearly
+  faster. That is the Class B claim we already make.
+- **Against aiohttp / tuned Sanic on connection+JSON:** expect a
+  **same-band fight**, maybe a modest edge (~1.0–1.3×) if the Cython
+  protocol tax stays. **Not** a 2× headline. Their Sanic already
+  matches aiohttp on those profiles; our local Sanic is a weaker
+  reference than theirs.
+- **Against Robyn:** both suites agree we (and aiohttp) are far ahead
+  on real request work. Their Robyn pipelined row is not usable.
+
+### Bodies and memory
+
+HttpArena’s 20 MB upload is I/O-bound. FastAPI/Starlette/Litestar
+**beat** aiohttp there (~2.1k vs 1.6k). Our 2 MB stream win vs ASGI
+does not automatically become an aiohttp win on their upload.
+
+aiohttp’s **539 MiB** at 64 workers is the Python efficiency story.
+ASGI entries sit at 3–5 GiB. Cython should land nearer aiohttp than
+FastAPI if we submit; that is one place we can actually look good
+even if RPS is a coin flip.
+
+### 4-core fill-the-box (ours only)
+
+`go-comparison.md`, 4 vCPU, `SO_REUSEPORT`: Cython **294k** plaintext /
+**252k** validate. That is how Stario scales, and it is the same
+knob aiohttp already uses. It is **not** a number you can put next
+to their 591k.
+
+## Feature gaps if we entered tomorrow
+
+HttpArena standard mode wants framework APIs, not a toy `if path`.
+We already have routing, scoped middleware, request, response, gzip /
+brotli / zstd, streamed bodies, and `reuse_port`. Gaps vs their
+HTTP/1.1 family:
+
+| Surface | Stario today | Needed for a fair entry |
+| --- | --- | --- |
+| TLS listener | not a product feature | `ssl.SSLContext` on the listen socket (asyncio can) |
+| Static files | no `FileResponse` | read-from-disk handler; they forbid preloading |
+| Postgres / Redis | none | app-level `asyncpg` / redis, same as aiohttp |
+| WebSocket | Upgrade → 400 | skip the WS family |
+| HTTP/2, HTTP/3, gRPC | no | skip those families |
+
+A complete **HTTP/1.1-only** entry with completeness 4/4 is enough to
+compete for #1 Python. Missing TLS/static/db is how Sanic ended at
+158 instead of ~240. Do not submit a plaintext-only app.
+
+`mq-bridge-py` (1.2M baseline) is **Class A** (Rust accept, 2/4). Do
+not treat it as the Python framework to beat. Same rule as Granian.
+
+## Lines that are safe
+
+**True today:** aiohttp is the best *complete, standard-mode* Python
+framework on HttpArena. It is the Class B opponent the “fastest
+Python framework” claim has to beat in public. We are not on that
+board, so we have **no HttpArena rank**.
+
+**True from our suite:** vs the ASGI frameworks HttpArena also runs
+(FastAPI, Starlette via FastAPI, Sanic-as-we-ran-it), Cython is
+~2–2.5× on honest 1-worker routes. That still supports the Class B
+headline **on our machine, our routes**.
+
+**Do not say:** “We are faster than aiohttp.” Different hardware,
+different client, different payloads, and their tuned Sanic already
+ties them on the closest profiles.
+
+**Do not say:** “aiohttp is slow.” It is mid-pack overall (240) and
+the efficiency leader in Python. The Python ceiling on this board is
+mid-pack; #1 Python is the prize, not catching C# / Bun / actix.
+
+**To actually know:** add `frameworks/stario/` to
+[MDA2AV/HttpArena](https://github.com/MDA2AV/HttpArena) — Dockerfile,
+the scored HTTP/1.1 endpoints, workers + `SO_REUSEPORT`, standard-mode
+APIs — and let their machine publish the row.

--- a/benchmarks/server/httparena-aiohttp.md
+++ b/benchmarks/server/httparena-aiohttp.md
@@ -39,6 +39,12 @@ The Python HTTP/1.1 board (Alpha Round):
 | robyn | 59 | incomplete; pipelined looks broken (~16M) |
 | django | 44 | |
 
+**Not on this gold-medal table:** [Pyronova](https://www.http-arena.com/frameworks/pyronova/)
+is **experimental + tuned**, composite **431**, baseline **826k**.
+HttpArena ranks that league apart so it does not take aiohttp’s
+flagship gold. JSON 723k is a per-worker byte cache in their Arena
+app. Write-up: `httparena-pyronova.md`.
+
 Sanic’s own server + ujson + httptools **beats aiohttp on raw
 connection and JSON**, then drops the composite because it skipped
 TLS, static, DB, CRUD, and the API-4/API-16 cliffs:

--- a/benchmarks/server/httparena-aiohttp.md
+++ b/benchmarks/server/httparena-aiohttp.md
@@ -176,14 +176,15 @@ framework on HttpArena. It is the Class B opponent the “fastest
 Python framework” claim has to beat in public. We are not on that
 board, so we have **no HttpArena rank**.
 
-**True from our suite:** vs the ASGI frameworks HttpArena also runs
-(FastAPI, Starlette via FastAPI, Sanic-as-we-ran-it), Cython is
-~2–2.5× on honest 1-worker routes. That still supports the Class B
-headline **on our machine, our routes**.
+**True from our suite (same machine, production setup):** Cython is
+**~2.5×** 1-worker aiohttp and **~1.8×** aiohttp ×4 on plaintext
+(`production-peers.md`). Litestar is slower still (~4.3× / ~2.8×).
+That is the Class B claim with the actual HttpArena #1 Python stack
+on this box.
 
-**Do not say:** “We are faster than aiohttp.” Different hardware,
-different client, different payloads, and their tuned Sanic already
-ties them on the closest profiles.
+**Do not say:** “Faster than HttpArena’s 591k aiohttp.” Different
+iron and client. Say “faster than production aiohttp on this
+machine, same routes.”
 
 **Do not say:** “aiohttp is slow.” It is mid-pack overall (240) and
 the efficiency leader in Python. The Python ceiling on this board is

--- a/benchmarks/server/httparena-litestar.md
+++ b/benchmarks/server/httparena-litestar.md
@@ -1,0 +1,24 @@
+# Stario vs Litestar
+
+[Litestar](https://github.com/litestar-org/litestar) is Class B: a
+real Python framework on uvicorn (HttpArena: uvloop + httptools,
+msgspec, one worker per core). Composite **236**, 2nd Python on
+HttpArena behind aiohttp 240.
+
+On this machine, same 10 honest routes, production uvicorn
+(`production-peers.md`):
+
+| | Plaintext | Validate |
+| --- | ---: | ---: |
+| Stario Cython 1w | **129,297** | **105,918** |
+| Litestar 1w | 30,353 | 19,796 |
+| Stario Cython ×4 | **282,133** | **244,755** |
+| Litestar ×4 | 100,635 | 71,323 |
+
+**~4.3×** (1 worker) and **~2.8×** (4 workers) on plaintext. Litestar
+is slower than aiohttp on this suite (51k / 155k). HttpArena’s near-tie
+with aiohttp is composite + completeness on their 64-core box, not a
+speed tie on our routes.
+
+Do not put Litestar in Class A. Do not use their HttpArena 316k
+baseline next to our 282k ×4.

--- a/benchmarks/server/httparena-pyronova.md
+++ b/benchmarks/server/httparena-pyronova.md
@@ -1,0 +1,141 @@
+# Stario vs Pyronova
+
+[Pyronova](https://github.com/leocaolab/pyronova) is the first
+Rust-core Python framework that is actually fast. It is on HttpArena
+as **experimental + tuned**, not on the flagship Python gold that
+aiohttp holds. We have not run it on this machine. This note says
+what their numbers measure, which class they belong in, and what we
+can say without inventing a rank.
+
+Sources: [repo](https://github.com/leocaolab/pyronova),
+[HttpArena entry](https://www.http-arena.com/frameworks/pyronova/),
+[Arena app](https://github.com/MDA2AV/HttpArena/blob/main/frameworks/pyronova/app.py),
+their [benchmark-14](https://github.com/leocaolab/pyronova/blob/main/benchmarks/benchmark-14-linux.md)
+(Ryzen 7 7840HS, 8C/16T), our `positioning.md` / `httparena-aiohttp.md`.
+
+## What it is
+
+Rust **hyper + tokio + rustls + mimalloc** accept loop. Python
+handlers run in **PEP 684 sub-interpreters** (one GIL each) inside
+**one process**. Decorator router, `Request` / `Response`,
+before/after hooks, gzip/brotli, TLS, HTTP/2, WebSocket, SSE, static
+files, sqlx Postgres. Completeness **4/4**.
+
+That is Robyn’s product shape with Granian/fasthttp metal. It is
+**not** aiohttp (Python protocol). It is **not** Granian (no
+framework). HttpArena’s own tags: `type: experimental`, `mode: tuned`.
+
+## HttpArena (same 64-core box as aiohttp)
+
+| Profile | Pyronova | aiohttp | sanic (tuned) |
+| --- | ---: | ---: | ---: |
+| Composite (H1) | **431** (experimental league, 2 of 2) | 240 (flagship gold) | 158 |
+| Baseline 4,096 | **825,534** | 590,654 | 611,737 |
+| JSON 4,096 | **723,144** | 286,695 | 344,340 |
+| JSON + gzip 4,096 | **463,958** | 101,899 | 172,836 |
+| JSON TLS 4,096 | **780,948** | 240,408 | — |
+| Upload 32 (20 MB) | **2,766** | 1,610 | 1,814 |
+| Async DB 1,024 | 23,302 | **102,119** | — |
+| CRUD 4,096 | 12,019 | **41,864** | — |
+| API-16 | **51,624** | 45,702 | — |
+| Memory (baseline 512) | 860 MiB | **539 MiB** | 1.6 GiB |
+| Pipelined 512 (not scored) | 4.10M | 1.17M | 1.46M |
+
+Baseline **is** a real handler (sum query ints, optional POST body).
+**1.4× aiohttp / 1.35× Sanic** on that profile is the Rust accept
+loop on the same iron. Treat that as the honest Pyronova-vs-Python
+gap on connection work.
+
+JSON **is not** honest. Their Arena app keeps a per-worker
+`_JSON_CACHE` of pre-serialized bytes (cap 256 keys) and documents
+it. `add_fast_response("GET", "/pipeline", b"ok")` skips Python
+entirely. gzip level=1 / brotli quality=0. Upload uses
+`req.stream.drain_count()` entirely in Rust. That is why the entry
+is **tuned**. Do not quote 723k JSON or 4.1M pipelined as a
+framework result.
+
+gRPC ~5M looks like a Rust-native stub, not a Python handler race.
+HTTP/2 is the same Hyper engine; we do not have h2.
+
+**Database is a loss:** 23k async-db vs aiohttp 102k. CRUD 12k vs
+42k. sqlx in Rust, but their CRUD handlers are `gil=True` on the
+main interpreter.
+
+## Their own 8C/16T report (not our box)
+
+`wrk -t4 -c100 -d10s`, 16 sub-interpreters + 16 io_workers, one
+process. GET `/` **429k**, `/json` **405k**, `/user/42` **395k**,
+POST `/echo` **372k**. vs Robyn 16 proc × 2 workers: **2.6–2.7×**
+and 189 MB vs 583 MB. 300s soak at 401k, 120M requests, zero
+errors.
+
+That is **fill-the-box on a 16-thread laptop**, not 1-worker. Do
+not put 429k next to our 120k Cython 1-worker row. The nearer
+published number we have is Cython **×4 on 4 vCPU = 294k**
+plaintext (`go-comparison.md`). They have ~2× the threads and
+print 1.46× the RPS. Per-core they look **same-band**, not 3×.
+
+They also advertise `@cached_json(ttl=...)` (68k → 336k on a
+100-row payload) and Rust `serde` for dict returns. Our handler
+policy forbids both.
+
+## Class
+
+| | Pyronova | Stario Cython | aiohttp |
+| --- | --- | --- | --- |
+| HTTP engine | Rust Hyper/Tokio | Cython llhttp + asyncio | aiohttp + uvloop |
+| Scale knob | sub-interpreters in 1 process | N processes, `SO_REUSEPORT` | N forks, `SO_REUSEPORT` |
+| Handler language | Python (`def` / `async def`) | Python async | Python async |
+| HttpArena board | experimental / tuned | not entered | flagship / standard / #1 Python |
+
+Put Pyronova with **Class A** in `positioning.md` (native accept +
+Python callbacks), next to Granian / Socketify / Robyn-as-metal —
+**not** in the Class B 2× table with FastAPI / Sanic / BlackSheep /
+aiohttp.
+
+It has more framework surface than Granian or Socketify (router,
+middleware hooks, WS, SSE, static, compression, TLS). That does not
+move the HTTP engine into Python. Robyn and Django-Bolt have a
+similar story and were *slow*; Pyronova is the one that made the
+story fast. Beating Robyn 4.7× on our suite does not beat Pyronova.
+
+C extensions (orjson, pydantic, numpy, sqlalchemy) need `gil=True`
+and fall back to the main interpreter. Fast Arena/README routes
+avoid that. Real apps that import those packages leave the 400k
+path.
+
+## What we can say
+
+**True:** Pyronova is the fastest *Rust-core Python* entry on
+HttpArena. On an honest baseline it is ~1.4× aiohttp on that
+64-core box. Their self-published 429k vs Robyn is consistent with
+our Robyn being the slow one, not with Stario being the slow one.
+
+**True from our suite:** vs Python-protocol Class B (aiohttp’s
+peers: FastAPI, Sanic, BlackSheep, Stario Python) Cython is still
+~2–2.5× on this machine. That claim does not include Pyronova.
+
+**Estimate, not a measurement:** Stario’s scale model is aiohttp’s
+(fork + `SO_REUSEPORT`), not Hyper-in-process. On HttpArena we
+would expect to land near aiohttp/Sanic on connection (~600–750k
+if the FastAPI transfer holds), **behind** Pyronova’s 826k
+baseline, and far behind their cached JSON. On 4 vCPU, 294k
+Cython vs a hypothetical 16-worker Pyronova is unknown; their
+8C/16T 429k suggests we would not be embarrassed per core and
+would not win a fill-the-box Rust race.
+
+**Do not say:** “Faster than Pyronova.” We have no same-machine
+row, and their Arena JSON/pipeline numbers are tuned.
+
+**Do not say:** “Pyronova is just Socketify.” More framework, real
+HttpArena completeness, production CLI, WS/H2. Say “Rust HTTP
+engine, Python handlers, experimental+tuned on the public board.”
+
+**Do not use their 429k or 723k in a Class B slide.**
+
+**To actually know:** add an honest `apps/pyronova_app.py` (same 10
+routes, per-request JSON, no cache, no `add_fast_response`) and
+run `pyronova` with `PYRONOVA_WORKERS=$nproc` next to
+`stario-cython-n` and a production aiohttp. Until that run exists,
+the only fair public number is HttpArena baseline 826k vs aiohttp
+591k.

--- a/benchmarks/server/httparena-pyronova.md
+++ b/benchmarks/server/httparena-pyronova.md
@@ -115,17 +115,15 @@ our Robyn being the slow one, not with Stario being the slow one.
 peers: FastAPI, Sanic, BlackSheep, Stario Python) Cython is still
 ~2–2.5× on this machine. That claim does not include Pyronova.
 
-**Estimate, not a measurement:** Stario’s scale model is aiohttp’s
-(fork + `SO_REUSEPORT`), not Hyper-in-process. On HttpArena we
-would expect to land near aiohttp/Sanic on connection (~600–750k
-if the FastAPI transfer holds), **behind** Pyronova’s 826k
-baseline, and far behind their cached JSON. On 4 vCPU, 294k
-Cython vs a hypothetical 16-worker Pyronova is unknown; their
-8C/16T 429k suggests we would not be embarrassed per core and
-would not win a fill-the-box Rust race.
+**Measured on this box** (`production-peers.md`): 1-worker Pyronova
+takes plaintext **143k vs Cython 129k (1.11×)** and stream 2MB;
+Cython takes validate and buffered 2MB. `PYRONOVA_WORKERS>=2`
+aborts here (double-free / SIGSEGV on CPython 3.14). No fill-the-box
+row.
 
-**Do not say:** “Faster than Pyronova.” We have no same-machine
-row, and their Arena JSON/pipeline numbers are tuned.
+**Do not say:** “Faster than Pyronova.” Say “1–1 on hello (they
+edge plaintext); we win validate; they crash at 2+ TPC threads on
+this host.”
 
 **Do not say:** “Pyronova is just Socketify.” More framework, real
 HttpArena completeness, production CLI, WS/H2. Say “Rust HTTP
@@ -133,9 +131,5 @@ engine, Python handlers, experimental+tuned on the public board.”
 
 **Do not use their 429k or 723k in a Class B slide.**
 
-**To actually know:** add an honest `apps/pyronova_app.py` (same 10
-routes, per-request JSON, no cache, no `add_fast_response`) and
-run `pyronova` with `PYRONOVA_WORKERS=$nproc` next to
-`stario-cython-n` and a production aiohttp. Until that run exists,
-the only fair public number is HttpArena baseline 826k vs aiohttp
-591k.
+Honest `apps/pyronova_app.py` is in the suite. 1-worker numbers are
+in `production-peers.md`. Fill-the-box waits on their TPC crash.

--- a/benchmarks/server/positioning.md
+++ b/benchmarks/server/positioning.md
@@ -55,6 +55,8 @@ honest handlers. Cython plaintext anchor **120k** (isolated re-run here
 | BlackSheep + Uvicorn | 59,195 | 50,554 | **2.0×** |
 | Sanic | 52,746 | 34,731 | **2.3×** |
 | FastAPI + Uvicorn | 47,533 | 34,263 | **2.5×** |
+| aiohttp (later 1-worker, `production-peers.md`) | 51,264 | 34,887 | **~2.5×** |
+| Litestar (later 1-worker) | 30,353 | 19,796 | **~4.3×** |
 | Django-Bolt | 28,084 | 23,067 | **4.3×** |
 | Robyn | 25,416 | 18,070 | **4.7×** |
 
@@ -83,13 +85,10 @@ this table.
   That is allowed. On 64KB we already tie (~30.8k). At **4 processes**
   (`STARIO_REUSE_PORT` vs `--workers`) Cython is **294k vs 224k**
   plaintext and **252k vs 144k** validate — we win the box.
-- **Pyronova:** no same-machine row. HttpArena baseline (honest sum of
-  query ints) is **826k vs aiohttp 591k** on the 64-core box — ~1.4×,
-  Rust accept. Their JSON 723k is a per-worker byte cache; ignore it.
-  Self-published **429k** GET `/` is 16 workers on 8C/16T, not 1-worker;
-  nearest published Cython is **294k ×4 on 4 vCPU**. Per-core, same
-  band; fill-the-box Rust, they should lead. Do not put 429k next to
-  120k.
+- **Pyronova:** 1-worker they take plaintext **143k vs 129k**; we take
+  validate **106k vs 87k**. `PYRONOVA_WORKERS>=2` crashes on this
+  CPython 3.14 host. HttpArena 826k / their 429k are other boxes.
+  Details: `httparena-pyronova.md`, `production-peers.md`.
 
 BlackSheep + Granian (112k plaintext) is **not** a Class B counterexample.
 Take Granian away (BlackSheep + Uvicorn = 59k) and it falls into the 2×
@@ -166,8 +165,8 @@ fill the machine.”
 **Do not say:** “Faster than Go.” Say “ahead of stdlib `net/http` on
 one core and on the box; 1-core fasthttp is a different class.”
 
-**Do not say:** “Faster than Pyronova.” Say “Rust HTTP engine, Python
-handlers; experimental+tuned on HttpArena; no same-machine number.”
+**Do not say:** “Faster than Pyronova.” Say “1–1 on hello (they edge
+plaintext); we win validate; they crash at 2+ TPC threads here.”
 
 ## HttpArena / aiohttp
 
@@ -178,12 +177,10 @@ on a 64-core box, not a plaintext RPS crown — tuned Sanic already
 beats aiohttp on baseline/JSON and then loses the composite by
 skipping TLS/static/DB.
 
-aiohttp is **Class B** (router, `json_response`, gzip, fork +
-`SO_REUSEPORT`). It is the opponent the headline has to beat in
-public. We are **not entered**, so there is no rank and no honest
-“faster than aiohttp” line. Shared peers (FastAPI, Sanic, Robyn)
-suggest a **same-band** fight on connection/JSON, not a 2× gap.
-Full write-up: `httparena-aiohttp.md`.
+aiohttp is **Class B**. On this machine, production setup, we are
+**~2.5×** (1 worker) and **~1.8×** (×4) on plaintext
+(`production-peers.md`). That is not an HttpArena rank. Full
+write-up: `httparena-aiohttp.md`.
 
 ## HttpArena / Pyronova
 
@@ -192,4 +189,5 @@ with PEP 684 sub-interpreters. HttpArena: **experimental + tuned**,
 composite 431, baseline **826k** (~1.4× aiohttp). JSON 723k is a
 per-worker byte cache; `/pipeline` is a Rust fast-path. Self-published
 429k GET `/` is 16 workers on 8C/16T. Class A, not the 2× table.
-Full write-up: `httparena-pyronova.md`.
+1-worker here: they edge plaintext (143k vs 129k); we win validate;
+2+ TPC threads crash. Full write-up: `httparena-pyronova.md`.

--- a/benchmarks/server/positioning.md
+++ b/benchmarks/server/positioning.md
@@ -182,6 +182,14 @@ aiohttp is **Class B**. On this machine, production setup, we are
 (`production-peers.md`). That is not an HttpArena rank. Full
 write-up: `httparena-aiohttp.md`.
 
+## HttpArena / Litestar
+
+[Litestar](https://github.com/litestar-org/litestar) is Class B
+(uvicorn + msgspec). HttpArena composite 236, just behind aiohttp.
+On this machine it is the slowest of the three peers: **~4.3×**
+behind 1-worker Cython, **~2.8×** behind ×4. Write-up:
+`httparena-litestar.md`.
+
 ## HttpArena / Pyronova
 
 [Pyronova](https://github.com/leocaolab/pyronova) is Hyper + Tokio

--- a/benchmarks/server/positioning.md
+++ b/benchmarks/server/positioning.md
@@ -18,9 +18,16 @@ two classes, then only fight the class that ships the same product.
 - **Socketify** — uWebSockets + a micro `app.get` / `:param` table. No
   host routing, no middleware tree, no HTML/SSE stack. Hello-world is a
   C++ server with a Python callback.
+- **Pyronova** — Hyper + Tokio + PEP 684 sub-interpreters. Real
+  decorator router, WS/H2/SSE, completeness 4/4. The HTTP engine is
+  still Rust. HttpArena marks the entry **experimental + tuned**
+  (cached JSON bytes, Rust `add_fast_response` for `/pipeline`).
+  Details: `httparena-pyronova.md`.
 
 Socketify *has* path params. Treat it as Class A anyway: it is a native
 server with a route table, not a framework you would build a product in.
+Pyronova has more framework than Socketify; it still does not belong
+in the Class B 2× table.
 
 **Class B** — this is the claim:
 
@@ -76,6 +83,13 @@ this table.
   That is allowed. On 64KB we already tie (~30.8k). At **4 processes**
   (`STARIO_REUSE_PORT` vs `--workers`) Cython is **294k vs 224k**
   plaintext and **252k vs 144k** validate — we win the box.
+- **Pyronova:** no same-machine row. HttpArena baseline (honest sum of
+  query ints) is **826k vs aiohttp 591k** on the 64-core box — ~1.4×,
+  Rust accept. Their JSON 723k is a per-worker byte cache; ignore it.
+  Self-published **429k** GET `/` is 16 workers on 8C/16T, not 1-worker;
+  nearest published Cython is **294k ×4 on 4 vCPU**. Per-core, same
+  band; fill-the-box Rust, they should lead. Do not put 429k next to
+  120k.
 
 BlackSheep + Granian (112k plaintext) is **not** a Class B counterexample.
 Take Granian away (BlackSheep + Uvicorn = 59k) and it falls into the 2×
@@ -149,6 +163,9 @@ fill the machine.”
 
 **Do not say:** “Faster than Go.” Say “ahead of stdlib `net/http` on
 one core and on the box; 1-core fasthttp is a different class.”
+
+**Do not say:** “Faster than Pyronova.” Say “Rust HTTP engine, Python
+handlers; experimental+tuned on HttpArena; no same-machine number.”
 
 ## HttpArena / aiohttp
 

--- a/benchmarks/server/positioning.md
+++ b/benchmarks/server/positioning.md
@@ -149,3 +149,19 @@ fill the machine.”
 
 **Do not say:** “Faster than Go.” Say “ahead of stdlib `net/http` on
 one core and on the box; 1-core fasthttp is a different class.”
+
+## HttpArena / aiohttp
+
+[HttpArena](https://www.http-arena.com/) is the public table now that
+TechEmpower is gone. **aiohttp is #1 Python on the HTTP/1.1 composite**
+(240, gold within language). That is a complete standard-mode suite
+on a 64-core box, not a plaintext RPS crown — tuned Sanic already
+beats aiohttp on baseline/JSON and then loses the composite by
+skipping TLS/static/DB.
+
+aiohttp is **Class B** (router, `json_response`, gzip, fork +
+`SO_REUSEPORT`). It is the opponent the headline has to beat in
+public. We are **not entered**, so there is no rank and no honest
+“faster than aiohttp” line. Shared peers (FastAPI, Sanic, Robyn)
+suggest a **same-band** fight on connection/JSON, not a 2× gap.
+Full write-up: `httparena-aiohttp.md`.

--- a/benchmarks/server/positioning.md
+++ b/benchmarks/server/positioning.md
@@ -1,0 +1,151 @@
+# Claiming “fastest Python HTTP stack”
+
+Stario can say it is the **fastest Python server framework we measured** —
+not “faster than every native accept loop on earth.” Split the field into
+two classes, then only fight the class that ships the same product.
+
+## Two classes
+
+| Class | What it is | Verdict |
+| --- | --- | --- |
+| **A. Thin native servers** | Accept loop + maybe a toy `app.get`. No framework model. | **1–1 is fine** |
+| **B. Python frameworks** | Routing, params, middleware-shaped apps, JSON/forms/uploads, a real handler model | **Must be ~2× or more** |
+
+**Class A** — do not use these as the headline opponent:
+
+- **Granian RSGI** — Rust server, no router. Our bench app is `if path ==`.
+  That is uvicorn-without-uvicorn, not FastAPI.
+- **Socketify** — uWebSockets + a micro `app.get` / `:param` table. No
+  host routing, no middleware tree, no HTML/SSE stack. Hello-world is a
+  C++ server with a Python callback.
+
+Socketify *has* path params. Treat it as Class A anyway: it is a native
+server with a route table, not a framework you would build a product in.
+
+**Class B** — this is the claim:
+
+FastAPI, Sanic, BlackSheep, Robyn, Django-Bolt, and **Stario Python**
+(httptools, no Cython). Same 10 routes, params, JSON, validate, form,
+buffered + streamed bodies, multipart. Handlers compute every response
+(see `benchmarks/README.md`).
+
+BlackSheep **on Granian** is Class A’s accept loop wearing a Class B
+coat. Quote BlackSheep **on Uvicorn** when you say “Python framework.”
+Quote BlackSheep+Granian only as “framework + Rust server.”
+
+## Proof (committed 1-worker suite)
+
+Source: `baseline-20260824.md`, same machine class, `wrk -t2 -c128`,
+honest handlers. Cython plaintext anchor **120k** (isolated re-run here
+**118k**; the 97k long-suite row was noise).
+
+### Class B — frameworks (headline)
+
+| Stack | Plaintext | Validate | vs Cython plaintext |
+| --- | ---: | ---: | ---: |
+| **Stario Cython** | **120,378** | **82,402** | 1.00× |
+| Stario Python | 63,268 | 50,417 | **1.9×** |
+| BlackSheep + Uvicorn | 59,195 | 50,554 | **2.0×** |
+| Sanic | 52,746 | 34,731 | **2.3×** |
+| FastAPI + Uvicorn | 47,533 | 34,263 | **2.5×** |
+| Django-Bolt | 28,084 | 23,067 | **4.3×** |
+| Robyn | 25,416 | 18,070 | **4.7×** |
+
+Reads, params, and small uploads tell the same story: **about 2–2.5×**
+the ASGI/uvloop frameworks people actually pick (FastAPI, Sanic,
+BlackSheep), **~2×** Stario’s own Python protocol, **4×+** Robyn /
+Django-Bolt.
+
+That is “extremely faster than every Python framework that provides the
+same HTTP surface,” as long as you do not put Granian or Socketify in
+this table.
+
+### Class A — native servers (1–1 is the deal)
+
+| Stack | Plaintext | JSON | Params | Validate |
+| --- | ---: | ---: | ---: | ---: |
+| Socketify | 120,992 | 95,237 | 75,609 | 13,314 |
+| **Stario Cython** | 120,378 | 117,556 | 104,519 | 82,402 |
+| Granian RSGI (primary, noisy) | 86,164 ± 29k | 118,099 | 133,193 | 106,976 |
+| Granian RSGI (later 1-worker run) | ~147k | ~136k | ~145k | ~108k |
+
+- **Socketify:** tied on plaintext. We win JSON/params. They collapse on
+  validate/forms (13k / 20k vs 82k / 94k). “1–1 on hello; we pull away
+  when there is routing work and a body.”
+- **Granian:** 1 worker can beat 1 Cython worker on reads (Rust accept).
+  That is allowed. On 64KB we already tie (~30.8k). At **4 processes**
+  (`STARIO_REUSE_PORT` vs `--workers`) Cython is **294k vs 224k**
+  plaintext and **252k vs 144k** validate — we win the box.
+
+BlackSheep + Granian (112k plaintext) is **not** a Class B counterexample.
+Take Granian away (BlackSheep + Uvicorn = 59k) and it falls into the 2×
+bucket. The 112k is Granian.
+
+## Why Class B is slower (rationale)
+
+1. **ASGI is a second HTTP stack.** FastAPI / BlackSheep / Uvicorn parse
+   and dispatch in Python, then run the app. Stario’s protocol *is* the
+   server (httptools or llhttp). No ASGI hop.
+2. **Framework tax.** FastAPI’s bench still uses Starlette `Route` +
+   per-request `ujson` (no Pydantic on most paths, no static
+   `Response`). Sanic/BlackSheep still build framework request objects.
+   We still lose ~2×. The gap is the stack, not “they validate and we
+   don’t.”
+3. **Cython is the protocol, not a different app.** Same
+   `apps/stario_app.py` as Stario Python. ~1.9× is llhttp + less Python
+   on the wire.
+4. **Honest handlers.** No cached `Response`, no pre-serialized JSON.
+   If we cheated, Class B would cry foul and the claim dies.
+
+## Feature surface — no bench blindspots
+
+The suite already forces the HTTP work a framework must do:
+
+| Surface | In the suite | Stario |
+| --- | --- | --- |
+| Method + path routing | `/user/42` | trie, `{id}`, `{path...}`, host routes |
+| JSON in/out | `/json`, `/validate`, `/echo/json` | `responses.json` + handler parse |
+| Validation | `/validate` | app-level (same helper as peers) |
+| Form body | `POST /form` | `await req.body()` |
+| Buffered upload | 64KB / 2MB | `req.body()` |
+| Streamed upload | `/ingest/stream/2m` | `async for req.stream()` |
+| Multipart | `/upload` | raw body (same as most bench apps) |
+
+Robyn and Django-Bolt **cannot stream** (documented). We can. That is
+the opposite of a blindspot.
+
+## What we do *not* claim (so the headline survives)
+
+These are product choices, not secret bench skips. Say them once so
+nobody “declassifies” *us*:
+
+| Not in Stario | Who has it | Line |
+| --- | --- | --- |
+| WebSocket | FastAPI, Sanic, Socketify, Robyn | HTTP + SSE/Datastar is the product; Upgrade is 400 |
+| OpenAPI / Pydantic | FastAPI, BlackSheep | Hypermedia stack, not a schema-first API framework |
+| Parsed `UploadFile` / `Form()` | FastAPI, Sanic, BlackSheep | Raw body + stream; parse in the app if you need parts |
+| ASGI mount / Uvicorn | the Class B field | We *are* the server |
+| HTTP/2 | proxies | HTTP/1.1 + keepalive; put h2 on the edge |
+
+If the audience is “JSON API with Swagger and WebSockets,” do not pick
+this fight. If the audience is “Python HTTP server + routing +
+HTML/SSE you can actually ship,” Class B is the field and the numbers
+hold.
+
+## Lines that are safe
+
+**Headline:** Stario (Cython protocol) is the fastest Python HTTP
+framework we have measured: **~2×** BlackSheep/Uvicorn and Stario
+Python, **~2.3×** Sanic, **~2.5×** FastAPI, **~4×** Robyn and
+Django-Bolt, on the same routes and honest handlers.
+
+**Class A:** Native servers without a framework (Granian, Socketify)
+match us on hello-world. We stay with them on JSON/params and move
+ahead on body work; with several processes we out-scale Granian.
+
+**Do not say:** “Faster than Granian.” Say “faster than every Python
+framework; 1–1 with thin native servers; faster than Granian when you
+fill the machine.”
+
+**Do not say:** “Faster than Go.” Say “ahead of stdlib `net/http` on
+one core and on the box; 1-core fasthttp is a different class.”

--- a/benchmarks/server/positioning.md
+++ b/benchmarks/server/positioning.md
@@ -153,9 +153,11 @@ framework we have measured: **~2×** BlackSheep/Uvicorn and Stario
 Python, **~2.3×** Sanic, **~2.5×** FastAPI, **~4×** Robyn and
 Django-Bolt, on the same routes and honest handlers.
 
-**Class A:** Native servers without a framework (Granian, Socketify)
-match us on hello-world. We stay with them on JSON/params and move
-ahead on body work; with several processes we out-scale Granian.
+**Class A:** Native servers without a Python HTTP engine (Granian,
+Socketify, **Pyronova**) match or beat us on hello-world. We stay
+with Granian/Socketify on JSON/params and move ahead on body work;
+with several processes we out-scale Granian. Pyronova has no
+same-machine row — treat it as the fast Robyn, not as FastAPI.
 
 **Do not say:** “Faster than Granian.” Say “faster than every Python
 framework; 1–1 with thin native servers; faster than Granian when you
@@ -182,3 +184,12 @@ public. We are **not entered**, so there is no rank and no honest
 “faster than aiohttp” line. Shared peers (FastAPI, Sanic, Robyn)
 suggest a **same-band** fight on connection/JSON, not a 2× gap.
 Full write-up: `httparena-aiohttp.md`.
+
+## HttpArena / Pyronova
+
+[Pyronova](https://github.com/leocaolab/pyronova) is Hyper + Tokio
+with PEP 684 sub-interpreters. HttpArena: **experimental + tuned**,
+composite 431, baseline **826k** (~1.4× aiohttp). JSON 723k is a
+per-worker byte cache; `/pipeline` is a Rust fast-path. Self-published
+429k GET `/` is 16 workers on 8C/16T. Class A, not the 2× table.
+Full write-up: `httparena-pyronova.md`.

--- a/benchmarks/server/production-peers.md
+++ b/benchmarks/server/production-peers.md
@@ -1,0 +1,102 @@
+# Stario vs aiohttp / Litestar / Pyronova (this machine)
+
+Same 10 honest routes as `apps/stario_app.py`. No cached JSON, no
+`add_fast_response`, no `drain_count()`. Fill-the-box uses each
+stack’s production scale knob. 1-worker is the code-path row.
+
+| | |
+|---|---|
+| Host | Intel Xeon (KVM), 4 vCPUs, 15 GiB |
+| Client | wrk 4.1.0, `-t2 -c128` (read/small upload), `-c32` (64KB/2MB) |
+| Samples | 10s × 3 measured + 1 warmup, IQR trim |
+| Python | 3.14.7 (uv) |
+| Fill-the-box raw | `results/20260825T200246Z` |
+| 1-worker raw | `results/20260825T203223Z` |
+
+Versions: aiohttp 3.14.3 + uvloop; Litestar 2.24.0 + uvicorn 0.52.4
+(uvloop/httptools, msgspec); Pyronova 2.7.0; Stario Cython this
+checkout.
+
+Reproduce:
+
+```bash
+# fill the box
+BENCH_PROCS=$(nproc) benchmarks/server/run.sh stario-cython-n aiohttp-n litestar-n pyronova-n
+
+# code path
+benchmarks/server/run.sh stario-cython aiohttp litestar pyronova
+```
+
+## 1 worker (code path)
+
+| Server | Plaintext | JSON | Params | Validate |
+| --- | ---: | ---: | ---: | ---: |
+| Pyronova (1 TPC thread) | **143,243 ± 6,386** | **141,818 ± 2,400** | **134,950 ± 4,177** | 86,873 ± 2,671 |
+| **Stario Cython** | 129,297 ± 5,686 | 113,894 ± 7,383 | 113,931 ± 2,252 | **105,918 ± 4,901** |
+| aiohttp + uvloop | 51,264 ± 74 | 49,950 ± 241 | 44,676 ± 140 | 34,887 ± 407 |
+| Litestar + Uvicorn | 30,353 ± 73 | 29,227 ± 546 | 25,423 ± 259 | 19,796 ± 81 |
+
+vs Cython plaintext: Pyronova **1.11×**, aiohttp **0.40×**, Litestar **0.23×**.
+
+| Server | Form | JSON 1K | 64KB | 2MB buf | 2MB stream | Multipart |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Pyronova | **125,281** | **126,310** | **50,074** | 1,455 | **4,756** | 1,501 |
+| **Stario Cython** | 122,385 | 101,376 | 34,396 | **2,598** | 2,650 | **2,671** |
+| aiohttp | 41,867 | 36,300 | 15,606 | 1,316 | 2,412 | 1,273 |
+| Litestar | 23,542 | 19,936 | 13,995 | 1,303 | 1,171 | 1,303 |
+
+## Fill the box (4 units)
+
+| Server | How |
+| --- | --- |
+| Stario Cython | 4 processes, `STARIO_REUSE_PORT=1` |
+| aiohttp | 4 processes, `SO_REUSEPORT`, uvloop |
+| Litestar | uvicorn `--workers 4`, uvloop + httptools |
+| Pyronova | `PYRONOVA_WORKERS=4` (TPC) — **aborted** |
+
+| Server | Plaintext | JSON | Params | Validate |
+| --- | ---: | ---: | ---: | ---: |
+| **Stario Cython ×4** | **282,133 ± 11,925** | **282,335 ± 21,273** | **276,876 ± 2,890** | **244,755 ± 4,140** |
+| aiohttp ×4 | 155,411 ± 555 | 149,412 ± 580 | 138,522 ± 1,993 | 116,685 ± 412 |
+| Litestar ×4 | 100,635 ± 5,848 | 98,303 ± 5,814 | 77,320 ± 8,746 | 71,323 ± 889 |
+| Pyronova ×4 | crash | crash | crash | crash |
+
+vs Cython plaintext: aiohttp **0.55×**, Litestar **0.36×**.
+
+| Server | Form | JSON 1K | 64KB | 2MB buf | 2MB stream | Multipart |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| **Stario Cython ×4** | **287,042** | **258,560** | **115,650** | **6,323** | **6,289** | **6,406** |
+| aiohttp ×4 | 128,922 | 117,868 | 63,592 | 3,974 | 5,808 | 3,794 |
+| Litestar ×4 | 79,886 | 56,280 | 47,111 | 3,108 | 4,470 | 3,259 |
+| Pyronova ×4 | crash | | | | | |
+
+Scaling plaintext 1 → 4: Cython 129k → 282k (**2.18×**), aiohttp 51k → 155k
+(**3.03×**), Litestar 30k → 101k (**3.31×**). aiohttp/Litestar scale
+closer to linear; Cython still finishes far ahead.
+
+Pyronova 2.7.0 on CPython 3.14 here: `TPC threads >= 2` dies under wrk
+with `double free or corruption` / `munmap_chunk(): invalid pointer` /
+SIGSEGV. One TPC thread is stable. Engine bug, not our handler.
+HttpArena’s 826k is 64 workers on their box.
+
+## Read against HttpArena
+
+HttpArena (64-core, gcannon, Alpha Round): aiohttp composite **240**
+(#1 flagship Python), Litestar **236**, Pyronova experimental/tuned
+**431**. Those RPS figures are not this box.
+
+On **this** 4-vCPU box, honest handlers:
+
+- **Litestar** is Class B and the slowest of the three Python
+  frameworks we just ran. ~4.3× behind 1-worker Cython, ~2.8× behind
+  ×4. HttpArena closeness to aiohttp is completeness + their iron,
+  not a speed tie on our routes.
+- **aiohttp** is the right Class B opponent. We are **~2.5×** (1
+  worker) and **~1.8×** (×4) on plaintext; validate is the same ratio.
+- **Pyronova** is Class A (Rust Hyper). 1-worker they take hello-world
+  / JSON / stream (**1.11×** plaintext); we take validate and buffered
+  2MB. They cannot fill this box (crash at 2+ TPC threads).
+
+Do not say “faster than HttpArena aiohttp.” Say “faster than
+production aiohttp and Litestar on this machine, same routes.”
+Do not say “faster than Pyronova” without the 1-worker split.

--- a/benchmarks/server/run.sh
+++ b/benchmarks/server/run.sh
@@ -23,6 +23,7 @@ TARGETS=(
   go-nethttp go-nethttp-n go-fasthttp
   socketify robyn granian-rsgi granian-rsgi-n sanic django-bolt
   blacksheep-granian blacksheep-uvicorn fastapi
+  aiohttp-n litestar-n pyronova-n
 )
 TARGET_LABELS=(
   "stario|Stario (Python httptools)"
@@ -41,12 +42,16 @@ TARGET_LABELS=(
   "blacksheep-granian|BlackSheep + Granian ASGI"
   "blacksheep-uvicorn|BlackSheep + Uvicorn ASGI"
   "fastapi|FastAPI + Uvicorn ASGI"
+  "aiohttp-n|aiohttp + uvloop (${BENCH_PROCS} processes, SO_REUSEPORT)"
+  "litestar-n|Litestar + Uvicorn (${BENCH_PROCS} workers, uvloop/httptools)"
+  "pyronova-n|Pyronova (${BENCH_PROCS} sub-interpreters)"
 )
 SUMMARY_GROUPS=(
   "Stario (this checkout)|stario stario-n stario-cython stario-cython-n"
   "Go|go-nethttp go-nethttp-n go-fasthttp"
   "Native HTTP servers|socketify robyn granian-rsgi granian-rsgi-n sanic django-bolt"
   "ASGI framework stacks|blacksheep-granian blacksheep-uvicorn fastapi"
+  "Production Python peers|aiohttp-n litestar-n pyronova-n"
 )
 READ_ENDPOINTS=(plaintext json params)
 UPLOAD_ENDPOINTS=(validate post-form post-json-1k post-octet-64k post-octet-2m post-stream-2m multipart-2m)
@@ -87,12 +92,14 @@ Targets (default: all):
   Go:                  go-nethttp, go-nethttp-n, go-fasthttp
   Native HTTP servers: socketify, robyn, granian-rsgi, granian-rsgi-n, sanic, django-bolt
   ASGI stacks:         blacksheep-granian, blacksheep-uvicorn, fastapi
+  Production peers:    aiohttp-n, litestar-n, pyronova-n
 
   go-nethttp / go-fasthttp pin GOMAXPROCS=1 (same 1-core budget as the
   Python/Cython one-worker rows). *-n targets fill the box: Go uses
   GOMAXPROCS=\$BENCH_PROCS in one process; stario-n / stario-cython-n start
-  N processes on one port with STARIO_REUSE_PORT=1; granian-rsgi-n uses
-  N workers.
+  N processes on one port with STARIO_REUSE_PORT=1; granian-rsgi-n and
+  litestar-n use N workers; aiohttp-n forks N processes with SO_REUSEPORT;
+  pyronova-n uses N sub-interpreters in one process.
 
 Environment: DURATION=10s THREADS=2 CONNECTIONS=128 UPLOAD_CONNECTIONS=32
              RUNS=7 WARMUP=2 HOST=127.0.0.1 PORT=3000 PYTHON=3.14
@@ -261,6 +268,9 @@ env_name_for() {
     stario-n) echo stario ;;
     stario-cython-n) echo stario-cython ;;
     granian-rsgi-n) echo granian-rsgi ;;
+    aiohttp-n) echo aiohttp ;;
+    litestar-n) echo litestar ;;
+    pyronova-n) echo pyronova ;;
     *) echo "$1" ;;
   esac
 }
@@ -276,7 +286,7 @@ python_for() {
 
 workers_for() {
   case "$1" in
-    stario-n|stario-cython-n) echo "$BENCH_PROCS" ;;
+    stario-n|stario-cython-n|aiohttp-n) echo "$BENCH_PROCS" ;;
     *) echo 1 ;;
   esac
 }
@@ -382,6 +392,9 @@ ensure_target() {
     sanic) ensure_env sanic sanic uvloop ujson ;;
     django-bolt) ensure_env django-bolt django django-bolt msgspec ujson ;;
     fastapi) ensure_env fastapi fastapi 'uvicorn[standard]' ujson ;;
+    aiohttp-n) ensure_env aiohttp aiohttp uvloop ujson ;;
+    litestar-n) ensure_env litestar litestar 'uvicorn[standard]' msgspec ;;
+    pyronova-n) ensure_env pyronova pyronova ;;
     blacksheep-uvicorn) ensure_env blacksheep-uvicorn blacksheep 'uvicorn[standard]' ujson ;;
     blacksheep-granian) ensure_env blacksheep-granian blacksheep granian uvloop ujson ;;
     granian-rsgi-n) ensure_env granian-rsgi granian uvloop ujson ;;
@@ -517,6 +530,36 @@ command_for() {
         runbolt --host "$HOST" --port "$SERVER_PORT" --processes 1
       )
       ;;
+    aiohttp-n)
+      export BENCH_HOST="$HOST"
+      export BENCH_PORT="$SERVER_PORT"
+      export AIOHTTP_REUSE_PORT=1
+      SERVER_CMD=(
+        "$(python_for aiohttp)" "$BENCHMARK_DIR/apps/aiohttp_app.py"
+        --host "$HOST" --port "$SERVER_PORT"
+      )
+      ;;
+    litestar-n)
+      SERVER_CMD=(
+        "$(python_for litestar)" -m uvicorn apps.litestar_app:app
+        --host "$HOST" --port "$SERVER_PORT"
+        --workers "$BENCH_PROCS"
+        --loop uvloop
+        --http httptools
+        --no-access-log
+        --log-level warning
+      )
+      ;;
+    pyronova-n)
+      export BENCH_HOST="$HOST"
+      export BENCH_PORT="$SERVER_PORT"
+      export PYRONOVA_HOST="$HOST"
+      export PYRONOVA_PORT="$SERVER_PORT"
+      export PYRONOVA_WORKERS="$BENCH_PROCS"
+      SERVER_CMD=(
+        "$(python_for pyronova)" "$BENCHMARK_DIR/apps/pyronova_app.py"
+      )
+      ;;
   esac
 }
 
@@ -584,7 +627,7 @@ start_server() {
   workers="$(workers_for "$target")"
   echo "+ ${SERVER_CMD[*]}"
   if ((workers > 1)); then
-    echo "  $workers processes on $HOST:$SERVER_PORT (STARIO_REUSE_PORT=1)"
+    echo "  $workers processes on $HOST:$SERVER_PORT (SO_REUSEPORT)"
   fi
   SERVER_PIDS=()
   : >"$log"
@@ -746,7 +789,7 @@ print_summary() {
     echo "Median requests/sec ± sample stdev after discarding $WARMUP warmup run(s)"
     echo "and applying IQR outlier trimming across $RUNS measured samples per endpoint."
     echo "Large uploads use $UPLOAD_CONNECTIONS connections; other cases use $CONNECTIONS."
-    echo "Go \`*-n\` uses BENCH_PROCS=$BENCH_PROCS in one process; stario-n / stario-cython-n start $BENCH_PROCS processes with STARIO_REUSE_PORT=1; granian-rsgi-n uses $BENCH_PROCS workers. Other rows stay 1 worker / GOMAXPROCS=1."
+    echo "Go \`*-n\` uses BENCH_PROCS=$BENCH_PROCS in one process; stario-n / stario-cython-n / aiohttp-n start $BENCH_PROCS processes with SO_REUSEPORT; litestar-n and granian-rsgi-n use $BENCH_PROCS workers; pyronova-n uses $BENCH_PROCS sub-interpreters. Other rows stay 1 worker / GOMAXPROCS=1."
     for group_entry in "${SUMMARY_GROUPS[@]}"; do
       group_name="${group_entry%%|*}"
       group_targets="${group_entry#*|}"

--- a/benchmarks/server/run.sh
+++ b/benchmarks/server/run.sh
@@ -17,17 +17,23 @@ PYTHON="${PYTHON:-3.14}"
 KEEP_RAW="${KEEP_RAW:-0}"
 WRK="${WRK:-wrk}"
 BROTLI_PKG_CONFIG="${BROTLI_PKG_CONFIG:-}"
+BENCH_PROCS="${BENCH_PROCS:-$(nproc 2>/dev/null || echo 4)}"
 TARGETS=(
   stario stario-cython
-  socketify robyn granian-rsgi sanic django-bolt
+  go-nethttp go-nethttp-n go-fasthttp
+  socketify robyn granian-rsgi granian-rsgi-n sanic django-bolt
   blacksheep-granian blacksheep-uvicorn fastapi
 )
 TARGET_LABELS=(
   "stario|Stario (Python httptools)"
   "stario-cython|Stario (Cython llhttp)"
+  "go-nethttp|Go net/http (GOMAXPROCS=1)"
+  "go-nethttp-n|Go net/http (GOMAXPROCS=${BENCH_PROCS})"
+  "go-fasthttp|Go fasthttp (GOMAXPROCS=1)"
   "socketify|Socketify (uWebSockets/libuv)"
   "robyn|Robyn (Rust/Actix)"
   "granian-rsgi|Granian RSGI (Rust, no framework)"
+  "granian-rsgi-n|Granian RSGI (${BENCH_PROCS} workers)"
   "sanic|Sanic (uvloop)"
   "django-bolt|Django-Bolt (Actix/Tokio)"
   "blacksheep-granian|BlackSheep + Granian ASGI"
@@ -36,7 +42,8 @@ TARGET_LABELS=(
 )
 SUMMARY_GROUPS=(
   "Stario (this checkout)|stario stario-cython"
-  "Native HTTP servers|socketify robyn granian-rsgi sanic django-bolt"
+  "Go|go-nethttp go-nethttp-n go-fasthttp"
+  "Native HTTP servers|socketify robyn granian-rsgi granian-rsgi-n sanic django-bolt"
   "ASGI framework stacks|blacksheep-granian blacksheep-uvicorn fastapi"
 )
 READ_ENDPOINTS=(plaintext json params)
@@ -74,12 +81,18 @@ Usage: benchmarks/server/run.sh [target ...]
 
 Targets (default: all):
   Stario:              stario, stario-cython
-  Native HTTP servers: socketify, robyn, granian-rsgi, sanic, django-bolt
+  Go:                  go-nethttp, go-nethttp-n, go-fasthttp
+  Native HTTP servers: socketify, robyn, granian-rsgi, granian-rsgi-n, sanic, django-bolt
   ASGI stacks:         blacksheep-granian, blacksheep-uvicorn, fastapi
+
+  go-nethttp / go-fasthttp pin GOMAXPROCS=1 (same 1-core budget as the
+  Python/Cython one-worker rows). go-nethttp-n and granian-rsgi-n fill the
+  box: one Go process with GOMAXPROCS=\$BENCH_PROCS, or N Granian workers.
 
 Environment: DURATION=10s THREADS=2 CONNECTIONS=128 UPLOAD_CONNECTIONS=32
              RUNS=7 WARMUP=2 HOST=127.0.0.1 PORT=3000 PYTHON=3.14
-             ENDPOINT_TIER=all|read|upload  ENDPOINTS=csv  REFRESH_ENVS=1 KEEP_RAW=1
+             BENCH_PROCS=\$(nproc) ENDPOINT_TIER=all|read|upload
+             ENDPOINTS=csv  REFRESH_ENVS=1 KEEP_RAW=1
 
 Endpoint tiers:
   read   — plaintext, json, params
@@ -226,7 +239,47 @@ format_int() {
   printf '%s%s' "$value" "$out"
 }
 
-python_for() { echo "$ENVS_DIR/$1/bin/python"; }
+host_python() {
+  if [[ -n "${STATS_PYTHON:-}" ]]; then
+    echo "$STATS_PYTHON"
+    return
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+    return
+  fi
+  echo "python3"
+}
+
+python_for() {
+  local candidate="$ENVS_DIR/$1/bin/python"
+  if [[ -x "$candidate" ]]; then
+    echo "$candidate"
+  else
+    host_python
+  fi
+}
+
+needs_uv() {
+  local target
+  for target in "$@"; do
+    case "$target" in
+      go-nethttp|go-nethttp-n|go-fasthttp) ;;
+      *) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+needs_go() {
+  local target
+  for target in "$@"; do
+    case "$target" in
+      go-nethttp|go-nethttp-n|go-fasthttp) return 0 ;;
+    esac
+  done
+  return 1
+}
 
 require_port_free() {
   local python="$1" target="$2" port="$3"
@@ -310,7 +363,18 @@ ensure_target() {
     fastapi) ensure_env fastapi fastapi 'uvicorn[standard]' ujson ;;
     blacksheep-uvicorn) ensure_env blacksheep-uvicorn blacksheep 'uvicorn[standard]' ujson ;;
     blacksheep-granian) ensure_env blacksheep-granian blacksheep granian uvloop ujson ;;
+    granian-rsgi-n) ensure_env granian-rsgi granian uvloop ujson ;;
+    go-nethttp|go-nethttp-n|go-fasthttp) build_go ;;
   esac
+}
+
+build_go() {
+  local bin="$BENCHMARK_DIR/.bin/stario-go-bench"
+  if [[ ! -x "$bin" || "${REFRESH_ENVS:-0}" == 1 ]]; then
+    echo "  building Go benchmark servers"
+    mkdir -p "$BENCHMARK_DIR/.bin"
+    (cd "$BENCHMARK_DIR/apps/go" && go build -o "$bin" .)
+  fi
 }
 
 uvicorn_cmd() {
@@ -396,6 +460,29 @@ command_for() {
         --loop uvloop
         --no-access-log
         --log-level warning
+      )
+      ;;
+    granian-rsgi-n)
+      SERVER_CMD=(
+        "$(python_for granian-rsgi)" -m granian apps.granian_rsgi_app:app
+        --interface rsgi
+        --host "$HOST" --port "$SERVER_PORT"
+        --workers "$BENCH_PROCS"
+        --runtime-threads 1
+        --loop uvloop
+        --no-access-log
+        --log-level warning
+      )
+      ;;
+    go-nethttp|go-nethttp-n|go-fasthttp)
+      local gomax=1 impl=nethttp
+      [[ "$1" == go-nethttp-n ]] && gomax="$BENCH_PROCS"
+      [[ "$1" == go-fasthttp ]] && impl=fasthttp
+      SERVER_CMD=(
+        env GOMAXPROCS="$gomax"
+        BENCH_HOST="$HOST" BENCH_PORT="$SERVER_PORT"
+        "$BENCHMARK_DIR/.bin/stario-go-bench" -impl "$impl"
+        -host "$HOST" -port "$SERVER_PORT"
       )
       ;;
     django-bolt)
@@ -600,11 +687,12 @@ print_summary() {
   SELECTED_TARGETS=("$@")
   : >"$table"
   {
-    echo "## Single-worker HTTP server comparison"
+    echo "## HTTP server comparison"
     echo
     echo "Median requests/sec ± sample stdev after discarding $WARMUP warmup run(s)"
     echo "and applying IQR outlier trimming across $RUNS measured samples per endpoint."
     echo "Large uploads use $UPLOAD_CONNECTIONS connections; other cases use $CONNECTIONS."
+    echo "Go \`*-n\` / Granian \`*-n\` use BENCH_PROCS=$BENCH_PROCS cores or workers; other rows stay 1 worker / GOMAXPROCS=1."
     for group_entry in "${SUMMARY_GROUPS[@]}"; do
       group_name="${group_entry%%|*}"
       group_targets="${group_entry#*|}"
@@ -645,7 +733,11 @@ target_selected() {
 }
 
 main() {
-  need uv; need curl
+  need curl
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "Missing required command: python3 (used for fixture generation and wrk stats)" >&2
+    exit 1
+  fi
   if ! command -v "$WRK" >/dev/null 2>&1; then
     echo "Missing wrk executable: $WRK" >&2
     echo "Install wrk or set WRK=/path/to/wrk." >&2
@@ -659,6 +751,12 @@ main() {
   case "${selected[0]}" in -h|--help|help) usage; exit 0 ;; esac
   for target in "${selected[@]}"; do known_target "$target" || { echo "Unknown target: $target" >&2; usage >&2; exit 1; }; done
   for endpoint in "${ENDPOINTS[@]}"; do path_for "$endpoint" >/dev/null || exit 1; done
+  if needs_uv "${selected[@]}"; then
+    need uv
+  fi
+  if needs_go "${selected[@]}"; then
+    need go
+  fi
 
   ensure_fixtures "$(python_for "${selected[0]}")"
   if [[ ! -x "$(python_for "${selected[0]}")" ]]; then
@@ -678,6 +776,7 @@ upload_connections=$UPLOAD_CONNECTIONS
 runs=$RUNS
 warmup=$WARMUP
 python=$PYTHON
+bench_procs=$BENCH_PROCS
 client=$WRK
 keep_raw=$KEEP_RAW
 endpoints=${ENDPOINTS[*]}

--- a/benchmarks/server/run.sh
+++ b/benchmarks/server/run.sh
@@ -19,7 +19,7 @@ WRK="${WRK:-wrk}"
 BROTLI_PKG_CONFIG="${BROTLI_PKG_CONFIG:-}"
 BENCH_PROCS="${BENCH_PROCS:-$(nproc 2>/dev/null || echo 4)}"
 TARGETS=(
-  stario stario-cython
+  stario stario-cython stario-n stario-cython-n
   go-nethttp go-nethttp-n go-fasthttp
   socketify robyn granian-rsgi granian-rsgi-n sanic django-bolt
   blacksheep-granian blacksheep-uvicorn fastapi
@@ -27,6 +27,8 @@ TARGETS=(
 TARGET_LABELS=(
   "stario|Stario (Python httptools)"
   "stario-cython|Stario (Cython llhttp)"
+  "stario-n|Stario (Python, ${BENCH_PROCS} processes, SO_REUSEPORT)"
+  "stario-cython-n|Stario (Cython, ${BENCH_PROCS} processes, SO_REUSEPORT)"
   "go-nethttp|Go net/http (GOMAXPROCS=1)"
   "go-nethttp-n|Go net/http (GOMAXPROCS=${BENCH_PROCS})"
   "go-fasthttp|Go fasthttp (GOMAXPROCS=1)"
@@ -41,7 +43,7 @@ TARGET_LABELS=(
   "fastapi|FastAPI + Uvicorn ASGI"
 )
 SUMMARY_GROUPS=(
-  "Stario (this checkout)|stario stario-cython"
+  "Stario (this checkout)|stario stario-n stario-cython stario-cython-n"
   "Go|go-nethttp go-nethttp-n go-fasthttp"
   "Native HTTP servers|socketify robyn granian-rsgi granian-rsgi-n sanic django-bolt"
   "ASGI framework stacks|blacksheep-granian blacksheep-uvicorn fastapi"
@@ -71,6 +73,7 @@ ENDPOINT_LABELS=(
 
 RUN_DIR=""
 SERVER_PID=""
+SERVER_PIDS=()
 SERVER_PORT=""
 SERVER_CMD=()
 SELECTED_TARGETS=()
@@ -80,14 +83,16 @@ usage() {
 Usage: benchmarks/server/run.sh [target ...]
 
 Targets (default: all):
-  Stario:              stario, stario-cython
+  Stario:              stario, stario-cython, stario-n, stario-cython-n
   Go:                  go-nethttp, go-nethttp-n, go-fasthttp
   Native HTTP servers: socketify, robyn, granian-rsgi, granian-rsgi-n, sanic, django-bolt
   ASGI stacks:         blacksheep-granian, blacksheep-uvicorn, fastapi
 
   go-nethttp / go-fasthttp pin GOMAXPROCS=1 (same 1-core budget as the
-  Python/Cython one-worker rows). go-nethttp-n and granian-rsgi-n fill the
-  box: one Go process with GOMAXPROCS=\$BENCH_PROCS, or N Granian workers.
+  Python/Cython one-worker rows). *-n targets fill the box: Go uses
+  GOMAXPROCS=\$BENCH_PROCS in one process; stario-n / stario-cython-n start
+  N processes on one port with STARIO_REUSE_PORT=1; granian-rsgi-n uses
+  N workers.
 
 Environment: DURATION=10s THREADS=2 CONNECTIONS=128 UPLOAD_CONNECTIONS=32
              RUNS=7 WARMUP=2 HOST=127.0.0.1 PORT=3000 PYTHON=3.14
@@ -251,13 +256,29 @@ host_python() {
   echo "python3"
 }
 
+env_name_for() {
+  case "$1" in
+    stario-n) echo stario ;;
+    stario-cython-n) echo stario-cython ;;
+    granian-rsgi-n) echo granian-rsgi ;;
+    *) echo "$1" ;;
+  esac
+}
+
 python_for() {
-  local candidate="$ENVS_DIR/$1/bin/python"
+  local candidate="$ENVS_DIR/$(env_name_for "$1")/bin/python"
   if [[ -x "$candidate" ]]; then
     echo "$candidate"
   else
     host_python
   fi
+}
+
+workers_for() {
+  case "$1" in
+    stario-n|stario-cython-n) echo "$BENCH_PROCS" ;;
+    *) echo 1 ;;
+  esac
 }
 
 needs_uv() {
@@ -350,8 +371,8 @@ target_label() {
 
 ensure_target() {
   case "$1" in
-    stario) ensure_env stario "stario @ file://$ROOT" uvloop ujson ;;
-    stario-cython)
+    stario|stario-n) ensure_env stario "stario @ file://$ROOT" uvloop ujson ;;
+    stario-cython|stario-cython-n)
       ensure_env stario-cython "stario @ file://$ROOT" uvloop ujson cython setuptools wheel
       build_stario_cython "$(python_for stario-cython)"
       ;;
@@ -392,7 +413,7 @@ uvicorn_cmd() {
 
 command_for() {
   case "$1" in
-    stario|stario-cython)
+    stario|stario-cython|stario-n|stario-cython-n)
       export STARIO_HOST="$HOST"
       export STARIO_PORT="$SERVER_PORT"
       export STARIO_LOOP=uvloop
@@ -400,9 +421,14 @@ command_for() {
       export STARIO_COMPRESS_ZSTD_LEVEL=-1
       export STARIO_COMPRESS_BROTLI_LEVEL=-1
       export STARIO_COMPRESS_GZIP_LEVEL=-1
-      if [[ "$1" == stario-cython ]]; then
+      case "$1" in
+        stario-n|stario-cython-n) export STARIO_REUSE_PORT=1 ;;
+        *) export STARIO_REUSE_PORT=0 ;;
+      esac
+      if [[ "$1" == stario-cython || "$1" == stario-cython-n ]]; then
         SERVER_CMD=(
           env PYTHONPATH="$ROOT/src:$BENCHMARK_DIR"
+          STARIO_REUSE_PORT="$STARIO_REUSE_PORT"
           "$(python_for stario-cython)" -m stario_cython apps.stario_app:bootstrap
         )
       else
@@ -495,19 +521,38 @@ command_for() {
 }
 
 stop_server() {
-  if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
-    kill "$SERVER_PID" >/dev/null 2>&1 || true
-    local deadline=$((SECONDS + 5))
-    while kill -0 "$SERVER_PID" >/dev/null 2>&1; do
-      if ((SECONDS >= deadline)); then
-        kill -9 "$SERVER_PID" >/dev/null 2>&1 || true
-        break
+  local pid deadline=$((SECONDS + 5))
+  if ((${#SERVER_PIDS[@]})); then
+    for pid in "${SERVER_PIDS[@]}"; do
+      if [[ -n "$pid" ]] && kill -0 "$pid" >/dev/null 2>&1; then
+        kill "$pid" >/dev/null 2>&1 || true
       fi
-      sleep 0.1
     done
-    wait "$SERVER_PID" >/dev/null 2>&1 || true
+    for pid in "${SERVER_PIDS[@]}"; do
+      [[ -n "$pid" ]] || continue
+      while kill -0 "$pid" >/dev/null 2>&1; do
+        if ((SECONDS >= deadline)); then
+          kill -9 "$pid" >/dev/null 2>&1 || true
+          break
+        fi
+        sleep 0.1
+      done
+      wait "$pid" >/dev/null 2>&1 || true
+    done
   fi
   SERVER_PID=""
+  SERVER_PIDS=()
+}
+
+workers_alive() {
+  local pid
+  ((${#SERVER_PIDS[@]})) || return 1
+  for pid in "${SERVER_PIDS[@]}"; do
+    if [[ -n "$pid" ]] && ! kill -0 "$pid" >/dev/null 2>&1; then
+      return 1
+    fi
+  done
+  return 0
 }
 
 fail_with_log() {
@@ -520,7 +565,7 @@ fail_with_log() {
 wait_ready() {
   local url="http://$HOST:$SERVER_PORT/plaintext" deadline=$((SECONDS + 30)) log="$1"
   until curl -fsS --max-time 1 "$url" >/dev/null 2>&1; do
-    if [[ -n "$SERVER_PID" ]] && ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    if ! workers_alive; then
       fail_with_log "Server exited before it was ready." "$log"
     fi
     if ((SECONDS >= deadline)); then
@@ -528,17 +573,26 @@ wait_ready() {
     fi
     sleep 0.1
   done
-  if [[ -n "$SERVER_PID" ]] && ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+  if ! workers_alive; then
     fail_with_log "Server exited after readiness check." "$log"
   fi
 }
 
 start_server() {
-  local target="$1" log="$RUN_DIR/$target.server.log"
+  local target="$1" log="$RUN_DIR/$target.server.log" workers i
   command_for "$target"
+  workers="$(workers_for "$target")"
   echo "+ ${SERVER_CMD[*]}"
-  (cd "$ROOT" && exec env PYTHONPATH="$BENCHMARK_DIR" "${SERVER_CMD[@]}") >"$log" 2>&1 &
-  SERVER_PID="$!"
+  if ((workers > 1)); then
+    echo "  $workers processes on $HOST:$SERVER_PORT (STARIO_REUSE_PORT=1)"
+  fi
+  SERVER_PIDS=()
+  : >"$log"
+  for ((i = 0; i < workers; i++)); do
+    (cd "$ROOT" && exec env PYTHONPATH="$ROOT/src:$BENCHMARK_DIR" "${SERVER_CMD[@]}") >>"$log" 2>&1 &
+    SERVER_PIDS+=("$!")
+  done
+  SERVER_PID="${SERVER_PIDS[0]}"
   wait_ready "$log"
 }
 
@@ -692,7 +746,7 @@ print_summary() {
     echo "Median requests/sec ± sample stdev after discarding $WARMUP warmup run(s)"
     echo "and applying IQR outlier trimming across $RUNS measured samples per endpoint."
     echo "Large uploads use $UPLOAD_CONNECTIONS connections; other cases use $CONNECTIONS."
-    echo "Go \`*-n\` / Granian \`*-n\` use BENCH_PROCS=$BENCH_PROCS cores or workers; other rows stay 1 worker / GOMAXPROCS=1."
+    echo "Go \`*-n\` uses BENCH_PROCS=$BENCH_PROCS in one process; stario-n / stario-cython-n start $BENCH_PROCS processes with STARIO_REUSE_PORT=1; granian-rsgi-n uses $BENCH_PROCS workers. Other rows stay 1 worker / GOMAXPROCS=1."
     for group_entry in "${SUMMARY_GROUPS[@]}"; do
       group_name="${group_entry%%|*}"
       group_targets="${group_entry#*|}"

--- a/benchmarks/server/run.sh
+++ b/benchmarks/server/run.sh
@@ -303,9 +303,9 @@ PY
 }
 
 ensure_env() {
-  local name="$1" python
+  local name="$1"
+  local python="$ENVS_DIR/$name/bin/python"
   shift
-  python="$(python_for "$name")"
   [[ "${REFRESH_ENVS:-0}" == 1 ]] && rm -rf "$ENVS_DIR/$name"
   if [[ ! -x "$python" ]]; then
     uv venv "$ENVS_DIR/$name" --python "$PYTHON"
@@ -758,11 +758,7 @@ main() {
     need go
   fi
 
-  ensure_fixtures "$(python_for "${selected[0]}")"
-  if [[ ! -x "$(python_for "${selected[0]}")" ]]; then
-    ensure_target "${selected[0]}"
-    ensure_fixtures "$(python_for "${selected[0]}")"
-  fi
+  ensure_fixtures "$(host_python)"
 
   RUN_DIR="$RESULTS_DIR/$(date -u +%Y%m%dT%H%M%SZ)"
   mkdir -p "$RUN_DIR"

--- a/benchmarks/server/run.sh
+++ b/benchmarks/server/run.sh
@@ -24,6 +24,7 @@ TARGETS=(
   socketify robyn granian-rsgi granian-rsgi-n sanic django-bolt
   blacksheep-granian blacksheep-uvicorn fastapi
   aiohttp-n litestar-n pyronova-n
+  aiohttp litestar pyronova
 )
 TARGET_LABELS=(
   "stario|Stario (Python httptools)"
@@ -45,13 +46,17 @@ TARGET_LABELS=(
   "aiohttp-n|aiohttp + uvloop (${BENCH_PROCS} processes, SO_REUSEPORT)"
   "litestar-n|Litestar + Uvicorn (${BENCH_PROCS} workers, uvloop/httptools)"
   "pyronova-n|Pyronova (${BENCH_PROCS} sub-interpreters)"
+  "aiohttp|aiohttp + uvloop (1 process)"
+  "litestar|Litestar + Uvicorn (1 worker, uvloop/httptools)"
+  "pyronova|Pyronova (1 sub-interpreter)"
 )
 SUMMARY_GROUPS=(
   "Stario (this checkout)|stario stario-n stario-cython stario-cython-n"
   "Go|go-nethttp go-nethttp-n go-fasthttp"
   "Native HTTP servers|socketify robyn granian-rsgi granian-rsgi-n sanic django-bolt"
   "ASGI framework stacks|blacksheep-granian blacksheep-uvicorn fastapi"
-  "Production Python peers|aiohttp-n litestar-n pyronova-n"
+  "Production Python peers (fill the box)|aiohttp-n litestar-n pyronova-n stario-cython-n"
+  "Production Python peers (1 worker)|aiohttp litestar pyronova stario-cython"
 )
 READ_ENDPOINTS=(plaintext json params)
 UPLOAD_ENDPOINTS=(validate post-form post-json-1k post-octet-64k post-octet-2m post-stream-2m multipart-2m)
@@ -93,6 +98,7 @@ Targets (default: all):
   Native HTTP servers: socketify, robyn, granian-rsgi, granian-rsgi-n, sanic, django-bolt
   ASGI stacks:         blacksheep-granian, blacksheep-uvicorn, fastapi
   Production peers:    aiohttp-n, litestar-n, pyronova-n
+                       aiohttp, litestar, pyronova (1 worker)
 
   go-nethttp / go-fasthttp pin GOMAXPROCS=1 (same 1-core budget as the
   Python/Cython one-worker rows). *-n targets fill the box: Go uses
@@ -392,9 +398,9 @@ ensure_target() {
     sanic) ensure_env sanic sanic uvloop ujson ;;
     django-bolt) ensure_env django-bolt django django-bolt msgspec ujson ;;
     fastapi) ensure_env fastapi fastapi 'uvicorn[standard]' ujson ;;
-    aiohttp-n) ensure_env aiohttp aiohttp uvloop ujson ;;
-    litestar-n) ensure_env litestar litestar 'uvicorn[standard]' msgspec ;;
-    pyronova-n) ensure_env pyronova pyronova ;;
+    aiohttp|aiohttp-n) ensure_env aiohttp aiohttp uvloop ujson ;;
+    litestar|litestar-n) ensure_env litestar litestar 'uvicorn[standard]' msgspec ;;
+    pyronova|pyronova-n) ensure_env pyronova pyronova ;;
     blacksheep-uvicorn) ensure_env blacksheep-uvicorn blacksheep 'uvicorn[standard]' ujson ;;
     blacksheep-granian) ensure_env blacksheep-granian blacksheep granian uvloop ujson ;;
     granian-rsgi-n) ensure_env granian-rsgi granian uvloop ujson ;;
@@ -530,32 +536,41 @@ command_for() {
         runbolt --host "$HOST" --port "$SERVER_PORT" --processes 1
       )
       ;;
-    aiohttp-n)
+    aiohttp|aiohttp-n)
       export BENCH_HOST="$HOST"
       export BENCH_PORT="$SERVER_PORT"
-      export AIOHTTP_REUSE_PORT=1
+      if [[ "$1" == aiohttp-n ]]; then
+        export AIOHTTP_REUSE_PORT=1
+      else
+        export AIOHTTP_REUSE_PORT=0
+      fi
       SERVER_CMD=(
         "$(python_for aiohttp)" "$BENCHMARK_DIR/apps/aiohttp_app.py"
         --host "$HOST" --port "$SERVER_PORT"
       )
       ;;
-    litestar-n)
+    litestar|litestar-n)
+      local uv_workers=1
+      [[ "$1" == litestar-n ]] && uv_workers="$BENCH_PROCS"
       SERVER_CMD=(
         "$(python_for litestar)" -m uvicorn apps.litestar_app:app
         --host "$HOST" --port "$SERVER_PORT"
-        --workers "$BENCH_PROCS"
+        --workers "$uv_workers"
         --loop uvloop
         --http httptools
         --no-access-log
         --log-level warning
       )
       ;;
-    pyronova-n)
+    pyronova|pyronova-n)
+      local pyro_workers=1
+      [[ "$1" == pyronova-n ]] && pyro_workers="$BENCH_PROCS"
       export BENCH_HOST="$HOST"
       export BENCH_PORT="$SERVER_PORT"
       export PYRONOVA_HOST="$HOST"
       export PYRONOVA_PORT="$SERVER_PORT"
-      export PYRONOVA_WORKERS="$BENCH_PROCS"
+      export PYRONOVA_WORKERS="$pyro_workers"
+      export PYRONOVA_IO_WORKERS="$pyro_workers"
       SERVER_CMD=(
         "$(python_for pyronova)" "$BENCHMARK_DIR/apps/pyronova_app.py"
       )

--- a/src/stario/cli/help.py
+++ b/src/stario/cli/help.py
@@ -11,6 +11,7 @@ Listen:
   STARIO_UNIX_SOCKET_MODE=660  (octal; after bind on unix socket)
   STARIO_BACKLOG=2048
   STARIO_REUSE_ADDR=1          (TCP only; set 0 to disable SO_REUSEADDR)
+  STARIO_REUSE_PORT=0          (TCP only; set 1 for SO_REUSEPORT / shared listen)
   STARIO_GRACEFUL_SHUTDOWN_TIMEOUT=5
 
 Telemetry (STARIO_TRACER plus json/sqlite backend tuning):

--- a/src/stario/http/config.py
+++ b/src/stario/http/config.py
@@ -32,6 +32,7 @@ DEFAULT_UNIX_SOCKET_MODE = 0o660
 DEFAULT_HEADER_TIMEOUT = 5.0
 DEFAULT_KEEP_ALIVE_TIMEOUT = 5.0
 DEFAULT_REUSE_ADDR = True
+DEFAULT_REUSE_PORT = False
 DEFAULT_MAX_PIPELINED_REQUESTS = 8
 DEFAULT_EVENT_LOOP = "asyncio"
 
@@ -130,8 +131,8 @@ def request_policy_from_env() -> RequestPolicy:
 class ServerConfig:
     """Listen address, transport policy, request policy, compression, and shutdown.
 
-    When `unix_socket` is set, `host`, `port`, and `reuse_addr` are ignored; only
-    `backlog` and `unix_socket_mode` apply to the Unix listener.
+    When `unix_socket` is set, `host`, `port`, `reuse_addr`, and `reuse_port`
+    are ignored; only `backlog` and `unix_socket_mode` apply to the Unix listener.
 
     Nested `requests` and `compression` objects are stored by reference; treat
     as immutable after construction.
@@ -151,6 +152,7 @@ class ServerConfig:
         "port",
         "requests",
         "reuse_addr",
+        "reuse_port",
         "unix_socket",
         "unix_socket_mode",
     )
@@ -167,6 +169,7 @@ class ServerConfig:
         graceful_shutdown_timeout: float = DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT,
         backlog: int = DEFAULT_BACKLOG,
         reuse_addr: bool = DEFAULT_REUSE_ADDR,
+        reuse_port: bool = DEFAULT_REUSE_PORT,
         event_loop: EventLoopKind = DEFAULT_EVENT_LOOP,
     ) -> None:
         if not 1 <= port <= 65535:
@@ -216,6 +219,7 @@ class ServerConfig:
         self.graceful_shutdown_timeout = graceful_shutdown_timeout
         self.backlog = backlog
         self.reuse_addr = reuse_addr
+        self.reuse_port = reuse_port
         self.event_loop: EventLoopKind = event_loop
 
 
@@ -246,6 +250,7 @@ def server_config_from_env() -> ServerConfig:
             ),
             backlog=env_int("STARIO_BACKLOG", DEFAULT_BACKLOG),
             reuse_addr=env_bool("STARIO_REUSE_ADDR", DEFAULT_REUSE_ADDR),
+            reuse_port=env_bool("STARIO_REUSE_PORT", DEFAULT_REUSE_PORT),
             event_loop=_event_loop_from_env(),
         )
     )

--- a/src/stario/http/server.py
+++ b/src/stario/http/server.py
@@ -192,6 +192,7 @@ class Server:
             self.config.port,
             backlog=self.config.backlog,
             reuse_address=self.config.reuse_addr,
+            reuse_port=self.config.reuse_port,
         )
 
     async def _drain_listener(
@@ -494,6 +495,7 @@ class Server:
             attrs["server.host"] = self.config.host
             attrs["server.port"] = self.config.port
             attrs["server.reuse_addr"] = self.config.reuse_addr
+            attrs["server.reuse_port"] = self.config.reuse_port
         attrs["server.limits.max_request_header_bytes"] = (
             self.config.requests.max_header_bytes
         )

--- a/src/stario_cython/serve.py
+++ b/src/stario_cython/serve.py
@@ -11,6 +11,7 @@ from email.utils import format_datetime
 
 import uvloop
 
+from stario._env import env_bool
 from stario.http.app import App
 from stario.http.bootstrap import Bootstrap, bootstrap_run
 from stario.http.compression import compression_config_from_env
@@ -67,6 +68,7 @@ async def serve(
             port,
             backlog=backlog,
             reuse_address=True,
+            reuse_port=env_bool("STARIO_REUSE_PORT", False),
         )
         span.attr("server.listening", True)
         span.attr("server.http_core", "cython")

--- a/tests/test_cli_env.py
+++ b/tests/test_cli_env.py
@@ -13,6 +13,7 @@ def test_server_config_from_env_reads_overrides(monkeypatch) -> None:
     monkeypatch.setenv("STARIO_UNIX_SOCKET", "/tmp/stario.sock")
     monkeypatch.setenv("STARIO_GRACEFUL_SHUTDOWN_TIMEOUT", "12.5")
     monkeypatch.setenv("STARIO_REUSE_ADDR", "0")
+    monkeypatch.setenv("STARIO_REUSE_PORT", "1")
 
     config = server_config_from_env()
     assert config.host == "0.0.0.0"
@@ -21,6 +22,7 @@ def test_server_config_from_env_reads_overrides(monkeypatch) -> None:
     assert config.unix_socket == "/tmp/stario.sock"
     assert config.graceful_shutdown_timeout == 12.5
     assert config.reuse_addr is False
+    assert config.reuse_port is True
 
 
 @pytest.mark.parametrize(
@@ -35,6 +37,7 @@ def test_server_config_from_env_reads_overrides(monkeypatch) -> None:
             "header_timeout must be greater than 0",
         ),
         ("STARIO_REUSE_ADDR", "maybe", "STARIO_REUSE_ADDR"),
+        ("STARIO_REUSE_PORT", "maybe", "STARIO_REUSE_PORT"),
     ],
 )
 def test_invalid_server_env_raises(monkeypatch, env_name, value, fragment) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -417,3 +417,57 @@ def test_unix_socket_cleanup_only_unlinks_owned_socket() -> None:
             replacement.close()
             if os.path.exists(path):
                 os.unlink(path)
+
+
+async def test_reuse_port_lets_two_servers_share_a_tcp_port() -> None:
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+
+    apps: list[App] = []
+
+    async def serve_bootstrap(app: App, span: Any):
+        apps.append(app)
+
+        async def hello(c, w):
+            responses.text(w, "shared")
+
+        app.get("/plaintext", hello)
+        yield
+
+    def make() -> Server:
+        return Server(
+            serve_bootstrap,
+            JsonTracer(StringIO()),
+            config=ServerConfig(
+                host="127.0.0.1",
+                port=port,
+                reuse_port=True,
+                graceful_shutdown_timeout=0.3,
+            ),
+        )
+
+    tasks = [asyncio.create_task(_serve(make())), asyncio.create_task(_serve(make()))]
+    try:
+        async with asyncio.timeout(2.0):
+            while True:
+                try:
+                    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+                    break
+                except OSError:
+                    await asyncio.sleep(0.01)
+        writer.write(b"GET /plaintext HTTP/1.1\r\nHost: t\r\n\r\n")
+        await writer.drain()
+        status, body = await _read_http_response(reader)
+        writer.close()
+        assert status == 200
+        assert body == b"shared"
+        assert len(apps) == 2
+    finally:
+        for app in apps:
+            drain = app.shutdown
+            if drain is not None and not drain.done():
+                drain.set_result(None)
+        async with asyncio.timeout(2.0):
+            await asyncio.gather(*tasks)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ports the Cython/Python server benchmark app to Go and adds multi-process Stario via `STARIO_REUSE_PORT`.

**Claim framing** (`benchmarks/server/positioning.md`): Stario is the fastest *Python framework* we measured. Granian, Socketify, and Pyronova are native HTTP engines with Python callbacks — 1–1 on hello-world is the deal, not the headline.

**Same-machine production peers** (`benchmarks/server/production-peers.md`), 4 vCPU, honest 10 routes, wrk 10s × 3:

- **1 worker:** Cython 129k plaintext vs aiohttp 51k (~2.5×), Litestar 30k (~4.3×), Pyronova 143k (they edge hello-world; we win validate 106k vs 87k).
- **Fill the box (×4):** Cython 282k vs aiohttp 155k (~1.8×), Litestar 101k (~2.8×). Pyronova `WORKERS>=2` aborts (double-free / SIGSEGV on CPython 3.14).

**HttpArena context:** aiohttp is #1 flagship Python composite (240); Litestar 236; Pyronova is experimental+tuned (431) with a JSON byte cache. Those RPS numbers are a 64-core box — do not mix with the table above.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03a09-ec58-76ef-9ea3-9a542990f638?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03a09-ec58-76ef-9ea3-9a542990f638&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

