### PR TITLE
Cython HTTP hot path: skip NoOpSpan, defer small bodies, cache URLs

### DIFF
--- a/CYTHON.md
+++ b/CYTHON.md
@@ -47,3 +47,28 @@ Official `benchmarks/server` suite, same machine, one worker, `10s` × 5 measure
 Read paths ~1.7×. Small POST ~1.2×. 64KB ingest even. Buffered 2MB, streaming 2MB,
 and multipart are ahead of Python after pre-sizing Content-Length bodies and
 pausing `body()` at 64KiB between parser quantums.
+
+## Hot path vs `cython-core` (2026-08-28)
+
+Same machine, official suite, unmodified `cython-core` (`f80d6f0`, run
+`20260828T110114Z`) vs this hot-path work (`174cef7`, run
+`20260828T112246Z`). Full table: `benchmarks/server/baseline-20260828.md`.
+Do not mix these Cython rows with the 2026-08-27 Python column (different
+host class).
+
+| Endpoint | Unmodified `cython-core` | Hot path | Hot / core |
+| --- | ---: | ---: | ---: |
+| Plaintext | 129,230 ± 2,877 | 132,083 ± 4,307 | 1.02× |
+| JSON | 123,825 ± 3,502 | 131,544 ± 825 | 1.06× |
+| Params | 111,894 ± 1,687 | 126,443 ± 252 | 1.13× |
+| Validate JSON | 66,359 ± 234 | 108,084 ± 1,902 | **1.63×** |
+| Form POST | 77,785 ± 1,875 | 131,462 ± 1,629 | **1.69×** |
+| JSON 1KB | 67,892 ± 1,636 | 112,493 ± 3,605 | **1.66×** |
+| Octet 64KB | 24,091 ± 164 | 37,735 ± 131 | **1.57×** |
+| Octet 2MB (buffer) | 3,117 ± 78 | 3,190 ± 31 | 1.02× |
+| Octet 2MB (stream) | 3,480 ± 3 | 3,485 ± 12 | 1.00× |
+| Multipart 2MB | 3,179 ± 151 | 3,350 ± 37 | 1.05× |
+
+Small POST and the 64KiB octet fixture (exactly the deferral cap) jump because
+`body()` no longer waits on an Event during `llhttp_execute`. 2MB paths stay
+header-dispatch and did not regress. Plaintext is within sample noise.

--- a/benchmarks/server/baseline-20260827.md
+++ b/benchmarks/server/baseline-20260827.md
@@ -4,9 +4,10 @@ Reference for comparing **Stario Cython** (llhttp) against **Stario Python**
 (httptools) on the official `benchmarks/server` suite. Relative comparisons on
 one machine — not lab-grade absolutes.
 
-**Going forward:** treat the Stario Cython row below as the baseline for Cython
-protocol work. Re-run the same suite after changes and compare median ± stdev
-to these numbers.
+**Going forward:** on a given machine, compare new Cython protocol work to a
+fresh unmodified `cython-core` wrk run on that machine. The 2026-08-28
+same-host hot-path capture is [`baseline-20260828.md`](baseline-20260828.md).
+The Cython row below remains the Python vs Cython snapshot for this date.
 
 Native/ASGI competitor tables from the previous capture remain in
 [`baseline-20260824.md`](baseline-20260824.md) (same machine class; not re-run

--- a/benchmarks/server/baseline-20260828.md
+++ b/benchmarks/server/baseline-20260828.md
@@ -1,0 +1,96 @@
+# Server benchmark: Cython hot path vs `cython-core` (2026-08-28)
+
+Same-machine comparison of **unmodified `cython-core`** against the hot-path
+changes on `cursor/cython-hotpath-d521` (PR #33). Relative numbers on one
+host — not lab-grade absolutes.
+
+**Going forward:** treat the “this branch” column below as the Cython
+protocol anchor on this machine. Re-run the same suite after further
+protocol work and compare median ± stdev to these numbers.
+
+The 2026-08-27 Python vs Cython capture remains in
+[`baseline-20260827.md`](baseline-20260827.md) (different host class; do not
+mix rows).
+
+## Reproduce
+
+```bash
+RUNS=5 WARMUP=1 DURATION=10s THREADS=2 \
+  CONNECTIONS=128 UPLOAD_CONNECTIONS=32 \
+  ENDPOINT_TIER=all KEEP_RAW=1 \
+  benchmarks/server/run.sh stario-cython
+```
+
+Unmodified baseline was a git worktree of `cython-core` at `f80d6f0`.
+Feature run used this branch (`174cef7`).
+
+## Environment
+
+| | |
+|---|---|
+| CPU | Intel Xeon (KVM), 4 vCPUs, x86_64 |
+| RAM | 16 GiB, no swap |
+| OS | Linux 6.12.94+ |
+| Python | 3.14.7 |
+| Client | wrk 4.1.0, `-t2 -c128` (read/small upload), `-c32` (64KB/2MB) |
+| Topology | wrk and servers on same host, `127.0.0.1` loopback |
+| Baseline commit | `f80d6f0` (`cython-core`) |
+| Feature commit | `174cef7` (`cursor/cython-hotpath-d521`) |
+| Baseline run | `20260828T110114Z` |
+| Feature run | `20260828T112246Z` |
+
+## Methodology
+
+- One worker/process. Suites ran sequentially (baseline first, then feature)
+  so they did not contend for CPU.
+- 10 endpoints: read (`plaintext`, `json`, `params`) + upload (`validate`,
+  `post-form`, `post-json-1k`, `post-octet-64k`, `post-octet-2m`,
+  `post-stream-2m`, `multipart-2m`).
+- **5 measured + 1 warmup**, `DURATION=10s`, IQR trimming via
+  `benchmarks/server/stats.py`.
+- Handlers **compute responses per request** (no reused/static `Response`
+  objects, no pre-serialized JSON bytes). See `benchmarks/README.md` handler
+  policy.
+
+## This-machine delta (`cython-core` → hot path)
+
+| Endpoint | Unmodified `cython-core` | This branch | Ratio |
+| --- | ---: | ---: | ---: |
+| Plaintext | 129,230 ± 2,877 | 132,083 ± 4,307 | 1.02× |
+| JSON | 123,825 ± 3,502 | 131,544 ± 825 | **1.06×** |
+| Params | 111,894 ± 1,687 | 126,443 ± 252 | **1.13×** |
+| Validate JSON | 66,359 ± 234 | 108,084 ± 1,902 | **1.63×** |
+| Form POST | 77,785 ± 1,875 | 131,462 ± 1,629 | **1.69×** |
+| JSON 1KB | 67,892 ± 1,636 | 112,493 ± 3,605 | **1.66×** |
+| Octet 64KB | 24,091 ± 164 | 37,735 ± 131 | **1.57×** |
+| Octet 2MB (buffer) | 3,117 ± 78 | 3,190 ± 31 | 1.02× |
+| Octet 2MB (stream) | 3,480 ± 3 | 3,485 ± 12 | 1.00× |
+| Multipart 2MB | 3,179 ± 151 | 3,350 ± 37 | 1.05× |
+
+JSON / params / multipart report one IQR outlier removed on the feature run
+(n_used=4). 2MB buffer likewise. Other rows used all 5 measured samples.
+
+## How to read it
+
+- **Small POST** (validate / form / JSON 1KB) is the real move: ~1.6–1.7×.
+  Content-Length bodies ≤ 64KiB now dispatch at `message_complete` after
+  `c_complete()`, so `body()` hits cached bytes instead of waiting on an
+  `asyncio.Event` nested in `llhttp_execute`.
+- **Octet 64KB** moved with that cohort because the fixture is exactly
+  `64 * 1024` bytes (`payload-64k.bin`), which is still in the deferral
+  bucket (`content_length <= 64KiB`). 2MB uploads stay header-dispatch.
+- **Read path** is flat-to-up. Plaintext (+2%) sits inside sample noise
+  (baseline stdev ~2.9k). JSON (+6%) and params (+13%) are clearer; those
+  also pick up the NoOpSpan skip, URL arena cache, and dropping the `_run`
+  wrapper.
+- **2MB buffer / stream** did not regress (the failure mode to watch).
+  Multipart is a modest +5%.
+
+## What landed in the feature commit
+
+- Skip `NoOpSpan` start/attrs/fail/end in `App.__call__`.
+- Defer small Content-Length bodies until message-complete.
+- Arena URL cache (no per-request URL `bytes` cache key).
+- Eager-start `App.__call__` without a `_run` wrapper; `deque` pipeline.
+- `-fno-strict-aliasing`; wraparound-safe `ParsedQuery.as_dict`.
+- `run.sh` creates the target venv before fixtures.

--- a/benchmarks/server/run.sh
+++ b/benchmarks/server/run.sh
@@ -660,11 +660,10 @@ main() {
   for target in "${selected[@]}"; do known_target "$target" || { echo "Unknown target: $target" >&2; usage >&2; exit 1; }; done
   for endpoint in "${ENDPOINTS[@]}"; do path_for "$endpoint" >/dev/null || exit 1; done
 
-  ensure_fixtures "$(python_for "${selected[0]}")"
   if [[ ! -x "$(python_for "${selected[0]}")" ]]; then
     ensure_target "${selected[0]}"
-    ensure_fixtures "$(python_for "${selected[0]}")"
   fi
+  ensure_fixtures "$(python_for "${selected[0]}")"
 
   RUN_DIR="$RESULTS_DIR/$(date -u +%Y%m%dT%H%M%SZ)"
   mkdir -p "$RUN_DIR"

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extensions = [
     Extension(
         "stario_cython.headers",
         sources=["src/stario_cython/headers.pyx"],
-        extra_compile_args=["-O3"],
+        extra_compile_args=["-O3", "-fno-strict-aliasing"],
     ),
     Extension(
         "stario_cython.exchange",
@@ -58,7 +58,7 @@ extensions = [
         include_dirs=["vendor", "src", *codec_include_dirs],
         library_dirs=codec_library_dirs,
         libraries=codec_libraries,
-        extra_compile_args=["-O3", *codec_compile_args],
+        extra_compile_args=["-O3", "-fno-strict-aliasing", *codec_compile_args],
         extra_link_args=codec_link_args,
     ),
     Extension(
@@ -71,7 +71,7 @@ extensions = [
             "vendor/llhttp/src/stario_alloc.c",
         ],
         include_dirs=["vendor/llhttp/include", "vendor", "src"],
-        extra_compile_args=["-O3"],
+        extra_compile_args=["-O3", "-fno-strict-aliasing"],
     ),
 ]
 

--- a/src/stario/http/app.py
+++ b/src/stario/http/app.py
@@ -20,6 +20,7 @@ from stario.exceptions import (
 )
 from stario.http.context import Context
 from stario.routing.locations import normalize_path
+from stario.telemetry.spans import NoOpSpan
 
 from .dispatch import Router
 from .writer import Writer
@@ -189,8 +190,12 @@ class App(Router):
         send a response on the success path.
         """
         span = c.span
-        span.start()
-        span.attrs({"request.method": c.req.method, "request.path": c.req.path})
+        # Cython (and benchmark) servers use NoOpTracer. Skip method calls and
+        # the attrs dict on that path; RecordingSpan and others still record.
+        record = type(span) is not NoOpSpan
+        if record:
+            span.start()
+            span.attrs({"request.method": c.req.method, "request.path": c.req.path})
         failed_after_start = False
 
         try:
@@ -236,14 +241,15 @@ class App(Router):
                         exc = handler_exc
                 if not handler_responded:
                     responses.text(w, "Internal Server Error", 500)
-            if not handler_responded:
+            if not handler_responded and record:
                 span.fail(str(exc))
                 span.exception(exc)
         finally:
             # After headers: abort the transport on failure; otherwise finish the message.
             if failed_after_start and not w.completed:
                 w.abort()
-            else:
+            elif not w.completed:
                 w.end()
-            span.attr("response.status_code", w.status_code)
-            span.end()
+            if record:
+                span.attr("response.status_code", w.status_code)
+                span.end()

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -516,8 +516,15 @@ cdef class ParsedQuery:
         return [(k, v) for k, vals in self._data.items() for v in vals]
 
     def as_dict(self, *, last=False):
-        cdef int i = -1 if last else 0
-        return {k: vals[i] for k, vals in self._data.items()}
+        cdef dict out = {}
+        cdef list vals
+        cdef Py_ssize_t idx
+        for k, vals in self._data.items():
+            if not vals:
+                continue
+            idx = len(vals) - 1 if last else 0
+            out[k] = vals[idx]
+        return out
 
     def as_lists(self):
         return {k: list(v) for k, v in self._data.items()}
@@ -1449,6 +1456,10 @@ cdef class RequestExchange:
     cdef void start_response(self):
         self.handler_started = True
         self.reset_response(self._req_encoding)
+
+    def on_handler_done(self, task):
+        """``Task.add_done_callback`` entry; recycles after ``App.__call__``."""
+        self.handler_finished()
 
     cdef void handler_finished(self):
         self.handler_done = True

--- a/src/stario_cython/headers.pyx
+++ b/src/stario_cython/headers.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 """One Headers type: a retained pair list plus the intern table.
 
 Application ``get``/``set`` still see clean names and values. Internally each

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 """asyncio Protocol + llhttp: one TCP connection, pipelining, and dispatch.
 
 ``HttpProtocol`` owns parser callbacks, pause/resume, and request dispatch.
@@ -6,8 +6,13 @@ URL bytes and header fragments are written into the current exchange arena.
 Path/query decoding is cached here because it is connection-parse work.
 """
 
-from libc.stdint cimport uint16_t, uint64_t
+from collections import deque
+
+from libc.stdint cimport uint16_t, uint32_t, uint64_t
+from libc.stdlib cimport free, malloc
+from libc.string cimport memcmp, memcpy
 from cpython.bytes cimport PyBytes_FromStringAndSize
+from cpython.unicode cimport PyUnicode_DecodeASCII
 
 from stario.http.wire import decode_path
 from stario.telemetry.noop import NoOpTracer
@@ -15,30 +20,150 @@ from stario.telemetry.noop import NoOpTracer
 from stario_cython.exchange cimport Request, RequestExchange, acquire_exchange, _status_line
 from stario_cython.llhttp cimport *
 
-cdef dict _URL_CACHE = {}
-cdef int _URL_CACHE_MAX = 256
+cdef enum:
+    URL_CACHE_CAP = 256
+    URL_CACHE_MAX_KEY = 512
+    SMALL_BODY_COMPLETE_DISPATCH = 64 * 1024
+
+cdef char* _UC_KEY[256]
+cdef Py_ssize_t _UC_LEN[256]
+cdef uint32_t _UC_HASH[256]
+cdef list _UC_PATH = None
+cdef list _UC_QUERY = None
+cdef object Q_EMPTY = b""
+cdef object PATH_EMPTY = ""
 
 
-cdef tuple _split_request_target(object url):
-    cdef object cached
-    cdef Py_ssize_t question
-    cdef object path_bytes
+cdef uint32_t _url_hash(const char* s, Py_ssize_t n) noexcept:
+    cdef uint32_t value = <uint32_t>2166136261
+    cdef Py_ssize_t i
+    for i in range(n):
+        value = (value ^ <unsigned char>s[i]) * <uint32_t>16777619
+    return value
+
+
+cdef void _url_cache_init():
+    global _UC_PATH, _UC_QUERY
+    cdef int i
+    if _UC_PATH is not None:
+        return
+    _UC_PATH = [None] * URL_CACHE_CAP
+    _UC_QUERY = [None] * URL_CACHE_CAP
+    for i in range(URL_CACHE_CAP):
+        _UC_KEY[i] = NULL
+        _UC_LEN[i] = 0
+        _UC_HASH[i] = 0
+
+
+cdef void _url_cache_clear():
+    cdef int i
+    for i in range(URL_CACHE_CAP):
+        if _UC_KEY[i] != NULL:
+            free(_UC_KEY[i])
+            _UC_KEY[i] = NULL
+        _UC_LEN[i] = 0
+        _UC_HASH[i] = 0
+        _UC_PATH[i] = None
+        _UC_QUERY[i] = None
+
+
+cdef int _url_find(const char* url, Py_ssize_t n, uint32_t h) noexcept:
+    cdef int slot = <int>(h & (URL_CACHE_CAP - 1))
+    cdef int i
+    for i in range(URL_CACHE_CAP):
+        if _UC_KEY[slot] == NULL:
+            return -1
+        if (
+            _UC_HASH[slot] == h
+            and _UC_LEN[slot] == n
+            and memcmp(_UC_KEY[slot], url, <size_t>n) == 0
+        ):
+            return slot
+        slot = (slot + 1) & (URL_CACHE_CAP - 1)
+    return -1
+
+
+cdef void _url_store(
+    const char* url,
+    Py_ssize_t n,
+    uint32_t h,
+    object path,
+    object query,
+):
+    cdef int slot
+    cdef int i
+    cdef char* copy
+    slot = <int>(h & (URL_CACHE_CAP - 1))
+    for i in range(URL_CACHE_CAP):
+        if _UC_KEY[slot] == NULL:
+            copy = <char*>malloc(<size_t>n if n > 0 else 1)
+            if copy == NULL:
+                return
+            if n:
+                memcpy(copy, url, <size_t>n)
+            _UC_KEY[slot] = copy
+            _UC_LEN[slot] = n
+            _UC_HASH[slot] = h
+            _UC_PATH[slot] = path
+            _UC_QUERY[slot] = query
+            return
+        slot = (slot + 1) & (URL_CACHE_CAP - 1)
+    _url_cache_clear()
+    slot = <int>(h & (URL_CACHE_CAP - 1))
+    copy = <char*>malloc(<size_t>n if n > 0 else 1)
+    if copy == NULL:
+        return
+    if n:
+        memcpy(copy, url, <size_t>n)
+    _UC_KEY[slot] = copy
+    _UC_LEN[slot] = n
+    _UC_HASH[slot] = h
+    _UC_PATH[slot] = path
+    _UC_QUERY[slot] = query
+
+
+cdef object _decode_path_n(const char* s, Py_ssize_t n):
+    cdef Py_ssize_t i
+    cdef unsigned char c
+    if n <= 0:
+        return PATH_EMPTY
+    for i in range(n):
+        c = <unsigned char>s[i]
+        if c == 37 or c >= 128:
+            return decode_path(PyBytes_FromStringAndSize(s, n))
+    return PyUnicode_DecodeASCII(s, n, NULL)
+
+
+cdef tuple _split_request_target_n(const char* url, Py_ssize_t n):
+    cdef Py_ssize_t question = -1
+    cdef Py_ssize_t i
+    cdef uint32_t h = 0
+    cdef int slot
+    cdef object path
     cdef object query
-    cdef tuple result
-    cached = _URL_CACHE.get(url)
-    if cached is not None:
-        return <tuple>cached
-    question = url.find(b"?")
-    if question == -1:
-        path_bytes, query = url, b""
+    if n <= 0:
+        return (PATH_EMPTY, Q_EMPTY)
+    if n <= URL_CACHE_MAX_KEY:
+        h = _url_hash(url, n)
+        slot = _url_find(url, n, h)
+        if slot >= 0:
+            return (_UC_PATH[slot], _UC_QUERY[slot])
+    for i in range(n):
+        if url[i] == 63:
+            question = i
+            break
+    if question < 0:
+        path = _decode_path_n(url, n)
+        query = Q_EMPTY
     else:
-        path_bytes, query = url[:question], url[question + 1 :]
-    result = (decode_path(path_bytes), query)
-    if len(_URL_CACHE) >= _URL_CACHE_MAX:
-        _URL_CACHE.clear()
-    if <Py_ssize_t>len(url) <= 512:
-        _URL_CACHE[url] = result
-    return result
+        path = _decode_path_n(url, question)
+        if question + 1 < n:
+            query = PyBytes_FromStringAndSize(url + question + 1, n - question - 1)
+        else:
+            query = Q_EMPTY
+    if n <= URL_CACHE_MAX_KEY:
+        _url_store(url, n, h, path, query)
+    return (path, query)
 
 cdef int F_CONTENT_LENGTH = 0x20
 cdef int PAUSE_WRITE = 1
@@ -46,8 +171,8 @@ cdef int PAUSE_PIPELINE = 2
 cdef int PAUSE_BODY = 4
 cdef int PARSER_QUANTUM = 512 * 1024
 cdef int MAX_PENDING_EXCHANGES = 64
-# Handlers always start at headers-complete. Body bytes accumulate on the exchange;
-# body() awaits one completion Event, stream() drains with backpressure.
+# GET and large/chunked bodies dispatch at headers-complete. Small
+# Content-Length bodies dispatch at message-complete so body() is cached.
 
 cdef object METH_DELETE = "DELETE"
 cdef object METH_GET = "GET"
@@ -95,10 +220,11 @@ cdef object _version_str(int major, int minor):
 
 
 
-cdef void _bind_settings() noexcept:
+cdef void _bind_settings():
     global _SETTINGS
     if _SETTINGS != NULL:
         return
+    _url_cache_init()
     _SETTINGS = stario_settings_new()
     _SETTINGS.on_message_begin = _cb_message_begin
     _SETTINGS.on_url = _cb_url
@@ -185,6 +311,7 @@ cdef class HttpProtocol:
     cdef object held_data
     cdef Py_ssize_t held_offset
     cdef bint pump_scheduled
+    cdef object _create_task
 
     def __cinit__(self):
         _bind_settings()
@@ -229,8 +356,9 @@ cdef class HttpProtocol:
         self.date_box = date_box
         self.compression = compression
         self.connections = connections
+        self._create_task = app.create_task
         self.transport = None
-        self.pending_exchanges = []
+        self.pending_exchanges = deque()
         self.head_bytes = 0
         self.max_header_bytes = max_header_bytes
         self.max_body_bytes = max_body_bytes
@@ -486,7 +614,6 @@ cdef class HttpProtocol:
 
     cdef void _on_headers_complete(self) noexcept:
         cdef RequestExchange exchange
-        cdef Request request
         cdef uint16_t flags
         cdef uint64_t content_length
         if self.rejected or self.reading_exchange is None:
@@ -517,12 +644,21 @@ cdef class HttpProtocol:
         if self.transport is None or self.transport.is_closing():
             return
         try:
-            request = self._build_request(exchange, exchange)
             exchange.reset_body(
                 exchange._req_expect_continue,
                 <Py_ssize_t>content_length if flags & F_CONTENT_LENGTH else -1,
             )
-            self._dispatch(exchange, request)
+            # Small Content-Length bodies that fit in the current read complete
+            # before the handler runs, so body() hits the cached bytes instead
+            # of waiting on an Event during llhttp_execute. Expect: 100-continue
+            # and large/chunked bodies still dispatch at headers-complete.
+            if (
+                not exchange._req_expect_continue
+                and (flags & F_CONTENT_LENGTH)
+                and 0 < content_length <= <uint64_t>SMALL_BODY_COMPLETE_DISPATCH
+            ):
+                return
+            self._dispatch(exchange, self._build_request(exchange, exchange))
         except Exception:
             self._close_error(400, "Invalid HTTP request")
 
@@ -540,22 +676,39 @@ cdef class HttpProtocol:
         if exchange is not None and exchange._body_active:
             if exchange.c_complete() != 0:
                 self._close_error(400, "Invalid HTTP request")
+                self.reading_exchange = None
+                return
+        if (
+            not self.request_dispatched
+            and exchange is not None
+            and not self.rejected
+        ):
+            try:
+                if self.transport is None or self.transport.is_closing():
+                    self.reading_exchange = None
+                    return
+                self._dispatch(
+                    exchange,
+                    self._build_request(exchange, exchange),
+                )
+            except Exception:
+                self._close_error(400, "Invalid HTTP request")
+                self.reading_exchange = None
+                return
         self.reading_exchange = None
 
     cdef Request _build_request(self, RequestExchange exchange, object body):
         cdef object method
         cdef object version
-        cdef object url
         cdef tuple split
         cdef Request request = exchange.req
         if exchange._req_url_length > 0:
-            url = PyBytes_FromStringAndSize(
+            split = _split_request_target_n(
                 exchange._req_arena + exchange._req_url_offset,
                 exchange._req_url_length,
             )
         else:
-            url = b""
-        split = _split_request_target(url)
+            split = (PATH_EMPTY, Q_EMPTY)
         method = _method_str(<int>llhttp_get_method(self.parser))
         version = _version_str(
             <int>llhttp_get_http_major(self.parser),
@@ -590,19 +743,18 @@ cdef class HttpProtocol:
             self._set_pause_reason(PAUSE_PIPELINE, True)
 
     cdef void _start_exchange(self, RequestExchange exchange, bint eager_start):
+        cdef object task
         self.active_exchange = exchange
         exchange.start_response()
-        self.app.create_task(
-            self._run(exchange),
+        task = self._create_task(
+            self.app(exchange, exchange),
             loop=self.loop,
             eager_start=eager_start,
         )
-
-    async def _run(self, RequestExchange exchange):
-        try:
-            await self.app(exchange, exchange)
-        finally:
+        if task.done():
             exchange.handler_finished()
+        else:
+            task.add_done_callback(exchange.on_handler_done)
 
     cdef void _drop_pending(self):
         cdef RequestExchange exchange
@@ -640,7 +792,7 @@ cdef class HttpProtocol:
             self._drop_pending()
             return
         if self.pending_exchanges:
-            next_exchange = self.pending_exchanges.pop(0)
+            next_exchange = self.pending_exchanges.popleft()
             self._start_exchange(next_exchange, False)
             if not self.pending_exchanges:
                 self._set_pause_reason(PAUSE_PIPELINE, False)

--- a/tests/cython/conftest.py
+++ b/tests/cython/conftest.py
@@ -1,0 +1,8 @@
+"""Load ``stario`` before Cython extensions.
+
+Importing ``stario_cython.headers`` while ``stario.__init__`` is still running
+re-enters the partial module (App → Writer → Headers). Completing the package
+init first makes collection order-independent.
+"""
+
+import stario as _stario  # noqa: F401

--- a/tests/cython/test_headers_writer.py
+++ b/tests/cython/test_headers_writer.py
@@ -5,8 +5,8 @@ import brotli
 import pytest
 from stario_cython.headers import Headers
 
-from stario import App
 import stario.cookies as cookies
+from stario import App
 from stario.exceptions import StarioError, StarioRuntime
 from stario.http.compression import CompressionConfig
 from stario.http.headers import Headers as PublicHeaders

--- a/tests/cython/test_protocol.py
+++ b/tests/cython/test_protocol.py
@@ -84,6 +84,51 @@ async def test_plaintext_and_post_and_keepalive() -> None:
 
 
 @pytest.mark.asyncio
+async def test_small_content_length_body_is_complete_when_handler_runs() -> None:
+    """Content-Length bodies <= 64KiB dispatch after llhttp finishes the message."""
+    loop = asyncio.get_running_loop()
+    app = App()
+
+    async def echo(c, w):
+        # Deferred dispatch: body() is already complete (no Event wait).
+        payload = await c.req.body()
+        assert payload == b"x" * 1024
+        w.respond(payload, b"text/plain; charset=utf-8")
+
+    app.post("/echo", echo)
+    connections: set[HttpProtocol] = set()
+    server = await loop.create_server(
+        lambda: HttpProtocol(
+            loop,
+            app,
+            NoOpTracer(),
+            [b"date: Tue, 18 Aug 2026 00:00:00 GMT\r\n"],
+            CompressionConfig(),
+            connections,
+        ),
+        "127.0.0.1",
+        free_port(),
+    )
+    port = server.sockets[0].getsockname()[1]
+    payload = b"x" * 1024
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(
+            b"POST /echo HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Content-Length: 1024\r\n\r\n" + payload
+        )
+        await writer.drain()
+        response = await read_response(reader)
+        assert payload in response
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
 async def test_fragmented_headers_materialize_correctly() -> None:
     loop = asyncio.get_running_loop()
     app = App()
@@ -714,9 +759,11 @@ async def test_exchange_pool_reuses_across_connections() -> None:
 
 @pytest.mark.asyncio
 async def test_handler_starts_before_content_length_body_arrives() -> None:
+    """Bodies larger than 64KiB still dispatch at headers-complete."""
     loop = asyncio.get_running_loop()
     app = App()
     started = asyncio.Event()
+    payload = b"x" * (65 * 1024)
 
     async def echo(c, w):
         started.set()
@@ -743,13 +790,15 @@ async def test_handler_starts_before_content_length_body_arrives() -> None:
         writer.write(
             b"POST /echo HTTP/1.1\r\n"
             b"Host: localhost\r\n"
-            b"Content-Length: 5\r\n\r\n"
+            b"Content-Length: "
+            + str(len(payload)).encode("ascii")
+            + b"\r\n\r\n"
         )
         await writer.drain()
         await asyncio.wait_for(started.wait(), timeout=1.0)
-        writer.write(b"hello")
+        writer.write(payload)
         await writer.drain()
-        assert b"hello" in await read_response(reader)
+        assert payload in await read_response(reader)
         writer.close()
         await writer.wait_closed()
     finally:
@@ -786,7 +835,7 @@ async def test_body_wait_survives_multi_segment_upload() -> None:
     port = server.sockets[0].getsockname()[1]
     try:
         reader, writer = await asyncio.open_connection("127.0.0.1", port)
-        payload = b"abcdefghij" * 1000  # 10 KiB
+        payload = b"abcdefghij" * 7000  # 70 KiB: above the small-body deferral cap
         writer.write(
             b"POST /echo HTTP/1.1\r\n"
             b"Host: localhost\r\n"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The Cython protocol was already ~1.7× Python on read paths, but `App.__call__` still paid NoOpSpan method calls on every request, small POSTs waited on an `asyncio.Event` during `llhttp_execute`, and every request allocated a URL `bytes` object just to key a decode cache.

This keeps the Python App/Router (PR #28’s dual Cython app was the wrong trade) and tightens the existing Cython protocol + shared `App.__call__` hot path.

## What changed

- **NoOpSpan skip** in `App.__call__`: skip `start` / `attrs` dict / `fail` / `end` when `type(span) is NoOpSpan`. Skip redundant `w.end()` when the writer is already completed.
- **Small Content-Length deferral**: bodies in `(0, 64KiB]` without `Expect: 100-continue` dispatch at `message_complete` after `c_complete()`, so `body()` hits cached bytes instead of waiting on an Event nested in `llhttp_execute`. Large, chunked, and Expect-continue still header-dispatch.
- **Arena URL cache**: 256-slot open-addressing C cache hashed from arena memory. ASCII paths without `%` use `PyUnicode_DecodeASCII`; empty query is interned `b""`.
- **Dispatch**: drop the `_run` wrapper; eager-start `App.__call__`. If the task finishes during eager start, call `handler_finished()` immediately.
- **Misc**: `pending_exchanges` is a `deque`; `-fno-strict-aliasing`; wraparound-safe `ParsedQuery.as_dict`.
- **Harness**: `run.sh` creates the target venv before `ensure_fixtures`.
- **Tests**: `tests/cython/conftest.py` imports `stario` first so collection cannot circular-import. Coverage for deferred small-body dispatch; 65KiB+ still header-dispatches.

## What we did not do

- Dual Cython App/Router (rejected in #28).
- Reuse pooled `asyncio.Event` objects (loop-bound; pytest-asyncio uses a new loop per test).
- Pass complete bodies as `Request._body` `bytes` (breaks `stream(max_chunk)` and can hang inside the parser callback).
- `initializedcheck=False` / wraparound on `exchange.pyx` (segfaulted `ParsedQuery`).
- Idle/header timeouts on the Cython protocol (timer churn vs wrk). Still a reliability gap vs Python.

## Benchmarks (same machine, official suite)

`RUNS=5 WARMUP=1 DURATION=10s THREADS=2 CONNECTIONS=128 UPLOAD_CONNECTIONS=32 ENDPOINT_TIER=all`.

Compared against a **fresh unmodified `cython-core` wrk run on this host** (`f80d6f0`, `20260828T110114Z`), not mixed with `baseline-20260827.md` (different host class). Feature run: `174cef7`, `20260828T112246Z`. Full write-up: [`benchmarks/server/baseline-20260828.md`](benchmarks/server/baseline-20260828.md).

| Endpoint | Unmodified `cython-core` | This branch | Ratio |
| --- | ---: | ---: | ---: |
| Plaintext | 129,230 ± 2,877 | 132,083 ± 4,307 | 1.02× |
| JSON | 123,825 ± 3,502 | 131,544 ± 825 | **1.06×** |
| Params | 111,894 ± 1,687 | 126,443 ± 252 | **1.13×** |
| Validate JSON | 66,359 ± 234 | 108,084 ± 1,902 | **1.63×** |
| Form POST | 77,785 ± 1,875 | 131,462 ± 1,629 | **1.69×** |
| JSON 1KB | 67,892 ± 1,636 | 112,493 ± 3,605 | **1.66×** |
| Octet 64KB | 24,091 ± 164 | 37,735 ± 131 | **1.57×** |
| Octet 2MB (buffer) | 3,117 ± 78 | 3,190 ± 31 | 1.02× |
| Octet 2MB (stream) | 3,480 ± 3 | 3,485 ± 12 | 1.00× |
| Multipart 2MB | 3,179 ± 151 | 3,350 ± 37 | 1.05× |

Small POST is the real move: `body()` no longer waits on an Event during parse. The 64KB octet fixture is exactly `64 * 1024` bytes, so it sits in the deferral bucket and moves with that cohort. 2MB stays header-dispatch and **did not regress**. Plaintext is within sample noise.

## Tests

`pytest tests`: **739 passed**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b33dd208-3536-4367-b07f-886550aed521?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b33dd208-3536-4367-b07f-886550aed521&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

