### PR TITLE
Move Router and App to Cython for request dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## Unreleased
 
+### Changed
+
+- Cython protocol uses compiled `Router` and `App` (`stario_cython.router` / `stario_cython.app`): in-place host/path trie walks, nested match cache, and `create_task` / request entry in C. Python httptools (`stario.http.dispatch` / `stario.http.app`) is unchanged.
+
 ## 4.1.0 - 2026-08-17
 
 ### Added

--- a/benchmarks/server/run.sh
+++ b/benchmarks/server/run.sh
@@ -660,11 +660,10 @@ main() {
   for target in "${selected[@]}"; do known_target "$target" || { echo "Unknown target: $target" >&2; usage >&2; exit 1; }; done
   for endpoint in "${ENDPOINTS[@]}"; do path_for "$endpoint" >/dev/null || exit 1; done
 
-  ensure_fixtures "$(python_for "${selected[0]}")"
   if [[ ! -x "$(python_for "${selected[0]}")" ]]; then
     ensure_target "${selected[0]}"
-    ensure_fixtures "$(python_for "${selected[0]}")"
   fi
+  ensure_fixtures "$(python_for "${selected[0]}")"
 
   RUN_DIR="$RESULTS_DIR/$(date -u +%Y%m%dT%H%M%SZ)"
   mkdir -p "$RUN_DIR"

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,16 @@ codec_link_args = _pkg_config(_CODEC_PACKAGES, "--libs-only-other")
 
 extensions = [
     Extension(
+        "stario_cython.router",
+        sources=["src/stario_cython/router.pyx"],
+        extra_compile_args=["-O3"],
+    ),
+    Extension(
+        "stario_cython.app",
+        sources=["src/stario_cython/app.pyx"],
+        extra_compile_args=["-O3"],
+    ),
+    Extension(
         "stario_cython.headers",
         sources=["src/stario_cython/headers.pyx"],
         extra_compile_args=["-O3"],

--- a/src/stario_cython/app.pxd
+++ b/src/stario_cython/app.pxd
@@ -8,3 +8,4 @@ cdef class App(Router):
     cdef object _loop
     cdef object _task_discard
     cdef bint _eager_start
+    cdef bint _eager_via_create_task

--- a/src/stario_cython/app.pxd
+++ b/src/stario_cython/app.pxd
@@ -8,4 +8,3 @@ cdef class App(Router):
     cdef object _loop
     cdef object _task_discard
     cdef bint _eager_start
-    cdef bint _eager_via_create_task

--- a/src/stario_cython/app.pxd
+++ b/src/stario_cython/app.pxd
@@ -7,3 +7,4 @@ cdef class App(Router):
     cdef object _find_error_handler
     cdef object _loop
     cdef object _task_discard
+    cdef bint _eager_start

--- a/src/stario_cython/app.pxd
+++ b/src/stario_cython/app.pxd
@@ -1,0 +1,9 @@
+from stario_cython.router cimport Router
+
+cdef class App(Router):
+    cdef public object shutdown
+    cdef public object tasks
+    cdef dict _error_handlers
+    cdef object _find_error_handler
+    cdef object _loop
+    cdef object _task_discard

--- a/src/stario_cython/app.pyx
+++ b/src/stario_cython/app.pyx
@@ -20,6 +20,10 @@ from stario_cython.router cimport Router
 cdef object NOOP_SPAN_TYPE = NoOpSpan
 
 
+async def _eager_probe():
+    return None
+
+
 async def _default_http_exception(_c, w, exc):
     responses.text(w, exc.detail or "Error", exc.status_code)
 
@@ -48,6 +52,14 @@ cdef class App(Router):
         self.shutdown = loop.create_future()
         self.tasks = set()
         self._task_discard = self.tasks.discard
+        self._eager_start = False
+        try:
+            probe = loop.create_task(_eager_probe(), eager_start=True)
+            self._eager_start = True
+            if not probe.done():
+                probe.cancel()
+        except TypeError:
+            pass
         self._error_handlers = {
             HttpException: _default_http_exception,
             RedirectException: _default_redirect_exception,
@@ -89,7 +101,7 @@ cdef class App(Router):
                     "app.create_task() requires a running event loop",
                     help_text="Call app.create_task() from async code while the app is running.",
                 ) from exc
-        if eager_start:
+        if eager_start and self._eager_start:
             task = loop.create_task(coro, name=name, eager_start=True)
         else:
             task = loop.create_task(coro, name=name)

--- a/src/stario_cython/app.pyx
+++ b/src/stario_cython/app.pyx
@@ -53,21 +53,13 @@ cdef class App(Router):
         self.tasks = set()
         self._task_discard = self.tasks.discard
         self._eager_start = False
-        self._eager_via_create_task = False
         try:
             probe = loop.create_task(_eager_probe(), eager_start=True)
             self._eager_start = True
-            self._eager_via_create_task = True
             if not probe.done():
                 probe.cancel()
         except TypeError:
-            try:
-                probe = asyncio.Task(_eager_probe(), loop=loop, eager_start=True)
-                self._eager_start = True
-                if not probe.done():
-                    probe.cancel()
-            except TypeError:
-                pass
+            pass
         self._error_handlers = {
             HttpException: _default_http_exception,
             RedirectException: _default_redirect_exception,
@@ -110,10 +102,7 @@ cdef class App(Router):
                     help_text="Call app.create_task() from async code while the app is running.",
                 ) from exc
         if eager_start and self._eager_start:
-            if self._eager_via_create_task:
-                task = loop.create_task(coro, name=name, eager_start=True)
-            else:
-                task = asyncio.Task(coro, loop=loop, name=name, eager_start=True)
+            task = loop.create_task(coro, name=name, eager_start=True)
         else:
             task = loop.create_task(coro, name=name)
         if not task.done():

--- a/src/stario_cython/app.pyx
+++ b/src/stario_cython/app.pyx
@@ -1,0 +1,183 @@
+# cython: language_level=3
+"""Cython App: compiled create_task + request entry, on the Cython Router trie."""
+
+import asyncio
+from functools import lru_cache
+
+import stario.responses as responses
+from stario.exceptions import (
+    ClientDisconnected,
+    HttpException,
+    RedirectException,
+    StarioError,
+    StarioRuntime,
+)
+from stario.routing.locations import normalize_path
+from stario.telemetry.spans import NoOpSpan
+
+from stario_cython.router cimport Router
+
+cdef object NOOP_SPAN_TYPE = NoOpSpan
+
+
+async def _default_http_exception(_c, w, exc):
+    responses.text(w, exc.detail or "Error", exc.status_code)
+
+
+async def _default_redirect_exception(_c, w, exc):
+    responses.redirect(w, exc.location, exc.status_code)
+
+
+async def _default_client_disconnected(_c, w, _exc):
+    w.abort()
+
+
+cdef class App(Router):
+    """Concrete app type: everything on `Router` plus errors and shutdown-aware tasks."""
+
+    def __init__(self):
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError as exc:
+            raise StarioError(
+                "App() requires a running event loop",
+                help_text="Create App inside serve(), bootstrap, or async test code.",
+            ) from exc
+
+        self._loop = loop
+        self.shutdown = loop.create_future()
+        self.tasks = set()
+        self._task_discard = self.tasks.discard
+        self._error_handlers = {
+            HttpException: _default_http_exception,
+            RedirectException: _default_redirect_exception,
+            ClientDisconnected: _default_client_disconnected,
+        }
+
+        @lru_cache(maxsize=64)
+        def find_handler(exc_type):
+            for t in exc_type.__mro__:
+                if t is Exception:
+                    return None
+                handler = self._error_handlers.get(t)
+                if handler is not None:
+                    return handler
+            return None
+
+        self._find_error_handler = find_handler
+
+    @property
+    def shutting_down(self):
+        return self.shutdown.done()
+
+    def signal_shutdown(self):
+        if not self.shutdown.done():
+            self.shutdown.set_result(None)
+
+    def on_error(self, exc_type, handler):
+        self._error_handlers[exc_type] = handler
+        self._find_error_handler.cache_clear()
+
+    def create_task(self, coro, *, loop=None, name=None, eager_start=False):
+        """Schedule a coroutine on the running loop and retain the task until it completes."""
+        cdef object task
+        if loop is None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError as exc:
+                raise StarioError(
+                    "app.create_task() requires a running event loop",
+                    help_text="Call app.create_task() from async code while the app is running.",
+                ) from exc
+        if eager_start:
+            task = loop.create_task(coro, name=name, eager_start=True)
+        else:
+            task = loop.create_task(coro, name=name)
+        if not task.done():
+            self.tasks.add(task)
+            task.add_done_callback(self._task_discard)
+        return task
+
+    async def drain_tasks(self):
+        while True:
+            pending = set(self.tasks)
+            if not pending:
+                return
+            await asyncio.wait(pending, return_when=asyncio.ALL_COMPLETED)
+
+    async def __call__(self, object c, object w):
+        cdef object span = c.span
+        cdef bint traced = type(span) is not NOOP_SPAN_TYPE
+        cdef object req = c.req
+        cdef object path = req.path
+        cdef object method = req.method
+        cdef object host
+        cdef object handler
+        cdef object route
+        cdef object target
+        cdef object query_bytes
+        cdef object exc
+        cdef object err_handler
+        cdef bint failed_after_start = False
+        cdef bint handler_responded
+
+        if traced:
+            span.start()
+            span.attrs({"request.method": method, "request.path": path})
+
+        try:
+            if path != "/" and path.endswith("/"):
+                target = normalize_path(path)
+                query_bytes = req.query_bytes
+                if query_bytes:
+                    target = f"{target}?{query_bytes.decode('latin-1')}"
+                responses.redirect(w, target, 308)
+                return
+
+            host = req.host if self._has_hosts else ""
+            handler, route = self.find_handler(host, path, method)
+            c.route = route
+            await handler(c, w)
+            if not w.started and not w.completed:
+                raise StarioRuntime(
+                    "Handler returned without sending a response",
+                    context={
+                        "method": method,
+                        "path": path,
+                        "route": route.pattern or None,
+                    },
+                    help_text=(
+                        "Call a response helper such as responses.text/json/html/empty, "
+                        "or explicitly use Writer.write_headers()/write()/end()."
+                    ),
+                )
+
+        except Exception as exc:
+            handler_responded = False
+            failed_after_start = w.started
+            if not w.started:
+                err_handler = self._find_error_handler(type(exc))
+                if err_handler is not None:
+                    try:
+                        await err_handler(c, w, exc)
+                        handler_responded = w.started or w.completed
+                    except Exception as handler_exc:
+                        failed_after_start = w.started
+                        exc = handler_exc
+                if not handler_responded:
+                    responses.text(w, "Internal Server Error", 500)
+            if not handler_responded:
+                if traced:
+                    span.fail(str(exc))
+                    span.exception(exc)
+        finally:
+            if failed_after_start and not w.completed:
+                w.abort()
+            else:
+                w.end()
+            if traced:
+                span.attr("response.status_code", w.status_code)
+                span.end()
+
+
+__all__ = ["App"]

--- a/src/stario_cython/app.pyx
+++ b/src/stario_cython/app.pyx
@@ -53,13 +53,21 @@ cdef class App(Router):
         self.tasks = set()
         self._task_discard = self.tasks.discard
         self._eager_start = False
+        self._eager_via_create_task = False
         try:
             probe = loop.create_task(_eager_probe(), eager_start=True)
             self._eager_start = True
+            self._eager_via_create_task = True
             if not probe.done():
                 probe.cancel()
         except TypeError:
-            pass
+            try:
+                probe = asyncio.Task(_eager_probe(), loop=loop, eager_start=True)
+                self._eager_start = True
+                if not probe.done():
+                    probe.cancel()
+            except TypeError:
+                pass
         self._error_handlers = {
             HttpException: _default_http_exception,
             RedirectException: _default_redirect_exception,
@@ -102,7 +110,10 @@ cdef class App(Router):
                     help_text="Call app.create_task() from async code while the app is running.",
                 ) from exc
         if eager_start and self._eager_start:
-            task = loop.create_task(coro, name=name, eager_start=True)
+            if self._eager_via_create_task:
+                task = loop.create_task(coro, name=name, eager_start=True)
+            else:
+                task = asyncio.Task(coro, loop=loop, name=name, eager_start=True)
         else:
             task = loop.create_task(coro, name=name)
         if not task.done():

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -172,6 +172,7 @@ cdef class HttpProtocol:
     cdef llhttp_t* parser
     cdef object loop
     cdef object app
+    cdef object _create_task
     cdef object tracer
     cdef object noop_span
     cdef list date_box
@@ -220,6 +221,7 @@ cdef class HttpProtocol:
         self.held_data = None
         self.held_offset = 0
         self.pump_scheduled = False
+        self._create_task = None
 
     def __dealloc__(self):
         if self.parser != NULL:
@@ -242,6 +244,7 @@ cdef class HttpProtocol:
     ):
         self.loop = loop
         self.app = app
+        self._create_task = app.create_task
         self.tracer = tracer
         self.noop_span = (
             tracer.create("request") if isinstance(tracer, NoOpTracer) else None
@@ -593,7 +596,7 @@ cdef class HttpProtocol:
     cdef void _start_exchange(self, RequestExchange exchange, bint eager_start):
         self.active_exchange = exchange
         exchange.start_response()
-        self.app.create_task(
+        self._create_task(
             self._run(exchange),
             loop=self.loop,
             eager_start=eager_start,

--- a/src/stario_cython/router.pxd
+++ b/src/stario_cython/router.pxd
@@ -1,0 +1,33 @@
+cdef class Node:
+    cdef public object not_found_handler
+    cdef public object method_not_allowed_handler
+    cdef public tuple middleware
+    cdef public int host_depth
+    cdef public dict exact
+    cdef public object wildcard_name
+    cdef public Node wildcard
+    cdef public object catchall_name
+    cdef public Node catchall
+    cdef public dict endpoints
+    cdef public object methods
+
+
+cdef class Endpoint:
+    cdef public object handler
+    cdef public object route_match
+
+
+cdef class Router:
+    cdef Node _path
+    cdef Node _hosts
+    cdef bint _has_hosts
+    cdef dict _cache
+    cdef int _cache_n
+    cdef dict __dict__
+
+    cpdef tuple find_handler(self, object host, object path, object method)
+    cdef tuple _match(self, object host, object path, object method)
+    cdef void _clear_match_cache(self)
+    cdef Node _registration_tree(self, object pattern)
+    cdef Node _leaf_node(self, object pattern)
+    cdef Node _policy_node(self, object pattern)

--- a/src/stario_cython/router.pyx
+++ b/src/stario_cython/router.pyx
@@ -1,0 +1,662 @@
+# cython: language_level=3
+"""Cython route table: cdef trie, in-place host/path walks, nested match cache."""
+
+from functools import lru_cache
+from types import MappingProxyType
+
+from cpython.dict cimport PyDict_GetItem
+from cpython.object cimport PyObject
+
+import stario.responses as responses
+from stario.exceptions import StarioError
+from stario.http.context import (
+    EMPTY_ROUTE_MATCH,
+    Context,
+    RouteMatch,
+)
+from stario.http.writer import Writer
+from stario.routing import Route, UrlPath
+
+cdef int CACHE_MAX = 1024
+cdef object KIND_CATCHALL = "catchall"
+cdef object KIND_WILDCARD = "wildcard"
+cdef object EMPTY_METHODS = frozenset()
+cdef object STATUS_FOUND = "found"
+cdef object STATUS_MNA = "method_not_allowed"
+cdef object STATUS_NF = "not_found"
+
+
+cdef class Node:
+    def __cinit__(self):
+        self.not_found_handler = None
+        self.method_not_allowed_handler = None
+        self.middleware = ()
+        self.host_depth = 0
+        self.exact = {}
+        self.wildcard_name = None
+        self.wildcard = None
+        self.catchall_name = None
+        self.catchall = None
+        self.endpoints = None
+        self.methods = EMPTY_METHODS
+
+    def __init__(self, host_depth=0):
+        self.host_depth = host_depth
+
+
+cdef class Endpoint:
+    def __init__(self, handler, route_match):
+        self.handler = handler
+        self.route_match = route_match
+
+
+cdef inline object _as_pattern(object path):
+    return path if isinstance(path, UrlPath) else UrlPath(path)
+
+
+cdef Node _pattern_child(Node current, object segment):
+    cdef object kind = segment.kind
+    cdef object child
+    if kind is KIND_CATCHALL or kind == KIND_CATCHALL:
+        if current.catchall is None or current.catchall_name != segment.name:
+            return None
+        return current.catchall
+    if kind is KIND_WILDCARD or kind == KIND_WILDCARD:
+        if current.wildcard is None or current.wildcard_name != segment.name:
+            return None
+        return current.wildcard
+    child = current.exact.get(segment.name)
+    if child is None:
+        return None
+    return <Node>child
+
+
+cdef Node trie_descend(Node root, object pattern, bint create, bint host_tree):
+    cdef Node current = root
+    cdef Node child
+    cdef object segment
+    for segment in pattern.host_trie():
+        if create:
+            current = _descend_or_create(current, segment, host_tree)
+        else:
+            child = _pattern_child(current, segment)
+            if child is None:
+                return current
+            current = child
+    for segment in pattern.path:
+        if create:
+            current = _descend_or_create(current, segment, False)
+        else:
+            child = _pattern_child(current, segment)
+            if child is None:
+                return current
+            current = child
+    return current
+
+
+cdef list _collect_middleware(Node tree, object pattern, bint path_only):
+    cdef list middlewares = list(tree.middleware)
+    cdef Node current = tree
+    cdef Node child
+    cdef object segment
+    if not path_only:
+        for segment in pattern.host_trie():
+            child = _pattern_child(current, segment)
+            if child is None:
+                return middlewares
+            current = child
+            middlewares.extend(current.middleware)
+    for segment in pattern.path:
+        child = _pattern_child(current, segment)
+        if child is None:
+            break
+        current = child
+        middlewares.extend(current.middleware)
+    return middlewares
+
+
+cdef bint _branch_has_endpoints(Node node):
+    cdef object child
+    if node.endpoints:
+        return True
+    if node.wildcard is not None and _branch_has_endpoints(node.wildcard):
+        return True
+    if node.catchall is not None and _branch_has_endpoints(node.catchall):
+        return True
+    for child in node.exact.values():
+        if _branch_has_endpoints(<Node>child):
+            return True
+    return False
+
+
+async def default_not_found(_c: Context, w: Writer):
+    responses.text(w, "Not Found", 404)
+
+
+@lru_cache(maxsize=256)
+def method_not_allowed_handler(allowed):
+    allow_header = ", ".join(sorted(allowed))
+
+    async def respond(_c, w):
+        w.headers.set("Allow", allow_header)
+        responses.text(w, "Method Not Allowed", 405)
+
+    return respond
+
+
+cdef object _walk_path(
+    Node current,
+    object path,
+    object params,
+    object not_found,
+    bint not_found_custom,
+    object method_na,
+):
+    cdef Py_ssize_t n = len(path)
+    cdef Py_ssize_t start
+    cdef Py_ssize_t slash
+    cdef Py_ssize_t path_off
+    cdef object seg
+    cdef object name
+    cdef object nf
+    cdef object mna
+    cdef PyObject *p
+    cdef Node node = current
+    cdef Node nxt
+
+    if path == "/":
+        return (node, params, not_found, not_found_custom, method_na)
+
+    start = 1
+    path_off = 1
+    while start < n:
+        slash = path.find("/", start)
+        if slash == -1:
+            seg = path[start:]
+        else:
+            seg = path[start:slash]
+        p = PyDict_GetItem(node.exact, seg)
+        if p != NULL:
+            nxt = <Node>p
+            if slash == -1:
+                start = n
+            else:
+                start = slash + 1
+            path_off = start
+        elif node.wildcard is not None:
+            if params is None:
+                params = {}
+            params[node.wildcard_name] = seg
+            nxt = node.wildcard
+            if slash == -1:
+                start = n
+            else:
+                start = slash + 1
+            path_off = start
+        elif node.catchall is not None:
+            name = node.catchall_name
+            if name is not None:
+                if params is None:
+                    params = {}
+                params[name] = path[path_off:]
+            nxt = node.catchall
+            start = n
+        else:
+            return None
+        nf = nxt.not_found_handler
+        if nf is not None:
+            not_found = nf
+            not_found_custom = True
+        mna = nxt.method_not_allowed_handler
+        if mna is not None:
+            method_na = mna
+        node = nxt
+    return (node, params, not_found, not_found_custom, method_na)
+
+
+cdef object _walk_host(
+    Node current,
+    object host,
+    object params,
+    object not_found,
+    bint not_found_custom,
+    object method_na,
+):
+    cdef Py_ssize_t n = len(host)
+    cdef Py_ssize_t end
+    cdef Py_ssize_t dot
+    cdef Py_ssize_t rest_end
+    cdef object seg
+    cdef object name
+    cdef object nf
+    cdef object mna
+    cdef PyObject *p
+    cdef Node node = current
+    cdef Node nxt
+
+    if n == 0:
+        return (node, params, not_found, not_found_custom, method_na)
+
+    end = n
+    while end > 0:
+        rest_end = end
+        dot = host.rfind(".", 0, end)
+        if dot == -1:
+            seg = host[:end]
+        else:
+            seg = host[dot + 1:end]
+        p = PyDict_GetItem(node.exact, seg)
+        if p != NULL:
+            nxt = <Node>p
+            end = 0 if dot == -1 else dot
+        elif node.wildcard is not None:
+            if params is None:
+                params = {}
+            params[node.wildcard_name] = seg
+            nxt = node.wildcard
+            end = 0 if dot == -1 else dot
+        elif node.catchall is not None:
+            name = node.catchall_name
+            if name is not None:
+                if params is None:
+                    params = {}
+                params[name] = host[:rest_end]
+            nxt = node.catchall
+            end = 0
+        else:
+            return None
+        nf = nxt.not_found_handler
+        if nf is not None:
+            not_found = nf
+            not_found_custom = True
+        mna = nxt.method_not_allowed_handler
+        if mna is not None:
+            method_na = mna
+        node = nxt
+    return (node, params, not_found, not_found_custom, method_na)
+
+
+cdef tuple _resolve(Node root, object host, object path, object method):
+    cdef object params = None
+    cdef object not_found = root.not_found_handler
+    cdef bint not_found_custom = not_found is not None
+    cdef object method_na = root.method_not_allowed_handler
+    cdef object walked
+    cdef Node current
+    cdef object endpoint
+    cdef PyObject *p
+    cdef dict endpoints
+
+    if not_found is None:
+        not_found = default_not_found
+
+    walked = _walk_host(
+        root, host, params, not_found, not_found_custom, method_na
+    )
+    if walked is None:
+        return not_found, EMPTY_ROUTE_MATCH, STATUS_NF, not_found_custom
+    current = <Node>walked[0]
+    params = walked[1]
+    not_found = walked[2]
+    not_found_custom = walked[3]
+    method_na = walked[4]
+
+    walked = _walk_path(
+        current, path, params, not_found, not_found_custom, method_na
+    )
+    if walked is None:
+        return not_found, EMPTY_ROUTE_MATCH, STATUS_NF, not_found_custom
+    current = <Node>walked[0]
+    params = walked[1]
+    not_found = walked[2]
+    not_found_custom = walked[3]
+    method_na = walked[4]
+
+    endpoints = current.endpoints
+    endpoint = None
+    if endpoints is not None:
+        p = PyDict_GetItem(endpoints, method)
+        if p != NULL:
+            endpoint = <Endpoint>p
+
+    if endpoint is None:
+        if current.methods:
+            return (
+                (method_na or method_not_allowed_handler)(current.methods),
+                EMPTY_ROUTE_MATCH,
+                STATUS_MNA,
+                not_found_custom,
+            )
+        return not_found, EMPTY_ROUTE_MATCH, STATUS_NF, not_found_custom
+
+    if params is None:
+        return (
+            (<Endpoint>endpoint).handler,
+            (<Endpoint>endpoint).route_match,
+            STATUS_FOUND,
+            not_found_custom,
+        )
+    return (
+        (<Endpoint>endpoint).handler,
+        RouteMatch(
+            pattern=(<Endpoint>endpoint).route_match.pattern,
+            params=MappingProxyType(params),
+        ),
+        STATUS_FOUND,
+        not_found_custom,
+    )
+
+
+cdef Node _descend_or_create(Node current, object segment, bint host_label):
+    cdef Node child = _pattern_child(current, segment)
+    cdef int child_host_depth
+    cdef object name
+    cdef object kind
+    if child is not None:
+        return child
+
+    child_host_depth = current.host_depth + (1 if host_label else 0)
+    kind = segment.kind
+    name = segment.name
+
+    if kind is KIND_CATCHALL or kind == KIND_CATCHALL:
+        if current.catchall is not None:
+            raise StarioError(
+                "Catchall parameter conflict",
+                context={
+                    "existing": current.catchall_name,
+                    "new": name,
+                    "segment": segment.pattern,
+                },
+                help_text="Use the same catchall parameter name for routes sharing this branch.",
+            )
+        if current.wildcard is not None:
+            raise StarioError(
+                "Ambiguous route parameter branch",
+                context={
+                    "existing": current.wildcard_name,
+                    "new": name,
+                    "segment": segment.pattern,
+                },
+                help_text=(
+                    "A wildcard and catchall cannot share the same branch because "
+                    "matching is deterministic and does not backtrack."
+                ),
+            )
+        child = Node(host_depth=child_host_depth)
+        current.catchall_name = name
+        current.catchall = child
+        return child
+
+    if kind is KIND_WILDCARD or kind == KIND_WILDCARD:
+        if current.wildcard is not None:
+            raise StarioError(
+                "Wildcard parameter conflict",
+                context={
+                    "existing": current.wildcard_name,
+                    "new": name,
+                    "segment": segment.pattern,
+                },
+                help_text="Use the same wildcard parameter name for routes sharing this branch.",
+            )
+        if current.catchall is not None:
+            raise StarioError(
+                "Ambiguous route parameter branch",
+                context={
+                    "existing": current.catchall_name,
+                    "new": name,
+                    "segment": segment.pattern,
+                },
+                help_text=(
+                    "A wildcard and catchall cannot share the same branch because "
+                    "matching is deterministic and does not backtrack."
+                ),
+            )
+        child = Node(host_depth=child_host_depth)
+        current.wildcard_name = name
+        current.wildcard = child
+        return child
+
+    child = Node(host_depth=child_host_depth)
+    current.exact[name] = child
+    return child
+
+
+cdef class Router:
+    """Route table: host routes override hostless defaults when they fully match."""
+
+    def __cinit__(self):
+        self._path = Node()
+        self._hosts = Node()
+        self._has_hosts = False
+        self._cache = {}
+        self._cache_n = 0
+
+    @property
+    def host_routing(self):
+        return self._has_hosts
+
+    cdef void _clear_match_cache(self):
+        self._cache = {}
+        self._cache_n = 0
+
+    cpdef tuple find_handler(self, object host, object path, object method):
+        cdef dict by_host
+        cdef dict by_path
+        cdef dict by_method
+        cdef object hit
+        cdef tuple result
+        cdef PyObject *p
+
+        by_host = self._cache
+        p = PyDict_GetItem(by_host, host)
+        by_path = <dict>p if p != NULL else None
+        if by_path is not None:
+            p = PyDict_GetItem(by_path, path)
+            by_method = <dict>p if p != NULL else None
+            if by_method is not None:
+                p = PyDict_GetItem(by_method, method)
+                if p != NULL:
+                    return <tuple>p
+        else:
+            by_method = None
+
+        result = self._match(host, path, method)
+        if self._cache_n >= CACHE_MAX:
+            self._cache = {}
+            self._cache_n = 0
+            by_host = self._cache
+            by_path = None
+            by_method = None
+        if by_path is None:
+            by_path = {}
+            by_host[host] = by_path
+            by_method = None
+        if by_method is None:
+            by_method = {}
+            by_path[path] = by_method
+        by_method[method] = result
+        self._cache_n += 1
+        return result
+
+    cdef tuple _match(self, object host, object path, object method):
+        cdef object host_key = host
+        cdef object host_handler
+        cdef object host_match
+        cdef object host_status
+        cdef bint host_nf_custom
+        cdef object path_handler
+        cdef object path_match
+        cdef object path_status
+        cdef tuple resolved
+
+        if self._has_hosts and host:
+            host_key = host.lower()
+            resolved = _resolve(self._hosts, host_key, path, method)
+            host_handler = resolved[0]
+            host_match = resolved[1]
+            host_status = resolved[2]
+            host_nf_custom = resolved[3]
+            if host_status is STATUS_FOUND:
+                return host_handler, host_match
+            resolved = _resolve(self._path, "", path, method)
+            path_handler = resolved[0]
+            path_match = resolved[1]
+            path_status = resolved[2]
+            if path_status is STATUS_FOUND:
+                return path_handler, path_match
+            if host_status is STATUS_MNA:
+                return host_handler, host_match
+            if path_status is STATUS_MNA:
+                return path_handler, path_match
+            if host_nf_custom:
+                return host_handler, host_match
+            return path_handler, path_match
+
+        resolved = _resolve(self._path, "", path, method)
+        return resolved[0], resolved[1]
+
+    cdef Node _registration_tree(self, object pattern):
+        if pattern.host:
+            self._has_hosts = True
+            return self._hosts
+        return self._path
+
+    cdef Node _leaf_node(self, object pattern):
+        cdef Node tree = self._registration_tree(pattern)
+        return trie_descend(tree, pattern, True, tree is self._hosts)
+
+    cdef Node _policy_node(self, object pattern):
+        cdef object route = _as_pattern(pattern)
+        cdef object segment
+        if any(segment.kind == KIND_CATCHALL for segment in route.host):
+            raise StarioError(
+                "Catchall host policy is not supported",
+                context={"pattern": route.text},
+                help_text=(
+                    "Use an exact host prefix such as "
+                    "UrlPath('/', host='api.example.com') or apply path policy like '/api'."
+                ),
+            )
+        if route.path and route.path[-1].kind == KIND_CATCHALL:
+            raise StarioError(
+                "Catchall route policy cannot have child routes",
+                context={"pattern": route.text},
+                help_text="Use a non-catchall prefix such as '/api' for route policy.",
+            )
+        return self._leaf_node(route)
+
+    def use(self, pattern, *middleware):
+        cdef Node current = self._policy_node(pattern)
+        if not middleware:
+            return
+        if _branch_has_endpoints(current):
+            raise StarioError(
+                "Middleware must be registered before matching routes",
+                context={"pattern": pattern},
+                help_text=(
+                    "Call app.use(pattern, ...) before app.add(...) or app.get/post on that prefix. "
+                    "Middleware is baked into route handlers at registration time."
+                ),
+            )
+        current.middleware = current.middleware + tuple(middleware)
+        self._clear_match_cache()
+
+    def not_found(self, pattern, handler):
+        self._policy_node(pattern).not_found_handler = handler
+        self._clear_match_cache()
+
+    def method_not_allowed(self, pattern, handler):
+        self._policy_node(pattern).method_not_allowed_handler = handler
+        self._clear_match_cache()
+
+    def handle(self, method, path, handler, *, middleware=()):
+        cdef object route = _as_pattern(path)
+        cdef Node tree
+        cdef Node current
+        cdef list scoped_middleware
+        cdef object wrapped
+        cdef object mw
+        cdef object existing
+        cdef Endpoint endpoint
+        cdef dict endpoints
+        method = method.upper()
+        tree = self._registration_tree(route)
+        scoped_middleware = _collect_middleware(tree, route, False)
+        if route.host:
+            scoped_middleware.extend(_collect_middleware(self._path, route, True))
+
+        current = trie_descend(tree, route, True, tree is self._hosts)
+
+        wrapped = handler
+        for mw in reversed([*scoped_middleware, *middleware]):
+            wrapped = mw(wrapped)
+
+        endpoints = current.endpoints
+        existing = None if endpoints is None else endpoints.get(method)
+        if existing is not None:
+            raise StarioError(
+                "Route already registered",
+                context={"method": method, "pattern": route.text},
+                help_text="Each HTTP method may be registered only once per route pattern.",
+            )
+
+        endpoint = Endpoint(
+            wrapped,
+            RouteMatch(
+                pattern=route.text,
+                params=EMPTY_ROUTE_MATCH.params,
+            ),
+        )
+        if endpoints is None:
+            current.endpoints = {method: endpoint}
+        else:
+            endpoints[method] = endpoint
+        if method not in current.methods:
+            current.methods = current.methods | frozenset({method})
+        self._clear_match_cache()
+
+    def add(self, route, handler, *, middleware=()):
+        """Register a `Route`. Path + method stay on `handle()`."""
+        if not isinstance(route, Route):
+            raise StarioError(
+                "add() takes a Route",
+                context={"got": type(route).__name__},
+                help_text=(
+                    "Declare the endpoint with Route.get/post/... and pass that object. "
+                    "Use app.handle(method, path, handler) or app.get(path, handler) "
+                    "for a path without a Route."
+                ),
+            )
+        self.handle(route.method, route.path, handler, middleware=middleware)
+
+    def get(self, path, handler, *, middleware=()):
+        self.handle("GET", path, handler, middleware=middleware)
+
+    def query(self, path, handler, *, middleware=()):
+        self.handle("QUERY", path, handler, middleware=middleware)
+
+    def post(self, path, handler, *, middleware=()):
+        self.handle("POST", path, handler, middleware=middleware)
+
+    def put(self, path, handler, *, middleware=()):
+        self.handle("PUT", path, handler, middleware=middleware)
+
+    def delete(self, path, handler, *, middleware=()):
+        self.handle("DELETE", path, handler, middleware=middleware)
+
+    def patch(self, path, handler, *, middleware=()):
+        self.handle("PATCH", path, handler, middleware=middleware)
+
+    def head(self, path, handler, *, middleware=()):
+        self.handle("HEAD", path, handler, middleware=middleware)
+
+    def options(self, path, handler, *, middleware=()):
+        self.handle("OPTIONS", path, handler, middleware=middleware)
+
+
+__all__ = [
+    "Router",
+    "default_not_found",
+    "method_not_allowed_handler",
+]

--- a/src/stario_cython/serve.py
+++ b/src/stario_cython/serve.py
@@ -11,7 +11,7 @@ from email.utils import format_datetime
 
 import uvloop
 
-from stario.http.app import App
+from stario_cython.app import App
 from stario.http.bootstrap import Bootstrap, bootstrap_run
 from stario.http.compression import compression_config_from_env
 from stario.telemetry.noop import NoOpTracer

--- a/tests/cython/test_headers_writer.py
+++ b/tests/cython/test_headers_writer.py
@@ -6,10 +6,10 @@ from contextlib import asynccontextmanager
 import brotli
 import pytest
 
-from stario import App
 from stario.exceptions import StarioError
 from stario.http.compression import CompressionConfig
 from stario.telemetry.noop import NoOpTracer
+from stario_cython.app import App
 from stario_cython.headers import Headers
 from stario_cython.protocol import HttpProtocol
 

--- a/tests/cython/test_protocol.py
+++ b/tests/cython/test_protocol.py
@@ -5,10 +5,9 @@ import pytest
 import uvloop
 
 import stario.responses as responses
-from stario import App
 from stario.http.compression import CompressionConfig
 from stario.telemetry.noop import NoOpTracer
-
+from stario_cython.app import App
 from stario_cython.protocol import HttpProtocol
 
 

--- a/tests/cython/test_protocol.py
+++ b/tests/cython/test_protocol.py
@@ -877,3 +877,49 @@ async def test_stream_respects_max_chunk_batches() -> None:
     finally:
         server.close()
         await server.wait_closed()
+
+
+def test_uvloop_plaintext_and_params() -> None:
+    """uvloop.Loop.create_task does not accept eager_start; App must still dispatch."""
+
+    async def main() -> None:
+        loop = asyncio.get_running_loop()
+        app = App()
+
+        async def plaintext(_c, w):
+            responses.text(w, "Hello, World!")
+
+        async def get_user(c, w):
+            responses.text(w, c.route.params["user_id"])
+
+        app.get("/plaintext", plaintext)
+        app.get("/user/{user_id}", get_user)
+        connections: set[HttpProtocol] = set()
+
+        def factory():
+            return HttpProtocol(
+                loop,
+                app,
+                NoOpTracer(),
+                [b"date: Tue, 18 Aug 2026 00:00:00 GMT\r\n"],
+                CompressionConfig(),
+                connections,
+            )
+
+        port = _free_port()
+        server = await loop.create_server(factory, "127.0.0.1", port)
+        try:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            writer.write(b"GET /plaintext HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+            await writer.drain()
+            assert b"Hello, World!" in await _read_response(reader)
+            writer.write(b"GET /user/42 HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+            await writer.drain()
+            assert b"42" in await _read_response(reader)
+            writer.close()
+            await writer.wait_closed()
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    uvloop.run(main())

--- a/tests/cython/test_router.py
+++ b/tests/cython/test_router.py
@@ -1,0 +1,246 @@
+"""Parity and behavior tests for the Cython Router and App."""
+
+import asyncio
+
+import pytest
+
+from stario.exceptions import (
+    HttpException,
+    StarioError,
+    StarioRuntime,
+)
+from stario.http.context import EMPTY_ROUTE_MATCH, Context
+from stario.http.dispatch import (
+    Router as PyRouter,
+    default_not_found as py_default_not_found,
+)
+from stario.http.writer import Writer
+from stario.routing import Route, UrlPath
+from stario_cython.app import App
+from stario_cython.router import (
+    Router,
+    default_not_found,
+    method_not_allowed_handler,
+)
+from tests.helpers import DummyWriter, make_context
+
+
+async def noop_handler(c: Context, w: Writer) -> None:
+    return None
+
+
+def _register(router):
+    router.get("/plaintext", noop_handler)
+    router.get("/json", noop_handler)
+    router.get("/user/{user_id}", noop_handler)
+    router.get("/users/{user_id}/posts/{post_id}", noop_handler)
+    router.get("/files/{path...}", noop_handler)
+    router.post("/echo", noop_handler)
+    router.get(UrlPath("/users", host="api.example.com"), noop_handler)
+    router.get(UrlPath("/dashboard", host="{subhost}.example.com"), noop_handler)
+    router.get(UrlPath("/x", host="{tenant...}.cdn.example.com"), noop_handler)
+    router.post("/api", noop_handler)
+    router.get("/health", noop_handler)
+
+
+CASES = [
+    ("", "/plaintext", "GET"),
+    ("", "/json", "GET"),
+    ("", "/user/42", "GET"),
+    ("", "/users/42/posts/7", "GET"),
+    ("", "/files/docs/readme.txt", "GET"),
+    ("", "/missing", "GET"),
+    ("", "/plaintext", "POST"),
+    ("", "/echo", "POST"),
+    ("", "/echo", "GET"),
+    ("api.example.com", "/users", "GET"),
+    ("api.example.com", "/users", "POST"),
+    ("www.example.org", "/health", "GET"),
+    ("acme.example.com", "/dashboard", "GET"),
+    ("a.b.cdn.example.com", "/x", "GET"),
+    ("api.example.com", "/api", "POST"),
+    ("", "/", "GET"),
+]
+
+
+def test_find_handler_parity_with_python_router():
+    py = PyRouter()
+    cy = Router()
+    _register(py)
+    _register(cy)
+
+    for host, path, method in CASES:
+        py_handler, py_match = py.find_handler(host, path, method)
+        cy_handler, cy_match = cy.find_handler(host, path, method)
+        assert py_match.pattern == cy_match.pattern, (host, path, method)
+        assert dict(py_match.params) == dict(cy_match.params), (host, path, method)
+        if py_handler is py_default_not_found:
+            assert cy_handler is default_not_found
+        elif py_match is EMPTY_ROUTE_MATCH and py_handler is not py_default_not_found:
+            assert cy_match is EMPTY_ROUTE_MATCH
+            assert cy_handler is not default_not_found
+        else:
+            assert py_handler is not None
+            assert cy_handler is not None
+
+
+def test_matches_path_params():
+    router = Router()
+    router.get("/users/{user_id}/posts/{post_id}", noop_handler)
+    _, match = router.find_handler("", "/users/42/posts/7", "GET")
+    assert match.pattern == "/users/{user_id}/posts/{post_id}"
+    assert dict(match.params) == {"user_id": "42", "post_id": "7"}
+
+
+def test_matches_catchall_params():
+    router = Router()
+    router.get("/files/{path...}", noop_handler)
+    _, match = router.find_handler("", "/files/docs/readme.txt", "GET")
+    assert match.pattern == "/files/{path...}"
+    assert dict(match.params) == {"path": "docs/readme.txt"}
+
+
+def test_method_not_allowed_allow_header_sorted():
+    router = Router()
+    router.get("/r", noop_handler)
+    router.post("/r", noop_handler)
+    router.patch("/r", noop_handler)
+    handler, _ = router.find_handler("", "/r", "DELETE")
+    assert handler is method_not_allowed_handler(frozenset({"GET", "PATCH", "POST"}))
+
+
+def test_hostless_fallback_and_host_params():
+    router = Router()
+    router.get("/health", noop_handler)
+    router.get(UrlPath("/dashboard", host="{subhost}.example.com"), noop_handler)
+    router.get(UrlPath("/x", host="{tenant...}.cdn.example.com"), noop_handler)
+
+    _, health = router.find_handler("www.example.org", "/health", "GET")
+    assert health.pattern == "/health"
+
+    _, dash = router.find_handler("acme.example.com", "/dashboard", "GET")
+    assert dict(dash.params) == {"subhost": "acme"}
+    assert dash.pattern == "{subhost}.example.com/dashboard"
+
+    _, tenant = router.find_handler("a.b.cdn.example.com", "/x", "GET")
+    assert dict(tenant.params) == {"tenant": "a.b"}
+    assert tenant.pattern == "{tenant...}.cdn.example.com/x"
+
+
+def test_add_registers_route():
+    router = Router()
+    router.add(Route.post("/rooms/{room_id}/send"), noop_handler)
+    _, match = router.find_handler("", "/rooms/7/send", "POST")
+    assert match.pattern == "/rooms/{room_id}/send"
+    assert dict(match.params) == {"room_id": "7"}
+
+
+def test_rejects_duplicate_route():
+    router = Router()
+    router.get("/hello", noop_handler)
+    with pytest.raises(StarioError, match="Route already registered"):
+        router.get("/hello", noop_handler)
+
+
+def test_cache_hit_returns_same_route_match():
+    router = Router()
+    router.get("/user/{user_id}", noop_handler)
+    _, first = router.find_handler("", "/user/42", "GET")
+    _, second = router.find_handler("", "/user/42", "GET")
+    assert first is second
+    assert dict(first.params) == {"user_id": "42"}
+
+
+def test_use_applies_middleware():
+    calls: list[str] = []
+
+    def scope_middleware(handler):
+        async def wrapped(c, w):
+            calls.append("scope")
+            await handler(c, w)
+
+        return wrapped
+
+    router = Router()
+    router.use("/", scope_middleware)
+    router.get("/users", noop_handler)
+    handler, _ = router.find_handler("", "/users", "GET")
+
+    async def _run():
+        await handler(make_context(loop=asyncio.get_running_loop()), DummyWriter())
+
+    asyncio.run(_run())
+    assert calls == ["scope"]
+
+
+def _run_app(setup, path, method="GET", host="", query=None):
+    async def _run():
+        app = App()
+        setup(app)
+        loop = asyncio.get_running_loop()
+        ctx = make_context(path, method, host, app=app, query=query, loop=loop)
+        w = DummyWriter()
+        await app(ctx, w)
+        return ctx, w
+
+    return asyncio.run(_run())
+
+
+def test_app_trailing_slash_redirect_preserves_query():
+    _ctx, writer = _run_app(lambda _app: None, "/search/", query={"q": "cats", "page": 2})
+    assert writer.status == 308
+    assert writer.headers.unsafe_get(b"location") == b"/search?q=cats&page=2"
+
+
+def test_app_params_and_http_exception():
+    seen: list[str] = []
+
+    async def handler(c, w):
+        seen.append(c.route.params["user_id"])
+        raise HttpException(422, "nope")
+
+    _ctx, writer = _run_app(lambda app: app.get("/user/{user_id}", handler), "/user/42")
+    assert seen == ["42"]
+    assert writer.status == 422
+    assert writer.body == "nope"
+
+
+def test_app_create_task_eager_start():
+    async def _run():
+        app = App()
+        started = False
+
+        async def worker():
+            nonlocal started
+            started = True
+            return 7
+
+        task = app.create_task(worker(), eager_start=True)
+        assert started
+        assert task.done()
+        assert task.result() == 7
+        assert task not in app.tasks
+
+    asyncio.run(_run())
+
+
+def test_app_handler_must_send_response():
+    async def missing(_c, _w):
+        return None
+
+    async def runtime_error_handler(_c, w, exc):
+        assert type(exc) is StarioRuntime
+        w.respond(b"missing", b"text/plain", 500)
+
+    def setup(app):
+        app.on_error(StarioRuntime, runtime_error_handler)
+        app.get("/missing", missing)
+
+    _ctx, writer = _run_app(setup, "/missing")
+    assert writer.status == 500
+    assert writer.body == "missing"
+
+
+def test_app_requires_running_loop():
+    with pytest.raises(StarioError, match="requires a running event loop"):
+        App()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Compile the route trie, path-param capture, `create_task`, and `App.__call__` so the Cython protocol can resolve handlers without bouncing through Python after llhttp parses the request.

## What changed

- New `stario_cython.router`: `cdef` trie nodes, in-place host/path walks (no segment tuples), nested match cache (no per-hit tuple keys).
- New `stario_cython.app`: compiled `create_task` + request entry; skips no-op span work on `NoOpSpan`.
- Cython `serve()` constructs this App; the protocol caches the bound `create_task`.
- `create_task` probes whether the running loop accepts `eager_start`. uvloop does not (`create_task(coro, *, name, context)`), so we keep uvloop native tasks. Forcing `asyncio.Task(eager_start=True)` restored 2MB stream rates but cut small POST throughput by ~40%.
- Python httptools (`stario.http.dispatch` / `stario.http.app`) is unchanged.

## Tests

Parity tests compare Cython vs Python router results (static routes, wildcards, catchalls, host routing). Cython protocol tests use the compiled App, including a uvloop plaintext/params smoke test. **707 passed**.

## Benchmark vs `baseline-20260824.md`

Same confirmatory shape as the committed refresh: `DURATION=5s`, `RUNS=3`, `WARMUP=1`, `-t2 -c128` / `-c32` for large uploads. Run `20260825T185522Z`, commit `e51185b`.

**Read-heavy (routing / params — the target of this change)**

| Endpoint | Baseline confirmatory | This PR | Δ |
| --- | ---: | ---: | ---: |
| Plaintext | 125,436 ± 4,971 | 128,821 ± 9,102 | **+2.7%** |
| JSON | 119,054 ± 6,789 | 132,769 ± 6,455 | **+11.5%** |
| Params (`GET /user/42`) | 121,619 ± 4,259 | 130,362 ± 1,406 | **+7.2%** |

**Small POST** (handler + body, not path matching)

| Endpoint | Baseline confirmatory | This PR | Δ |
| --- | ---: | ---: | ---: |
| Validate | 110,118 ± 408 | 103,811 ± 2,767 | −5.7% |
| Form POST | 124,616 ± 4,699 | 120,411 ± 1,896 | −3.4% |
| JSON 1KB | 108,319 ± 453 | 107,659 ± 2,313 | −0.6% |

**Large ingest** on this VM sits well below the confirmatory row (64KB ~24k vs ~33k; 2MB buffer/stream/multipart ~1.1–1.3k vs ~2.1–3.1k). Two independent uvloop-native runs here agreed, so treat those columns as host/memory-bandwidth limited rather than a routing-path result.

Params is the path-param case: about **+7%** vs the confirmatory Cython baseline, with JSON also up. The Python httptools target was not re-run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1ee7397-886e-481c-b664-473965bb8c0e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1ee7397-886e-481c-b664-473965bb8c0e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

