### PR TITLE
Cython HTTP: faster small POST, timeouts on the Date tick

### DIFF
--- a/CYTHON.md
+++ b/CYTHON.md
@@ -83,8 +83,8 @@ the header deadline. `RequestPolicy.max_pipelined_requests` (default 8) caps
 the pipeline queue. Body stall is a generation counter — chunks do not
 `call_later`.
 
-Same-machine callback vs 10ms-sweep vs timeouts-off vs 50ms-sweep:
-`benchmarks/server/baseline-20260828.md`. Sweep ≈ callback on plaintext;
-timeouts-off is ~+5% plaintext (not worth dropping timeouts);
-10ms sweep was −7% on 2MB stream; 50ms recovered 2MB. Production now uses
-the 1s Date tick (5s/30s timeouts do not need 50ms).
+Same-machine callback vs 10ms-sweep vs timeouts-off vs 50ms-sweep vs
+1s Date tick: `benchmarks/server/baseline-20260828.md`. Sweep ≈ callback
+on plaintext; timeouts-off is ~+5% plaintext (not worth dropping timeouts);
+10ms sweep was −7% on 2MB stream; 50ms recovered 2MB. **1s Date tick vs
+50ms vs callbacks is a wash on plaintext** (129.3k / 130.8k / 128.0k).

--- a/CYTHON.md
+++ b/CYTHON.md
@@ -48,27 +48,35 @@ Read paths ~1.7×. Small POST ~1.2×. 64KB ingest even. Buffered 2MB, streaming 
 and multipart are ahead of Python after pre-sizing Content-Length bodies and
 pausing `body()` at 64KiB between parser quantums.
 
-## Hot path vs `cython-core` (2026-08-28)
+## Hot path + timeouts vs `cython-core` (2026-08-28)
 
 Same machine, official suite, unmodified `cython-core` (`f80d6f0`, run
-`20260828T110114Z`) vs this hot-path work (`174cef7`, run
-`20260828T112246Z`). Full table: `benchmarks/server/baseline-20260828.md`.
+`20260828T153450Z`) vs this branch (`460114d`, run `20260828T154518Z`).
+Full table: `benchmarks/server/baseline-20260828.md`.
 Do not mix these Cython rows with the 2026-08-27 Python column (different
-host class).
+host class), or with the earlier same-day PR #33-only capture
+(`20260828T110114Z`) from a prior VM.
 
-| Endpoint | Unmodified `cython-core` | Hot path | Hot / core |
+| Endpoint | Unmodified `cython-core` | This branch | Ratio |
 | --- | ---: | ---: | ---: |
-| Plaintext | 129,230 ± 2,877 | 132,083 ± 4,307 | 1.02× |
-| JSON | 123,825 ± 3,502 | 131,544 ± 825 | 1.06× |
-| Params | 111,894 ± 1,687 | 126,443 ± 252 | 1.13× |
-| Validate JSON | 66,359 ± 234 | 108,084 ± 1,902 | **1.63×** |
-| Form POST | 77,785 ± 1,875 | 131,462 ± 1,629 | **1.69×** |
-| JSON 1KB | 67,892 ± 1,636 | 112,493 ± 3,605 | **1.66×** |
-| Octet 64KB | 24,091 ± 164 | 37,735 ± 131 | **1.57×** |
-| Octet 2MB (buffer) | 3,117 ± 78 | 3,190 ± 31 | 1.02× |
-| Octet 2MB (stream) | 3,480 ± 3 | 3,485 ± 12 | 1.00× |
-| Multipart 2MB | 3,179 ± 151 | 3,350 ± 37 | 1.05× |
+| Plaintext | 125,495 ± 879 | 130,032 ± 602 | **1.04×** |
+| JSON | 121,997 ± 2,671 | 119,338 ± 4,601 | 0.98× |
+| Params | 117,005 ± 211 | 122,350 ± 1,991 | **1.05×** |
+| Validate JSON | 67,425 ± 512 | 106,918 ± 1,108 | **1.59×** |
+| Form POST | 75,089 ± 1,124 | 126,328 ± 3,486 | **1.68×** |
+| JSON 1KB | 68,866 ± 93 | 108,776 ± 781 | **1.58×** |
+| Octet 64KB | 22,013 ± 390 | 37,948 ± 406 | **1.72×** |
+| Octet 2MB (buffer) | 3,004 ± 14 | 3,172 ± 71 | **1.06×** |
+| Octet 2MB (stream) | 3,435 ± 48 | 3,391 ± 120 | 0.99× |
+| Multipart 2MB | 2,998 ± 59 | 3,178 ± 18 | **1.06×** |
 
 Small POST and the 64KiB octet fixture (exactly the deferral cap) jump because
-`body()` no longer waits on an Event during `llhttp_execute`. 2MB paths stay
-header-dispatch and did not regress. Plaintext is within sample noise.
+`body()` no longer waits on an Event during `llhttp_execute`. Header/idle
+timeouts reuse one timer handle per connection; plaintext is **+3.6%** (not
+killed). JSON and 2MB stream sit inside sample noise. 2MB buffer did not
+regress.
+
+Header timeout is armed only while headers (or a deferred small body) are
+still arriving. Idle timeout is armed only when the connection is idle.
+`RequestPolicy.max_pipelined_requests` (default 8) caps the pipeline queue.
+Body stall timeout takes `RequestPolicy.body_timeout`.

--- a/CYTHON.md
+++ b/CYTHON.md
@@ -25,39 +25,18 @@ only. Python Stario still negotiates zstd.
 `PYTHONPATH=src` is required so `stario_cython` resolves after the inplace
 build.
 
-## Python vs Cython (2026-08-27)
+## Merge snapshot (2026-08-28)
 
-Official `benchmarks/server` suite, same machine, one worker, `10s` × 5 measured
-+ 1 warmup, IQR trimming. Full tables and reproduce steps:
-`benchmarks/server/baseline-20260827.md`.
+Official `benchmarks/server` suite, one worker, `10s` × 5 measured + 1
+warmup, IQR trimming. Full lab log:
+[`benchmarks/server/baseline-20260828.md`](benchmarks/server/baseline-20260828.md).
 
-| Endpoint | Python httptools | Cython llhttp | Cython / Python |
-| --- | ---: | ---: | ---: |
-| Plaintext | 72,734 ± 647 | 125,160 ± 298 | 1.72× |
-| JSON | 71,042 ± 582 | 123,017 ± 3,211 | 1.73× |
-| Params | 71,033 ± 1,669 | 117,136 ± 2,590 | 1.65× |
-| Validate JSON | 56,663 ± 1,621 | 69,992 ± 838 | 1.24× |
-| Form POST | 60,476 ± 1,105 | 73,163 ± 361 | 1.21× |
-| JSON 1KB | 56,451 ± 276 | 66,933 ± 104 | 1.19× |
-| Octet 64KB | 25,228 ± 219 | 24,229 ± 244 | 0.96× |
-| Octet 2MB (buffer) | 2,062 ± 292 | 2,947 ± 35 | 1.43× |
-| Octet 2MB (stream) | 2,863 ± 15 | 3,208 ± 8 | 1.12× |
-| Multipart 2MB | 2,047 ± 173 | 2,905 ± 60 | 1.42× |
+### vs unmodified `cython-core` (current Cython)
 
-Read paths ~1.7×. Small POST ~1.2×. 64KB ingest even. Buffered 2MB, streaming 2MB,
-and multipart are ahead of Python after pre-sizing Content-Length bodies and
-pausing `body()` at 64KiB between parser quantums.
+`f80d6f0` (`20260828T153450Z`) → this branch `460114d`
+(`20260828T154518Z`). Same host, sequential.
 
-## Hot path + timeouts vs `cython-core` (2026-08-28)
-
-Same machine, official suite, unmodified `cython-core` (`f80d6f0`, run
-`20260828T153450Z`) vs this branch (`460114d`, run `20260828T154518Z`).
-Full table: `benchmarks/server/baseline-20260828.md`.
-Do not mix these Cython rows with the 2026-08-27 Python column (different
-host class), or with the earlier same-day PR #33-only capture
-(`20260828T110114Z`) from a prior VM.
-
-| Endpoint | Unmodified `cython-core` | This branch | Ratio |
+| Endpoint | Current (`cython-core`) | This branch | Ratio |
 | --- | ---: | ---: | ---: |
 | Plaintext | 125,495 ± 879 | 130,032 ± 602 | **1.04×** |
 | JSON | 121,997 ± 2,671 | 119,338 ± 4,601 | 0.98× |
@@ -70,21 +49,49 @@ host class), or with the earlier same-day PR #33-only capture
 | Octet 2MB (stream) | 3,435 ± 48 | 3,391 ± 120 | 0.99× |
 | Multipart 2MB | 2,998 ± 59 | 3,178 ± 18 | **1.06×** |
 
-Small POST and the 64KiB octet fixture (exactly the deferral cap) jump because
-`body()` no longer waits on an Event during `llhttp_execute`. Header/idle
-timeouts reuse one timer handle per connection; plaintext is **+3.6%** (not
-killed). JSON and 2MB stream sit inside sample noise. 2MB buffer did not
-regress.
+Small POST and the 64KiB fixture jump because deferred Content-Length ≤64KiB
+bodies complete before the handler’s `body()` wait. GET / 2MB stream are
+noise. Timeouts did not kill plaintext (+3.6%).
 
-Header, idle, and body-stall timeouts share one cleanup: under Server they
-ride the Date-header tick (once a second, one `loop.time()` then compare).
-Idle is armed only when the connection is idle; trickle bytes do not reset
-the header deadline. `RequestPolicy.max_pipelined_requests` (default 8) caps
-the pipeline queue. Body stall is a generation counter — chunks do not
-`call_later`.
+### vs Python httptools (current Python Stario)
 
-Same-machine callback vs 10ms-sweep vs timeouts-off vs 50ms-sweep vs
-1s Date tick: `benchmarks/server/baseline-20260828.md`. Sweep ≈ callback
-on plaintext; timeouts-off is ~+5% plaintext (not worth dropping timeouts);
-10ms sweep was −7% on 2MB stream; 50ms recovered 2MB. **1s Date tick vs
-50ms vs callbacks is a wash on plaintext** (129.3k / 130.8k / 128.0k).
+Same suite `20260828T193136Z`. Python: `stario.cli serve`. Cython:
+`python -m stario_cython`.
+
+| Endpoint | Current Python | This Cython | Cython / Python |
+| --- | ---: | ---: | ---: |
+| Plaintext | 74,752 ± 274 | 132,903 ± 3,484 | **1.78×** |
+| JSON | 72,983 ± 1,742 | 133,817 ± 7,033 | **1.83×** |
+| Params | 70,804 ± 95 | 126,707 ± 5,128 | **1.79×** |
+| Validate JSON | 56,566 ± 619 | 112,068 ± 4,145 | **1.98×** |
+| Form POST | 60,305 ± 106 | 123,813 ± 1,677 | **2.05×** |
+| JSON 1KB | 55,945 ± 431 | 110,946 ± 4,462 | **1.98×** |
+| Octet 64KB | 20,065 ± 202 | 37,772 ± 487 | **1.88×** |
+| Octet 2MB (buffer) | 1,981 ± 33 | 3,441 ± 20 | **1.74×** |
+| Octet 2MB (stream) | 2,969 ± 7 | 3,652 ± 16 | **1.23×** |
+| Multipart 2MB | 2,007 ± 80 | 3,563 ± 99 | **1.77×** |
+
+GET ~1.8×. Small POST ~2.0× (was ~1.2× on 27 Aug). 2MB stream 1.23×.
+
+### Timeouts that land
+
+Header, idle, and body-stall share **one** cleanup: the Date-header tick
+(1s) calls `check_timeouts(now)` on live connections. One `loop.time()`
+per wake. No extra sweeper, no per-request `TimerHandle`, no stall
+`call_later` per chunk.
+
+| | |
+| --- | --- |
+| Header | 5s, while headers or a deferred small body are still arriving |
+| Idle | 5s, only when the connection is idle |
+| Body stall | 30s, generation counter on the exchange |
+| Pipeline cap | 8 |
+| Tests | fallback sweeper at 50ms (`STARIO_CYTHON_TIMEOUT_SWEEP`) |
+| Hatch | `STARIO_CYTHON_TIMEOUTS=off` |
+
+wrk: sweep ≈ callbacks on plaintext; timeouts-off ~+5% plaintext (keep
+timeouts); 10ms sweep −7% on 2MB stream; 50ms and 1s Date tick are a wash
+(129.3k / 130.8k / 128.0k). Callbacks were deleted.
+
+App/Router stay Python. Do not revive dual Cython App/Router, a contiguous
+serializer, pooled `asyncio.Event`, or static/pre-serialized handlers.

--- a/CYTHON.md
+++ b/CYTHON.md
@@ -82,7 +82,8 @@ connection is idle; trickle bytes do not reset the header deadline.
 `RequestPolicy.max_pipelined_requests` (default 8) caps the pipeline queue.
 Body stall is a generation counter — chunks do not `call_later`.
 
-Same-machine callback vs 10ms-sweep vs timeouts-off:
+Same-machine callback vs 10ms-sweep vs timeouts-off vs 50ms-sweep:
 `benchmarks/server/baseline-20260828.md`. Sweep ≈ callback on plaintext;
 timeouts-off is ~+5% plaintext (not worth dropping timeouts);
-10ms sweep was −7% on 2MB stream, which is why the period is 50ms.
+10ms sweep was −7% on 2MB stream; 50ms sweep recovered 2MB (3,734 stream /
+3,471 buffer) and kept plaintext at 130.8k.

--- a/CYTHON.md
+++ b/CYTHON.md
@@ -76,14 +76,15 @@ timeouts reuse one timer handle per connection; plaintext is **+3.6%** (not
 killed). JSON and 2MB stream sit inside sample noise. 2MB buffer did not
 regress.
 
-Header, idle, and body-stall timeouts share one connection-set sweeper
-(`loop.time()` once per wake, default 50ms). Idle is armed only when the
-connection is idle; trickle bytes do not reset the header deadline.
-`RequestPolicy.max_pipelined_requests` (default 8) caps the pipeline queue.
-Body stall is a generation counter — chunks do not `call_later`.
+Header, idle, and body-stall timeouts share one cleanup: under Server they
+ride the Date-header tick (once a second, one `loop.time()` then compare).
+Idle is armed only when the connection is idle; trickle bytes do not reset
+the header deadline. `RequestPolicy.max_pipelined_requests` (default 8) caps
+the pipeline queue. Body stall is a generation counter — chunks do not
+`call_later`.
 
 Same-machine callback vs 10ms-sweep vs timeouts-off vs 50ms-sweep:
 `benchmarks/server/baseline-20260828.md`. Sweep ≈ callback on plaintext;
 timeouts-off is ~+5% plaintext (not worth dropping timeouts);
-10ms sweep was −7% on 2MB stream; 50ms sweep recovered 2MB (3,734 stream /
-3,471 buffer) and kept plaintext at 130.8k.
+10ms sweep was −7% on 2MB stream; 50ms recovered 2MB. Production now uses
+the 1s Date tick (5s/30s timeouts do not need 50ms).

--- a/CYTHON.md
+++ b/CYTHON.md
@@ -73,6 +73,24 @@ Same suite `20260828T193136Z`. Python: `stario.cli serve`. Cython:
 
 GET ~1.8×. Small POST ~2.0× (was ~1.2× on 27 Aug). 2MB stream 1.23×.
 
+### All servers (this host)
+
+Median req/s. Same knobs, one worker. Stario: `20260828T193136Z`. Granian /
+Socketify / Robyn / Django-Bolt: `20260828T183308Z`. BlackSheep+Granian:
+`20260828T180757Z`. Bold is best in that column. Granian is RSGI, no
+framework. Full ± and lab log:
+[`benchmarks/server/baseline-20260828.md`](benchmarks/server/baseline-20260828.md).
+
+| Server | Plaintext | JSON | Params | Validate | Form | JSON 1KB | 64KB | 2MB buf | 2MB stream | Multipart |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Granian RSGI | **146,875** | **144,111** | **146,201** | 106,610 | 118,928 | **114,517** | 31,212 | 1,429 | 3,108 | 3,138 |
+| Stario Cython | 132,903 | 133,817 | 126,707 | **112,068** | **123,813** | 110,946 | **37,772** | **3,441** | 3,652 | **3,563** |
+| Socketify | 122,497 | 103,563 | 79,977 | 13,267 | 19,556 | 13,293 | 12,365 | 674 | **4,062** | 663 |
+| BlackSheep+Granian | 113,487 | 102,801 | 105,259 | 42,628 | 46,420 | 42,622 | 21,029 | 1,214 | 3,155 | 1,228 |
+| Stario Python | 74,752 | 72,983 | 70,804 | 56,566 | 60,305 | 55,945 | 20,065 | 1,981 | 2,969 | 2,007 |
+| Django-Bolt | 30,071 | 31,946 | 30,310 | 25,585 | 26,272 | 26,252 | 20,037 | 1,499 | 1,478 | 1,488 |
+| Robyn | 25,780 | 25,206 | 19,351 | 18,382 | 4,721 | 18,270 | 15,629 | 735 | 751 | 498 |
+
 ### Timeouts that land
 
 Header, idle, and body-stall share **one** cleanup: the Date-header tick

--- a/CYTHON.md
+++ b/CYTHON.md
@@ -47,3 +47,28 @@ Official `benchmarks/server` suite, same machine, one worker, `10s` × 5 measure
 Read paths ~1.7×. Small POST ~1.2×. 64KB ingest even. Buffered 2MB, streaming 2MB,
 and multipart are ahead of Python after pre-sizing Content-Length bodies and
 pausing `body()` at 64KiB between parser quantums.
+
+## Hot path vs `cython-core` (2026-08-28)
+
+Same machine, official suite, unmodified `cython-core` (`f80d6f0`, run
+`20260828T110114Z`) vs this hot-path work (`174cef7`, run
+`20260828T112246Z`). Full table: `benchmarks/server/baseline-20260828.md`.
+Do not mix these Cython rows with the 2026-08-27 Python column (different
+host class).
+
+| Endpoint | Unmodified `cython-core` | Hot path | Hot / core |
+| --- | ---: | ---: | ---: |
+| Plaintext | 129,230 ± 2,877 | 132,083 ± 4,307 | 1.02× |
+| JSON | 123,825 ± 3,502 | 131,544 ± 825 | 1.06× |
+| Params | 111,894 ± 1,687 | 126,443 ± 252 | 1.13× |
+| Validate JSON | 66,359 ± 234 | 108,084 ± 1,902 | **1.63×** |
+| Form POST | 77,785 ± 1,875 | 131,462 ± 1,629 | **1.69×** |
+| JSON 1KB | 67,892 ± 1,636 | 112,493 ± 3,605 | **1.66×** |
+| Octet 64KB | 24,091 ± 164 | 37,735 ± 131 | **1.57×** |
+| Octet 2MB (buffer) | 3,117 ± 78 | 3,190 ± 31 | 1.02× |
+| Octet 2MB (stream) | 3,480 ± 3 | 3,485 ± 12 | 1.00× |
+| Multipart 2MB | 3,179 ± 151 | 3,350 ± 37 | 1.05× |
+
+Small POST and the 64KiB octet fixture (exactly the deferral cap) jump because
+`body()` no longer waits on an Event during `llhttp_execute`. 2MB paths stay
+header-dispatch and did not regress. Plaintext is within sample noise.

--- a/CYTHON.md
+++ b/CYTHON.md
@@ -76,7 +76,13 @@ timeouts reuse one timer handle per connection; plaintext is **+3.6%** (not
 killed). JSON and 2MB stream sit inside sample noise. 2MB buffer did not
 regress.
 
-Header timeout is armed only while headers (or a deferred small body) are
-still arriving. Idle timeout is armed only when the connection is idle.
+Header, idle, and body-stall timeouts share one connection-set sweeper
+(`loop.time()` once per wake, default 50ms). Idle is armed only when the
+connection is idle; trickle bytes do not reset the header deadline.
 `RequestPolicy.max_pipelined_requests` (default 8) caps the pipeline queue.
-Body stall timeout takes `RequestPolicy.body_timeout`.
+Body stall is a generation counter — chunks do not `call_later`.
+
+Same-machine callback vs 10ms-sweep vs timeouts-off:
+`benchmarks/server/baseline-20260828.md`. Sweep ≈ callback on plaintext;
+timeouts-off is ~+5% plaintext (not worth dropping timeouts);
+10ms sweep was −7% on 2MB stream, which is why the period is 50ms.

--- a/benchmarks/server/baseline-20260827.md
+++ b/benchmarks/server/baseline-20260827.md
@@ -4,9 +4,10 @@ Reference for comparing **Stario Cython** (llhttp) against **Stario Python**
 (httptools) on the official `benchmarks/server` suite. Relative comparisons on
 one machine — not lab-grade absolutes.
 
-**Going forward:** treat the Stario Cython row below as the baseline for Cython
-protocol work. Re-run the same suite after changes and compare median ± stdev
-to these numbers.
+**Going forward:** on a given machine, compare new Cython protocol work to a
+fresh unmodified `cython-core` wrk run on that machine. The 2026-08-28
+same-host hot-path capture is [`baseline-20260828.md`](baseline-20260828.md).
+The Cython row below remains the Python vs Cython snapshot for this date.
 
 Native/ASGI competitor tables from the previous capture remain in
 [`baseline-20260824.md`](baseline-20260824.md) (same machine class; not re-run

--- a/benchmarks/server/baseline-20260828.md
+++ b/benchmarks/server/baseline-20260828.md
@@ -1,20 +1,91 @@
-# Server benchmark: Cython hot path + timeouts vs `cython-core` (2026-08-28)
+# Server benchmark: merge snapshot (2026-08-28)
 
-Same-machine comparison of **unmodified `cython-core`** against this branch
-(PR #33 hot path + header/idle timeouts + pipeline cap). Relative numbers on
-one host — not lab-grade absolutes.
+Relative numbers on one host — not lab-grade absolutes. Cite the two tables
+in **Merge snapshot**. Chronology and competitor suites are under **Lab log**.
 
-**Going forward:** treat the “this branch” column below as the Cython
-protocol anchor on this machine. Re-run the same suite after further
-protocol work and compare median ± stdev to these numbers.
+Do not mix rows with [`baseline-20260827.md`](baseline-20260827.md)
+(different host class) or the earlier same-day PR #33-only capture
+(`20260828T110114Z`, other VM).
 
-The 2026-08-27 Python vs Cython capture remains in
-[`baseline-20260827.md`](baseline-20260827.md) (different host class; do not
-mix rows). An earlier same-day hot-path-only table (`20260828T110114Z` /
-`20260828T112246Z`, commit `174cef7`) was captured on a prior agent VM
-(~129k plaintext). Do not mix those rows with the table below.
+## Merge snapshot
 
-## Reproduce
+Official suite: `RUNS=5 WARMUP=1 DURATION=10s THREADS=2 CONNECTIONS=128
+UPLOAD_CONNECTIONS=32 ENDPOINT_TIER=all`. One worker. Handlers compute
+responses per request.
+
+### Current Cython (`cython-core`) vs this branch
+
+Sequential, same host. Unmodified `cython-core` `f80d6f0`
+(`20260828T153450Z`) → this branch `460114d` (`20260828T154518Z`). Later
+Date-tick captures stay in the same 130k plaintext band.
+
+| Endpoint | Current (`cython-core`) | This branch | Ratio |
+| --- | ---: | ---: | ---: |
+| Plaintext | 125,495 ± 879 | 130,032 ± 602 | **1.04×** |
+| JSON | 121,997 ± 2,671 | 119,338 ± 4,601 | 0.98× |
+| Params | 117,005 ± 211 | 122,350 ± 1,991 | **1.05×** |
+| Validate JSON | 67,425 ± 512 | 106,918 ± 1,108 | **1.59×** |
+| Form POST | 75,089 ± 1,124 | 126,328 ± 3,486 | **1.68×** |
+| JSON 1KB | 68,866 ± 93 | 108,776 ± 781 | **1.58×** |
+| Octet 64KB | 22,013 ± 390 | 37,948 ± 406 | **1.72×** |
+| Octet 2MB (buffer) | 3,004 ± 14 | 3,172 ± 71 | **1.06×** |
+| Octet 2MB (stream) | 3,435 ± 48 | 3,391 ± 120 | 0.99× |
+| Multipart 2MB | 2,998 ± 59 | 3,178 ± 18 | **1.06×** |
+
+Small POST and the 64KiB fixture (exactly the deferral cap) are the move:
+`body()` no longer waits on an `asyncio.Event` inside `llhttp_execute`.
+GET and 2MB stream sit inside run-to-run noise. Timeouts did not kill
+plaintext (**+3.6%**).
+
+### Current Python Stario vs this Cython
+
+Same suite `20260828T193136Z` (`d80e264`). Python: `stario.cli serve` +
+httptools. Cython: `python -m stario_cython` + llhttp.
+
+| Endpoint | Current Python (httptools) | This Cython (llhttp) | Cython / Python |
+| --- | ---: | ---: | ---: |
+| Plaintext | 74,752 ± 274 | 132,903 ± 3,484 | **1.78×** |
+| JSON | 72,983 ± 1,742 | 133,817 ± 7,033 | **1.83×** |
+| Params | 70,804 ± 95 | 126,707 ± 5,128 | **1.79×** |
+| Validate JSON | 56,566 ± 619 | 112,068 ± 4,145 | **1.98×** |
+| Form POST | 60,305 ± 106 | 123,813 ± 1,677 | **2.05×** |
+| JSON 1KB | 55,945 ± 431 | 110,946 ± 4,462 | **1.98×** |
+| Octet 64KB | 20,065 ± 202 | 37,772 ± 487 | **1.88×** |
+| Octet 2MB (buffer) | 1,981 ± 33 | 3,441 ± 20 | **1.74×** |
+| Octet 2MB (stream) | 2,969 ± 7 | 3,652 ± 16 | **1.23×** |
+| Multipart 2MB | 2,007 ± 80 | 3,563 ± 99 | **1.77×** |
+
+GET ~**1.8×**. Small POST ~**2.0×** (was ~1.2× on 27 Aug, before CL ≤64KiB
+deferral). 2MB stream is the closest (1.23×).
+
+### Decisions
+
+| Question | Decision | Why |
+| --- | --- | --- |
+| Callbacks (`TimerHandle` / stall `call_later`) vs sweep | **Sweep** | wrk wash on plaintext (~1%); one mechanism |
+| Extra 10ms sweeper | **No** | −7% on 2MB stream |
+| Extra 50ms sweeper vs Date tick (1s) | **Date tick** | wrk wash; Date refresh already wakes once a second |
+| Compile timeouts out | **No** | off is only ~+5% plaintext; 2MB buffer does not speed up |
+| Cythonize App/Router | **No** | PR #28; App/Router stay Python |
+| Static / pre-serialized handlers | **No** | official suite policy |
+
+### Defaults that land
+
+| | |
+| --- | --- |
+| Header timeout | 5s (armed while headers or a deferred small body are still arriving) |
+| Idle / keep-alive | 5s (armed only when nothing is in flight) |
+| Body stall | 30s (`RequestPolicy.body_timeout`; generation counter, not `call_later` per chunk) |
+| Pipeline cap | 8 |
+| Sweep period in production | Date-header tick, 1s |
+| Tests | `STARIO_CYTHON_TIMEOUT_SWEEP=0.05` (no Server Date tick) |
+| Profiling hatch | `STARIO_CYTHON_TIMEOUTS=off` |
+
+## Lab log
+
+Reproduce, environment, and the chronological A/B / competitor captures.
+
+### Reproduce
 
 ```bash
 RUNS=5 WARMUP=1 DURATION=10s THREADS=2 \
@@ -84,10 +155,11 @@ one on baseline (n_used=4). Other rows used all 5 measured samples.
 - **Octet 64KB** moved with that cohort because the fixture is exactly
   `64 * 1024` bytes (`payload-64k.bin`), which is still in the deferral
   bucket (`content_length <= 64KiB`). 2MB uploads stay header-dispatch.
-- **Timeout rps cost:** header/idle timers reuse one `TimerHandle` per
-  connection (deadline store + `loop.time()`, no `call_later` per request).
-  Plaintext is **+3.6%** vs unmodified core (tighter stdev). JSON (−2%) and
-  2MB stream (−1%) sit inside overlapping sample noise — not a bisect.
+- **Timeout rps cost (this capture still used per-connection
+  `TimerHandle`s):** plaintext is **+3.6%** vs unmodified core (tighter
+  stdev). Production now sweeps on the Date tick instead; that A/B is a
+  wash (see below). JSON (−2%) and 2MB stream (−1%) sit inside overlapping
+  sample noise — not a bisect.
 - **2MB buffer** did not regress (+6%). Multipart +6%.
 
 ## Timeout cleanup: callback vs sweep vs off (2026-08-28)

--- a/benchmarks/server/baseline-20260828.md
+++ b/benchmarks/server/baseline-20260828.md
@@ -1,8 +1,8 @@
-# Server benchmark: Cython hot path vs `cython-core` (2026-08-28)
+# Server benchmark: Cython hot path + timeouts vs `cython-core` (2026-08-28)
 
-Same-machine comparison of **unmodified `cython-core`** against the hot-path
-changes on `cursor/cython-hotpath-d521` (PR #33). Relative numbers on one
-host — not lab-grade absolutes.
+Same-machine comparison of **unmodified `cython-core`** against this branch
+(PR #33 hot path + header/idle timeouts + pipeline cap). Relative numbers on
+one host — not lab-grade absolutes.
 
 **Going forward:** treat the “this branch” column below as the Cython
 protocol anchor on this machine. Re-run the same suite after further
@@ -10,7 +10,9 @@ protocol work and compare median ± stdev to these numbers.
 
 The 2026-08-27 Python vs Cython capture remains in
 [`baseline-20260827.md`](baseline-20260827.md) (different host class; do not
-mix rows).
+mix rows). An earlier same-day hot-path-only table (`20260828T110114Z` /
+`20260828T112246Z`, commit `174cef7`) was captured on a prior agent VM
+(~129k plaintext). Do not mix those rows with the table below.
 
 ## Reproduce
 
@@ -21,8 +23,10 @@ RUNS=5 WARMUP=1 DURATION=10s THREADS=2 \
   benchmarks/server/run.sh stario-cython
 ```
 
-Unmodified baseline was a git worktree of `cython-core` at `f80d6f0`.
-Feature run used this branch (`174cef7`).
+Unmodified baseline was a git worktree of `cython-core` at `f80d6f0`
+(harness-only `run.sh` venv-before-fixtures patch so a cold tree does not
+exit 127; protocol sources unchanged). Feature run used this branch
+(`460114d`). Suites ran sequentially on a quiet host (no overlapping wrk).
 
 ## Environment
 
@@ -35,9 +39,9 @@ Feature run used this branch (`174cef7`).
 | Client | wrk 4.1.0, `-t2 -c128` (read/small upload), `-c32` (64KB/2MB) |
 | Topology | wrk and servers on same host, `127.0.0.1` loopback |
 | Baseline commit | `f80d6f0` (`cython-core`) |
-| Feature commit | `174cef7` (`cursor/cython-hotpath-d521`) |
-| Baseline run | `20260828T110114Z` |
-| Feature run | `20260828T112246Z` |
+| Feature commit | `460114d` (`cursor/cython-timeouts-hotpath-8736`) |
+| Baseline run | `20260828T153450Z` |
+| Feature run | `20260828T154518Z` |
 
 ## Methodology
 
@@ -52,45 +56,66 @@ Feature run used this branch (`174cef7`).
   objects, no pre-serialized JSON bytes). See `benchmarks/README.md` handler
   policy.
 
-## This-machine delta (`cython-core` → hot path)
+## This-machine delta (`cython-core` → hot path + timeouts)
 
 | Endpoint | Unmodified `cython-core` | This branch | Ratio |
 | --- | ---: | ---: | ---: |
-| Plaintext | 129,230 ± 2,877 | 132,083 ± 4,307 | 1.02× |
-| JSON | 123,825 ± 3,502 | 131,544 ± 825 | **1.06×** |
-| Params | 111,894 ± 1,687 | 126,443 ± 252 | **1.13×** |
-| Validate JSON | 66,359 ± 234 | 108,084 ± 1,902 | **1.63×** |
-| Form POST | 77,785 ± 1,875 | 131,462 ± 1,629 | **1.69×** |
-| JSON 1KB | 67,892 ± 1,636 | 112,493 ± 3,605 | **1.66×** |
-| Octet 64KB | 24,091 ± 164 | 37,735 ± 131 | **1.57×** |
-| Octet 2MB (buffer) | 3,117 ± 78 | 3,190 ± 31 | 1.02× |
-| Octet 2MB (stream) | 3,480 ± 3 | 3,485 ± 12 | 1.00× |
-| Multipart 2MB | 3,179 ± 151 | 3,350 ± 37 | 1.05× |
+| Plaintext | 125,495 ± 879 | 130,032 ± 602 | **1.04×** |
+| JSON | 121,997 ± 2,671 | 119,338 ± 4,601 | 0.98× |
+| Params | 117,005 ± 211 | 122,350 ± 1,991 | **1.05×** |
+| Validate JSON | 67,425 ± 512 | 106,918 ± 1,108 | **1.59×** |
+| Form POST | 75,089 ± 1,124 | 126,328 ± 3,486 | **1.68×** |
+| JSON 1KB | 68,866 ± 93 | 108,776 ± 781 | **1.58×** |
+| Octet 64KB | 22,013 ± 390 | 37,948 ± 406 | **1.72×** |
+| Octet 2MB (buffer) | 3,004 ± 14 | 3,172 ± 71 | **1.06×** |
+| Octet 2MB (stream) | 3,435 ± 48 | 3,391 ± 120 | 0.99× |
+| Multipart 2MB | 2,998 ± 59 | 3,178 ± 18 | **1.06×** |
 
-JSON / params / multipart report one IQR outlier removed on the feature run
-(n_used=4). 2MB buffer likewise. Other rows used all 5 measured samples.
+Params reports two IQR outliers removed on the baseline (n_used=3). JSON 1KB
+one on baseline (n_used=4). 2MB buffer two on baseline (n_used=3). Multipart
+one on baseline (n_used=4). Other rows used all 5 measured samples.
 
 ## How to read it
 
 - **Small POST** (validate / form / JSON 1KB) is the real move: ~1.6–1.7×.
-  Content-Length bodies ≤ 64KiB now dispatch at `message_complete` after
+  Content-Length bodies ≤ 64KiB dispatch at `message_complete` after
   `c_complete()`, so `body()` hits cached bytes instead of waiting on an
   `asyncio.Event` nested in `llhttp_execute`.
 - **Octet 64KB** moved with that cohort because the fixture is exactly
   `64 * 1024` bytes (`payload-64k.bin`), which is still in the deferral
   bucket (`content_length <= 64KiB`). 2MB uploads stay header-dispatch.
-- **Read path** is flat-to-up. Plaintext (+2%) sits inside sample noise
-  (baseline stdev ~2.9k). JSON (+6%) and params (+13%) are clearer; those
-  also pick up the NoOpSpan skip, URL arena cache, and dropping the `_run`
-  wrapper.
-- **2MB buffer / stream** did not regress (the failure mode to watch).
-  Multipart is a modest +5%.
+- **Timeout rps cost:** header/idle timers reuse one `TimerHandle` per
+  connection (deadline store + `loop.time()`, no `call_later` per request).
+  Plaintext is **+3.6%** vs unmodified core (tighter stdev). JSON (−2%) and
+  2MB stream (−1%) sit inside overlapping sample noise — not a bisect.
+- **2MB buffer** did not regress (+6%). Multipart +6%.
 
-## What landed in the feature commit
+## What landed
 
 - Skip `NoOpSpan` start/attrs/fail/end in `App.__call__`.
 - Defer small Content-Length bodies until message-complete.
 - Arena URL cache (no per-request URL `bytes` cache key).
 - Eager-start `App.__call__` without a `_run` wrapper; `deque` pipeline.
 - `-fno-strict-aliasing`; wraparound-safe `ParsedQuery.as_dict`.
+- Header timeout while reading headers / deferred small bodies; idle
+  timeout only when idle; pipeline cap 8; `body_timeout` from `RequestPolicy`.
 - `run.sh` creates the target venv before fixtures.
+
+## Tried / won / rejected
+
+**Won**
+
+- Header + idle timeouts without per-request `call_later`.
+- Pipeline cap 8; policy `body_timeout` on the exchange stall timer.
+- PR #33 hot path (NoOpSpan skip, defer CL ≤64KiB, arena URL cache).
+
+**Rejected / not revived**
+
+- Dual Cython App/Router (PR #28).
+- Contiguous response serializer (4–9% slower).
+- Pooled `asyncio.Event` (loop-bound).
+- `initializedcheck=False` on `exchange.pyx` (ParsedQuery segfault).
+- Passing complete body as `Request._body` bytes (breaks `stream(max_chunk)`).
+- `body()` cached-bytes fast path: py-spy on `/validate` did not show
+  `Request.body` / `read()` after deferral (ujson + `create_task` dominate).
+- Per-request `call_later` for timeouts (would kill plaintext).

--- a/benchmarks/server/baseline-20260828.md
+++ b/benchmarks/server/baseline-20260828.md
@@ -170,6 +170,39 @@ No extra win from going 50ms → 1s on wrk; the point of 1s is one timer
 Do not mix these columns with the `cython-core` table above (that
 feature run was `460114d` / `20260828T154518Z`).
 
+## Stario Cython vs BlackSheep + Granian (2026-08-28)
+
+Same host, sequential, official knobs, this branch at `caae836`
+(`20260828T180757Z`). One worker each. Do not mix with
+`baseline-20260824.md`.
+
+```bash
+RUNS=5 WARMUP=1 DURATION=10s THREADS=2 \
+  CONNECTIONS=128 UPLOAD_CONNECTIONS=32 \
+  ENDPOINT_TIER=all KEEP_RAW=1 \
+  benchmarks/server/run.sh stario-cython blacksheep-granian
+```
+
+| Endpoint | Stario Cython | BlackSheep + Granian | Stario / BS |
+| --- | ---: | ---: | ---: |
+| Plaintext | 134,568 ± 2,033 | 113,487 ± 627 | **1.19×** |
+| JSON | 126,972 ± 1,529 | 102,801 ± 10,478 | **1.24×** |
+| Params | 121,269 ± 1,830 | 105,259 ± 1,539 | **1.15×** |
+| Validate JSON | 107,151 ± 1,179 | 42,628 ± 37 | **2.51×** |
+| Form POST | 126,837 ± 1,724 | 46,420 ± 496 | **2.73×** |
+| JSON 1KB | 108,266 ± 381 | 42,622 ± 246 | **2.54×** |
+| Octet 64KB | 37,075 ± 1,034 | 21,029 ± 91 | **1.76×** |
+| Octet 2MB (buffer) | 3,304 ± 119 | 1,214 ± 26 | **2.72×** |
+| Octet 2MB (stream) | 2,732 ± 83 | 3,155 ± 53 | 0.87× |
+| Multipart 2MB | 3,333 ± 234 | 1,228 ± 35 | **2.72×** |
+
+Read paths ~1.2×. Small POST and buffered 2MB/multipart ~2.5–2.7× (Stario
+defers Content-Length ≤64KiB; BlackSheep `request.read()` pays ASGI body
+assembly). **2MB stream** is the exception: BlackSheep is ahead in this
+pairing. Stario’s stream samples here are a tight 2.6–2.8k band, below
+this branch’s focused captures today (~3.5k). Treat that row as noisy
+until a dedicated stream re-run; do not invert the rest of the table on it.
+
 ## What landed
 
 - Skip `NoOpSpan` start/attrs/fail/end in `App.__call__`.

--- a/benchmarks/server/baseline-20260828.md
+++ b/benchmarks/server/baseline-20260828.md
@@ -58,6 +58,28 @@ httptools. Cython: `python -m stario_cython` + llhttp.
 GET ~**1.8×**. Small POST ~**2.0×** (was ~1.2× on 27 Aug, before CL ≤64KiB
 deferral). 2MB stream is the closest (1.23×).
 
+### All servers (this host)
+
+One table, all frameworks measured tonight. Median req/s ± sample stdev.
+Same knobs, one worker. **Not** one sequential suite: Stario rows are
+`20260828T193136Z`; Granian / Socketify / Robyn / Django-Bolt are
+`20260828T183308Z`; BlackSheep+Granian is `20260828T180757Z`. Sorted by
+plaintext. Bold is the highest cell in that column. Sanic, FastAPI, and
+BlackSheep+Uvicorn were not run.
+
+Granian is **RSGI, no framework**. Robyn and Django-Bolt buffer the stream
+route (no request streaming API).
+
+| Server | Plaintext | JSON | Params | Validate | Form | JSON 1KB | 64KB | 2MB buf | 2MB stream | Multipart |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Granian RSGI | **146,875 ± 713** | **144,111 ± 269** | **146,201 ± 3,838** | 106,610 ± 1,068 | 118,928 ± 1,581 | **114,517 ± 1,516** | 31,212 ± 198 | 1,429 ± 12 | 3,108 ± 20 | 3,138 ± 77 |
+| Stario Cython | 132,903 ± 3,484 | 133,817 ± 7,033 | 126,707 ± 5,128 | **112,068 ± 4,145** | **123,813 ± 1,677** | 110,946 ± 4,462 | **37,772 ± 487** | **3,441 ± 20** | 3,652 ± 16 | **3,563 ± 99** |
+| Socketify | 122,497 ± 62 | 103,563 ± 332 | 79,977 ± 812 | 13,267 ± 66 | 19,556 ± 195 | 13,293 ± 179 | 12,365 ± 220 | 674 ± 20 | **4,062 ± 74** | 663 ± 6 |
+| BlackSheep+Granian | 113,487 ± 627 | 102,801 ± 10,478 | 105,259 ± 1,539 | 42,628 ± 37 | 46,420 ± 496 | 42,622 ± 246 | 21,029 ± 91 | 1,214 ± 26 | 3,155 ± 53 | 1,228 ± 35 |
+| Stario Python | 74,752 ± 274 | 72,983 ± 1,742 | 70,804 ± 95 | 56,566 ± 619 | 60,305 ± 106 | 55,945 ± 431 | 20,065 ± 202 | 1,981 ± 33 | 2,969 ± 7 | 2,007 ± 80 |
+| Django-Bolt | 30,071 ± 147 | 31,946 ± 168 | 30,310 ± 255 | 25,585 ± 184 | 26,272 ± 157 | 26,252 ± 953 | 20,037 ± 1,936 | 1,499 ± 11 | 1,478 ± 14 | 1,488 ± 20 |
+| Robyn | 25,780 ± 74 | 25,206 ± 64 | 19,351 ± 49 | 18,382 ± 60 | 4,721 ± 5 | 18,270 ± 52 | 15,629 ± 32 | 735 ± 48 | 751 ± 13 | 498 ± 37 |
+
 ### Decisions
 
 | Question | Decision | Why |

--- a/benchmarks/server/baseline-20260828.md
+++ b/benchmarks/server/baseline-20260828.md
@@ -129,9 +129,10 @@ Runs: callback `20260828T164108Z`, sweep `20260828T165111Z`, off `20260828T17011
   and does not justify deleting timeouts or spending more time on the
   cleanup path. py-spy still points at `writev` and `App.create_task`.
 - **10ms sweep hurt 2MB stream** (−7% vs callback, −12% vs off). The
-  sweeper was waking 100×/s while handlers waited on body. Default period
-  is now **50ms** (production timeouts are 5s/30s). Callback code is
-  gone; sweep is the only cleanup.
+  sweeper was waking 100×/s while handlers waited on body. 50ms recovered
+  2MB. Production now rides the **Date-header tick (1s)** — header/idle/body
+  defaults are 5s/5s/30s, so 50ms was overkill. Callback code is gone;
+  sweep is the only cleanup.
 
 Focused re-run on `1d5b9e7` with the **50ms** default (`20260828T172052Z`,
 same official knobs, endpoints `plaintext,post-form,post-octet-2m,post-stream-2m`):
@@ -146,6 +147,9 @@ same official knobs, endpoints `plaintext,post-form,post-octet-2m,post-stream-2m
 50ms sweep puts plaintext back on the 130k band (same as the earlier
 timeouts-on feature run). 2MB stream/buffer are **not** the 10ms-sweep
 regression; they sit at or above the callback and off columns.
+
+Production default after that measurement is the **1s Date tick** (no
+extra timer). Tests still force 50ms via `STARIO_CYTHON_TIMEOUT_SWEEP`.
 
 Do not mix these three columns with the `cython-core` table above (that
 feature run was `460114d` / `20260828T154518Z`).

--- a/benchmarks/server/baseline-20260828.md
+++ b/benchmarks/server/baseline-20260828.md
@@ -223,8 +223,11 @@ Read-heavy (req/s):
 | Granian RSGI (no framework) | 146,875 ± 713 | 144,111 ± 269 | 146,201 ± 3,838 |
 | Stario Cython | 139,876 ± 8,738 | 124,344 ± 1,959 | 124,129 ± 2,426 |
 | Socketify | 122,497 ± 62 | 103,563 ± 332 | 79,977 ± 812 |
+| Stario Python (httptools) | 74,752 ± 274 | 72,983 ± 1,742 | 70,804 ± 95 |
 | Django-Bolt | 30,071 ± 147 | 31,946 ± 168 | 30,310 ± 255 |
 | Robyn | 25,780 ± 74 | 25,206 ± 64 | 19,351 ± 49 |
+
+Stario Python is a follow-up capture (`20260828T193136Z`, `d80e264`, `stario.cli serve` + httptools). Other rows are `20260828T183308Z`. Same host and knobs.
 
 Upload / body (req/s):
 
@@ -232,6 +235,7 @@ Upload / body (req/s):
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | Stario Cython | 107,659 ± 1,824 | 126,114 ± 421 | 110,834 ± 1,020 | 38,256 ± 593 | 3,246 ± 134 | 3,649 ± 22 | 3,445 ± 55 |
 | Granian RSGI | 106,610 ± 1,068 | 118,928 ± 1,581 | 114,517 ± 1,516 | 31,212 ± 198 | 1,429 ± 12 | 3,108 ± 20 | 3,138 ± 77 |
+| Stario Python (httptools) | 56,566 ± 619 | 60,305 ± 106 | 55,945 ± 431 | 20,065 ± 202 | 1,981 ± 33 | 2,969 ± 7 | 2,007 ± 80 |
 | Django-Bolt | 25,585 ± 184 | 26,272 ± 157 | 26,252 ± 953 | 20,037 ± 1,936 | 1,499 ± 11 | 1,478 ± 14 | 1,488 ± 20 |
 | Socketify | 13,267 ± 66 | 19,556 ± 195 | 13,293 ± 179 | 12,365 ± 220 | 674 ± 20 | **4,062 ± 74** | 663 ± 6 |
 | Robyn | 18,382 ± 60 | 4,721 ± 5 | 18,270 ± 52 | 15,629 ± 32 | 735 ± 48 | 751 ± 13 | 498 ± 37 |
@@ -256,6 +260,54 @@ overlaps). Small POST is even. Stario pulls away on 64KB and buffered 2MB
 (Content-Length deferral + pause). Socketify wins **2MB stream** (4.1k);
 Stario stream is 3.6k in this suite (the 2.7k BlackSheep pairing was the
 dip). Robyn and Django-Bolt are ~4–5× behind on plaintext at one worker.
+Python httptools Stario sits ~2× behind this branch’s Cython on reads and
+small POST, and ~1.2× behind on 2MB stream — still ~2.5–3× Robyn/Django-Bolt
+on plaintext.
+
+## Stario Cython vs Stario Python (2026-08-28)
+
+Same host, official knobs. Python is **httptools** (`stario.cli serve`,
+port 3000, `stario.http.protocol`). Cython is **llhttp**
+(`python -m stario_cython`, port 3001). Python run `20260828T193136Z`
+(`d80e264`). Cython column is the native-suite capture `20260828T183308Z`
+(`28d6cc7`) — same machine and knobs, not the still-running paired Cython
+half of `193136Z`. Do not mix with [`baseline-20260827.md`](baseline-20260827.md).
+
+```bash
+RUNS=5 WARMUP=1 DURATION=10s THREADS=2 \
+  CONNECTIONS=128 UPLOAD_CONNECTIONS=32 \
+  ENDPOINT_TIER=all KEEP_RAW=1 \
+  benchmarks/server/run.sh stario stario-cython
+```
+
+| Endpoint | Python httptools | Cython llhttp | Cython / Python |
+| --- | ---: | ---: | ---: |
+| Plaintext | 74,752 ± 274 | 139,876 ± 8,738 | **1.87×** |
+| JSON | 72,983 ± 1,742 | 124,344 ± 1,959 | **1.70×** |
+| Params | 70,804 ± 95 | 124,129 ± 2,426 | **1.75×** |
+| Validate JSON | 56,566 ± 619 | 107,659 ± 1,824 | **1.90×** |
+| Form POST | 60,305 ± 106 | 126,114 ± 421 | **2.09×** |
+| JSON 1KB | 55,945 ± 431 | 110,834 ± 1,020 | **1.98×** |
+| Octet 64KB | 20,065 ± 202 | 38,256 ± 593 | **1.91×** |
+| Octet 2MB (buffer) | 1,981 ± 33 | 3,246 ± 134 | **1.64×** |
+| Octet 2MB (stream) | 2,969 ± 7 | 3,649 ± 22 | **1.23×** |
+| Multipart 2MB | 2,007 ± 80 | 3,445 ± 55 | **1.72×** |
+
+Params (Python) two IQR outliers removed (n_used=3). Form (Cython) two.
+2MB stream one on each side. Other rows used all 5 measured samples.
+
+**Read it**
+
+- **GET** is ~**1.7–1.9×**. Python plaintext is a tight 74.5–75.1k band.
+  Cython plaintext in the native suite is the noisy 129–149k capture
+  (±8.7k). Other same-day Cython plaintext sits 130–135k, which is still
+  ~**1.75×** this Python row. The 27 Aug snapshot was 72.7k vs 125.2k
+  (**1.72×**) on an earlier commit.
+- **Small POST** (validate / form / JSON 1KB) is ~**1.9–2.1×**. On 27 Aug
+  this cohort was only ~1.2×; Cython’s Content-Length ≤64KiB deferral is
+  the gap. **64KB** moved with it (fixture is exactly 64KiB) — was even
+  on 27 Aug (0.96×), **1.91×** now.
+- **2MB stream** is the closest (1.23×). Buffered 2MB / multipart ~1.6–1.7×.
 
 ## What landed
 
@@ -267,6 +319,8 @@ dip). Robyn and Django-Bolt are ~4–5× behind on plaintext at one worker.
 - Header timeout while reading headers / deferred small bodies; idle
   timeout only when idle; pipeline cap 8; `body_timeout` from `RequestPolicy`.
 - `run.sh` creates the target venv before fixtures.
+- `run.sh stario` (Python httptools) sets `PYTHONPATH` to `src` so this
+  branch’s Cython `Headers` import.
 
 ## Tried / won / rejected
 

--- a/benchmarks/server/baseline-20260828.md
+++ b/benchmarks/server/baseline-20260828.md
@@ -148,10 +148,26 @@ same official knobs, endpoints `plaintext,post-form,post-octet-2m,post-stream-2m
 timeouts-on feature run). 2MB stream/buffer are **not** the 10ms-sweep
 regression; they sit at or above the callback and off columns.
 
-Production default after that measurement is the **1s Date tick** (no
-extra timer). Tests still force 50ms via `STARIO_CYTHON_TIMEOUT_SWEEP`.
+**Date-tick 1s** vs that 50ms run and vs callbacks (`2ed44a9`, same four
+endpoints, same knobs). First capture (`20260828T174435Z`) had plaintext
+132k–148k (median 144,625 ± 7,315) — not usable. Repeat
+(`20260828T175027Z`) is the row below.
 
-Do not mix these three columns with the `cython-core` table above (that
+| Endpoint | Callback | Sweep 50ms | Date tick 1s | 1s / cb | 1s / 50ms |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Plaintext | 128,038 ± 1,283 | 130,755 ± 1,038 | 129,328 ± 566 | 1.01× | 0.99× |
+| Form POST | 132,633 ± 2,994 | 124,567 ± 201 | 124,689 ± 1,958 | 0.94× | 1.00× |
+| Octet 2MB (buffer) | 3,195 ± 15 | 3,471 ± 11 | 3,273 ± 108 | 1.02× | 0.94× |
+| Octet 2MB (stream) | 3,388 ± 98 | 3,734 ± 33 | 3,513 ± 68 | 1.04× | 0.94× |
+
+Plaintext: 1s Date tick is **the same** as 50ms sweep and callbacks (1% is
+inside this host’s run-to-run band). Form: 1s and 50ms agree; the callback
+form row was a hot outlier vs the morning 126k. 2MB: 1s sits between
+callback and the 50ms capture (that 50ms 2MB buffer used n=3 after IQR).
+No extra win from going 50ms → 1s on wrk; the point of 1s is one timer
+(the Date tick) instead of Date + a 20 Hz sweeper.
+
+Do not mix these columns with the `cython-core` table above (that
 feature run was `460114d` / `20260828T154518Z`).
 
 ## What landed

--- a/benchmarks/server/baseline-20260828.md
+++ b/benchmarks/server/baseline-20260828.md
@@ -90,6 +90,52 @@ one on baseline (n_used=4). Other rows used all 5 measured samples.
   2MB stream (−1%) sit inside overlapping sample noise — not a bisect.
 - **2MB buffer** did not regress (+6%). Multipart +6%.
 
+## Timeout cleanup: callback vs sweep vs off (2026-08-28)
+
+Same host, same commit (`5b11563`), official suite, sequential, quiet
+machine. One mechanism question: per-connection `TimerHandle` + stall
+`call_later` vs one sweeper that stores deadlines and compares them to a
+single `loop.time()` per wake vs timeouts compiled out.
+
+`STARIO_CYTHON_TIMEOUTS=callback|sweep|off`
+`RUNS=5 WARMUP=1 DURATION=10s THREADS=2 CONNECTIONS=128 UPLOAD_CONNECTIONS=32 ENDPOINT_TIER=all KEEP_RAW=1`
+
+Sweep period for this table was **10ms** (`STARIO_CYTHON_TIMEOUT_SWEEP` default
+at that commit).
+
+| Endpoint | Callback | Sweep 10ms | Off | Sweep/cb | Off/cb |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Plaintext | 128,038 ± 1,283 | 129,067 ± 3,177 | 133,912 ± 2,068 | 1.01× | **1.05×** |
+| JSON | 119,297 ± 7,923 | 121,358 ± 1,293 | 127,210 ± 7,604 | 1.02× | 1.07× |
+| Params | 118,769 ± 2,176 | 118,718 ± 91 | 127,810 ± 6,718 | 1.00× | 1.08× |
+| Validate JSON | 106,347 ± 7,796 | 103,509 ± 195 | 108,815 ± 520 | 0.97× | 1.02× |
+| Form POST | 132,633 ± 2,994 | 123,772 ± 3,105 | 129,545 ± 1,496 | 0.93× | 0.98× |
+| JSON 1KB | 109,822 ± 2,583 | 106,875 ± 617 | 114,530 ± 4,591 | 0.97× | 1.04× |
+| Octet 64KB | 37,830 ± 334 | 37,482 ± 736 | 38,881 ± 504 | 0.99× | 1.03× |
+| Octet 2MB (buffer) | 3,195 ± 15 | 3,038 ± 11 | 3,032 ± 106 | 0.95× | 0.95× |
+| Octet 2MB (stream) | 3,388 ± 98 | 3,143 ± 24 | 3,569 ± 40 | **0.93×** | 1.05× |
+| Multipart 2MB | 3,108 ± 60 | 3,252 ± 37 | 3,298 ± 60 | 1.05× | 1.06× |
+
+Runs: callback `20260828T164108Z`, sweep `20260828T165111Z`, off `20260828T170115Z`.
+
+**Read it**
+
+- Sweep vs callback on plaintext is **inside noise** (+0.8%, overlapping
+  stdev). One connection-set sweeper is not slower than TimerHandles on
+  the keep-alive hot path.
+- **Off** is about **+4–5% plaintext** vs callback. JSON/params move the
+  same way but with huge stdev. 2MB buffer does **not** get faster with
+  timeouts off (callback 3,195 vs off 3,032). This is not a 20% footgun
+  and does not justify deleting timeouts or spending more time on the
+  cleanup path. py-spy still points at `writev` and `App.create_task`.
+- **10ms sweep hurt 2MB stream** (−7% vs callback, −12% vs off). The
+  sweeper was waking 100×/s while handlers waited on body. Default period
+  is now **50ms** (production timeouts are 5s/30s). Callback code is
+  gone; sweep is the only cleanup.
+
+Do not mix these three columns with the `cython-core` table above (that
+feature run was `460114d` / `20260828T154518Z`).
+
 ## What landed
 
 - Skip `NoOpSpan` start/attrs/fail/end in `App.__call__`.

--- a/benchmarks/server/baseline-20260828.md
+++ b/benchmarks/server/baseline-20260828.md
@@ -133,6 +133,20 @@ Runs: callback `20260828T164108Z`, sweep `20260828T165111Z`, off `20260828T17011
   is now **50ms** (production timeouts are 5s/30s). Callback code is
   gone; sweep is the only cleanup.
 
+Focused re-run on `1d5b9e7` with the **50ms** default (`20260828T172052Z`,
+same official knobs, endpoints `plaintext,post-form,post-octet-2m,post-stream-2m`):
+
+| Endpoint | Callback (10ms-era) | Sweep 10ms | Sweep 50ms | Off |
+| --- | ---: | ---: | ---: | ---: |
+| Plaintext | 128,038 ± 1,283 | 129,067 ± 3,177 | 130,755 ± 1,038 | 133,912 ± 2,068 |
+| Form POST | 132,633 ± 2,994 | 123,772 ± 3,105 | 124,567 ± 201 | 129,545 ± 1,496 |
+| Octet 2MB (buffer) | 3,195 ± 15 | 3,038 ± 11 | **3,471 ± 11** | 3,032 ± 106 |
+| Octet 2MB (stream) | 3,388 ± 98 | 3,143 ± 24 | **3,734 ± 33** | 3,569 ± 40 |
+
+50ms sweep puts plaintext back on the 130k band (same as the earlier
+timeouts-on feature run). 2MB stream/buffer are **not** the 10ms-sweep
+regression; they sit at or above the callback and off columns.
+
 Do not mix these three columns with the `cython-core` table above (that
 feature run was `460114d` / `20260828T154518Z`).
 

--- a/benchmarks/server/baseline-20260828.md
+++ b/benchmarks/server/baseline-20260828.md
@@ -1,0 +1,96 @@
+# Server benchmark: Cython hot path vs `cython-core` (2026-08-28)
+
+Same-machine comparison of **unmodified `cython-core`** against the hot-path
+changes on `cursor/cython-hotpath-d521` (PR #33). Relative numbers on one
+host — not lab-grade absolutes.
+
+**Going forward:** treat the “this branch” column below as the Cython
+protocol anchor on this machine. Re-run the same suite after further
+protocol work and compare median ± stdev to these numbers.
+
+The 2026-08-27 Python vs Cython capture remains in
+[`baseline-20260827.md`](baseline-20260827.md) (different host class; do not
+mix rows).
+
+## Reproduce
+
+```bash
+RUNS=5 WARMUP=1 DURATION=10s THREADS=2 \
+  CONNECTIONS=128 UPLOAD_CONNECTIONS=32 \
+  ENDPOINT_TIER=all KEEP_RAW=1 \
+  benchmarks/server/run.sh stario-cython
+```
+
+Unmodified baseline was a git worktree of `cython-core` at `f80d6f0`.
+Feature run used this branch (`174cef7`).
+
+## Environment
+
+| | |
+|---|---|
+| CPU | Intel Xeon (KVM), 4 vCPUs, x86_64 |
+| RAM | 16 GiB, no swap |
+| OS | Linux 6.12.94+ |
+| Python | 3.14.7 |
+| Client | wrk 4.1.0, `-t2 -c128` (read/small upload), `-c32` (64KB/2MB) |
+| Topology | wrk and servers on same host, `127.0.0.1` loopback |
+| Baseline commit | `f80d6f0` (`cython-core`) |
+| Feature commit | `174cef7` (`cursor/cython-hotpath-d521`) |
+| Baseline run | `20260828T110114Z` |
+| Feature run | `20260828T112246Z` |
+
+## Methodology
+
+- One worker/process. Suites ran sequentially (baseline first, then feature)
+  so they did not contend for CPU.
+- 10 endpoints: read (`plaintext`, `json`, `params`) + upload (`validate`,
+  `post-form`, `post-json-1k`, `post-octet-64k`, `post-octet-2m`,
+  `post-stream-2m`, `multipart-2m`).
+- **5 measured + 1 warmup**, `DURATION=10s`, IQR trimming via
+  `benchmarks/server/stats.py`.
+- Handlers **compute responses per request** (no reused/static `Response`
+  objects, no pre-serialized JSON bytes). See `benchmarks/README.md` handler
+  policy.
+
+## This-machine delta (`cython-core` → hot path)
+
+| Endpoint | Unmodified `cython-core` | This branch | Ratio |
+| --- | ---: | ---: | ---: |
+| Plaintext | 129,230 ± 2,877 | 132,083 ± 4,307 | 1.02× |
+| JSON | 123,825 ± 3,502 | 131,544 ± 825 | **1.06×** |
+| Params | 111,894 ± 1,687 | 126,443 ± 252 | **1.13×** |
+| Validate JSON | 66,359 ± 234 | 108,084 ± 1,902 | **1.63×** |
+| Form POST | 77,785 ± 1,875 | 131,462 ± 1,629 | **1.69×** |
+| JSON 1KB | 67,892 ± 1,636 | 112,493 ± 3,605 | **1.66×** |
+| Octet 64KB | 24,091 ± 164 | 37,735 ± 131 | **1.57×** |
+| Octet 2MB (buffer) | 3,117 ± 78 | 3,190 ± 31 | 1.02× |
+| Octet 2MB (stream) | 3,480 ± 3 | 3,485 ± 12 | 1.00× |
+| Multipart 2MB | 3,179 ± 151 | 3,350 ± 37 | 1.05× |
+
+JSON / params / multipart report one IQR outlier removed on the feature run
+(n_used=4). 2MB buffer likewise. Other rows used all 5 measured samples.
+
+## How to read it
+
+- **Small POST** (validate / form / JSON 1KB) is the real move: ~1.6–1.7×.
+  Content-Length bodies ≤ 64KiB now dispatch at `message_complete` after
+  `c_complete()`, so `body()` hits cached bytes instead of waiting on an
+  `asyncio.Event` nested in `llhttp_execute`.
+- **Octet 64KB** moved with that cohort because the fixture is exactly
+  `64 * 1024` bytes (`payload-64k.bin`), which is still in the deferral
+  bucket (`content_length <= 64KiB`). 2MB uploads stay header-dispatch.
+- **Read path** is flat-to-up. Plaintext (+2%) sits inside sample noise
+  (baseline stdev ~2.9k). JSON (+6%) and params (+13%) are clearer; those
+  also pick up the NoOpSpan skip, URL arena cache, and dropping the `_run`
+  wrapper.
+- **2MB buffer / stream** did not regress (the failure mode to watch).
+  Multipart is a modest +5%.
+
+## What landed in the feature commit
+
+- Skip `NoOpSpan` start/attrs/fail/end in `App.__call__`.
+- Defer small Content-Length bodies until message-complete.
+- Arena URL cache (no per-request URL `bytes` cache key).
+- Eager-start `App.__call__` without a `_run` wrapper; `deque` pipeline.
+- `-fno-strict-aliasing`; wraparound-safe `ParsedQuery.as_dict`.
+- `run.sh` creates the target venv before fixtures.

--- a/benchmarks/server/baseline-20260828.md
+++ b/benchmarks/server/baseline-20260828.md
@@ -203,6 +203,60 @@ pairing. Stario’s stream samples here are a tight 2.6–2.8k band, below
 this branch’s focused captures today (~3.5k). Treat that row as noisy
 until a dedicated stream re-run; do not invert the rest of the table on it.
 
+## Stario Cython vs Granian RSGI / Socketify / Robyn / Django-Bolt (2026-08-28)
+
+Same host, sequential, official knobs, this branch at `28d6cc7`
+(`20260828T183308Z`). One worker each. Granian is **RSGI, no framework**.
+Robyn/Django-Bolt buffer the stream route (no request streaming API).
+
+```bash
+RUNS=5 WARMUP=1 DURATION=10s THREADS=2 \
+  CONNECTIONS=128 UPLOAD_CONNECTIONS=32 \
+  ENDPOINT_TIER=all KEEP_RAW=1 \
+  benchmarks/server/run.sh stario-cython granian-rsgi socketify robyn django-bolt
+```
+
+Read-heavy (req/s):
+
+| Server | Plaintext | JSON | Params |
+| --- | ---: | ---: | ---: |
+| Granian RSGI (no framework) | 146,875 ± 713 | 144,111 ± 269 | 146,201 ± 3,838 |
+| Stario Cython | 139,876 ± 8,738 | 124,344 ± 1,959 | 124,129 ± 2,426 |
+| Socketify | 122,497 ± 62 | 103,563 ± 332 | 79,977 ± 812 |
+| Django-Bolt | 30,071 ± 147 | 31,946 ± 168 | 30,310 ± 255 |
+| Robyn | 25,780 ± 74 | 25,206 ± 64 | 19,351 ± 49 |
+
+Upload / body (req/s):
+
+| Server | Validate | Form | JSON 1KB | 64KB | 2MB buf | 2MB stream | Multipart |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Stario Cython | 107,659 ± 1,824 | 126,114 ± 421 | 110,834 ± 1,020 | 38,256 ± 593 | 3,246 ± 134 | 3,649 ± 22 | 3,445 ± 55 |
+| Granian RSGI | 106,610 ± 1,068 | 118,928 ± 1,581 | 114,517 ± 1,516 | 31,212 ± 198 | 1,429 ± 12 | 3,108 ± 20 | 3,138 ± 77 |
+| Django-Bolt | 25,585 ± 184 | 26,272 ± 157 | 26,252 ± 953 | 20,037 ± 1,936 | 1,499 ± 11 | 1,478 ± 14 | 1,488 ± 20 |
+| Socketify | 13,267 ± 66 | 19,556 ± 195 | 13,293 ± 179 | 12,365 ± 220 | 674 ± 20 | **4,062 ± 74** | 663 ± 6 |
+| Robyn | 18,382 ± 60 | 4,721 ± 5 | 18,270 ± 52 | 15,629 ± 32 | 735 ± 48 | 751 ± 13 | 498 ± 37 |
+
+Vs Stario (competitor / Stario; >1 means they are faster):
+
+| Endpoint | Granian RSGI | Socketify | Robyn | Django-Bolt |
+| --- | ---: | ---: | ---: | ---: |
+| Plaintext | 1.05× | 0.88× | 0.18× | 0.21× |
+| JSON | 1.16× | 0.83× | 0.20× | 0.26× |
+| Params | 1.18× | 0.64× | 0.16× | 0.24× |
+| Validate | 0.99× | 0.12× | 0.17× | 0.24× |
+| Form | 0.94× | 0.16× | 0.04× | 0.21× |
+| JSON 1KB | 1.03× | 0.12× | 0.16× | 0.24× |
+| 64KB | 0.82× | 0.32× | 0.41× | 0.52× |
+| 2MB buf | 0.44× | 0.21× | 0.23× | 0.46× |
+| 2MB stream | 0.85× | 1.11× | 0.21× | 0.41× |
+| Multipart | 0.91× | 0.19× | 0.14× | 0.43× |
+
+Granian RSGI wins GET JSON/params; plaintext is close (Stario’s ±8.7k band
+overlaps). Small POST is even. Stario pulls away on 64KB and buffered 2MB
+(Content-Length deferral + pause). Socketify wins **2MB stream** (4.1k);
+Stario stream is 3.6k in this suite (the 2.7k BlackSheep pairing was the
+dip). Robyn and Django-Bolt are ~4–5× behind on plaintext at one worker.
+
 ## What landed
 
 - Skip `NoOpSpan` start/attrs/fail/end in `App.__call__`.

--- a/benchmarks/server/baseline-20260828.md
+++ b/benchmarks/server/baseline-20260828.md
@@ -266,12 +266,11 @@ on plaintext.
 
 ## Stario Cython vs Stario Python (2026-08-28)
 
-Same host, official knobs. Python is **httptools** (`stario.cli serve`,
-port 3000, `stario.http.protocol`). Cython is **llhttp**
-(`python -m stario_cython`, port 3001). Python run `20260828T193136Z`
-(`d80e264`). Cython column is the native-suite capture `20260828T183308Z`
-(`28d6cc7`) — same machine and knobs, not the still-running paired Cython
-half of `193136Z`. Do not mix with [`baseline-20260827.md`](baseline-20260827.md).
+Same host, same suite, official knobs (`20260828T193136Z`, `d80e264`).
+Python is **httptools** (`stario.cli serve`, port 3000,
+`stario.http.protocol`). Cython is **llhttp** (`python -m stario_cython`,
+port 3001). Sequential: Python first, then Cython. Do not mix with
+[`baseline-20260827.md`](baseline-20260827.md).
 
 ```bash
 RUNS=5 WARMUP=1 DURATION=10s THREADS=2 \
@@ -282,32 +281,31 @@ RUNS=5 WARMUP=1 DURATION=10s THREADS=2 \
 
 | Endpoint | Python httptools | Cython llhttp | Cython / Python |
 | --- | ---: | ---: | ---: |
-| Plaintext | 74,752 ± 274 | 139,876 ± 8,738 | **1.87×** |
-| JSON | 72,983 ± 1,742 | 124,344 ± 1,959 | **1.70×** |
-| Params | 70,804 ± 95 | 124,129 ± 2,426 | **1.75×** |
-| Validate JSON | 56,566 ± 619 | 107,659 ± 1,824 | **1.90×** |
-| Form POST | 60,305 ± 106 | 126,114 ± 421 | **2.09×** |
-| JSON 1KB | 55,945 ± 431 | 110,834 ± 1,020 | **1.98×** |
-| Octet 64KB | 20,065 ± 202 | 38,256 ± 593 | **1.91×** |
-| Octet 2MB (buffer) | 1,981 ± 33 | 3,246 ± 134 | **1.64×** |
-| Octet 2MB (stream) | 2,969 ± 7 | 3,649 ± 22 | **1.23×** |
-| Multipart 2MB | 2,007 ± 80 | 3,445 ± 55 | **1.72×** |
+| Plaintext | 74,752 ± 274 | 132,903 ± 3,484 | **1.78×** |
+| JSON | 72,983 ± 1,742 | 133,817 ± 7,033 | **1.83×** |
+| Params | 70,804 ± 95 | 126,707 ± 5,128 | **1.79×** |
+| Validate JSON | 56,566 ± 619 | 112,068 ± 4,145 | **1.98×** |
+| Form POST | 60,305 ± 106 | 123,813 ± 1,677 | **2.05×** |
+| JSON 1KB | 55,945 ± 431 | 110,946 ± 4,462 | **1.98×** |
+| Octet 64KB | 20,065 ± 202 | 37,772 ± 487 | **1.88×** |
+| Octet 2MB (buffer) | 1,981 ± 33 | 3,441 ± 20 | **1.74×** |
+| Octet 2MB (stream) | 2,969 ± 7 | 3,652 ± 16 | **1.23×** |
+| Multipart 2MB | 2,007 ± 80 | 3,563 ± 99 | **1.77×** |
 
-Params (Python) two IQR outliers removed (n_used=3). Form (Cython) two.
-2MB stream one on each side. Other rows used all 5 measured samples.
+Params (Python) two IQR outliers removed (n_used=3). 2MB stream one on
+each side. Other rows used all 5 measured samples.
 
 **Read it**
 
-- **GET** is ~**1.7–1.9×**. Python plaintext is a tight 74.5–75.1k band.
-  Cython plaintext in the native suite is the noisy 129–149k capture
-  (±8.7k). Other same-day Cython plaintext sits 130–135k, which is still
-  ~**1.75×** this Python row. The 27 Aug snapshot was 72.7k vs 125.2k
-  (**1.72×**) on an earlier commit.
-- **Small POST** (validate / form / JSON 1KB) is ~**1.9–2.1×**. On 27 Aug
-  this cohort was only ~1.2×; Cython’s Content-Length ≤64KiB deferral is
-  the gap. **64KB** moved with it (fixture is exactly 64KiB) — was even
-  on 27 Aug (0.96×), **1.91×** now.
-- **2MB stream** is the closest (1.23×). Buffered 2MB / multipart ~1.6–1.7×.
+- **GET** is ~**1.8×**. Python plaintext is a tight 74.5–75.1k band.
+  Cython plaintext here is 128–137k (median 132.9k) — in the same-day
+  130–135k band, not the noisy native-suite 139k ± 8.7k. The 27 Aug
+  snapshot was 72.7k vs 125.2k (**1.72×**) on an earlier commit.
+- **Small POST** (validate / form / JSON 1KB) is ~**2.0×**. On 27 Aug this
+  cohort was only ~1.2×; Cython’s Content-Length ≤64KiB deferral is the
+  gap. **64KB** moved with it (fixture is exactly 64KiB) — was even on
+  27 Aug (0.96×), **1.88×** now.
+- **2MB stream** is the closest (1.23×). Buffered 2MB / multipart ~1.7–1.8×.
 
 ## What landed
 

--- a/benchmarks/server/run.sh
+++ b/benchmarks/server/run.sh
@@ -342,7 +342,9 @@ command_for() {
           "$(python_for stario-cython)" -m stario_cython apps.stario_app:bootstrap
         )
       else
+        # This branch's Headers live in stario_cython; load inplace .so via src.
         SERVER_CMD=(
+          env PYTHONPATH="$ROOT/src:$BENCHMARK_DIR"
           "$(python_for stario)" -m stario.cli serve apps.stario_app:bootstrap
         )
       fi

--- a/benchmarks/server/run.sh
+++ b/benchmarks/server/run.sh
@@ -660,11 +660,10 @@ main() {
   for target in "${selected[@]}"; do known_target "$target" || { echo "Unknown target: $target" >&2; usage >&2; exit 1; }; done
   for endpoint in "${ENDPOINTS[@]}"; do path_for "$endpoint" >/dev/null || exit 1; done
 
-  ensure_fixtures "$(python_for "${selected[0]}")"
   if [[ ! -x "$(python_for "${selected[0]}")" ]]; then
     ensure_target "${selected[0]}"
-    ensure_fixtures "$(python_for "${selected[0]}")"
   fi
+  ensure_fixtures "$(python_for "${selected[0]}")"
 
   RUN_DIR="$RESULTS_DIR/$(date -u +%Y%m%dT%H%M%SZ)"
   mkdir -p "$RUN_DIR"

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extensions = [
     Extension(
         "stario_cython.headers",
         sources=["src/stario_cython/headers.pyx"],
-        extra_compile_args=["-O3"],
+        extra_compile_args=["-O3", "-fno-strict-aliasing"],
     ),
     Extension(
         "stario_cython.exchange",
@@ -58,7 +58,7 @@ extensions = [
         include_dirs=["vendor", "src", *codec_include_dirs],
         library_dirs=codec_library_dirs,
         libraries=codec_libraries,
-        extra_compile_args=["-O3", *codec_compile_args],
+        extra_compile_args=["-O3", "-fno-strict-aliasing", *codec_compile_args],
         extra_link_args=codec_link_args,
     ),
     Extension(
@@ -71,7 +71,7 @@ extensions = [
             "vendor/llhttp/src/stario_alloc.c",
         ],
         include_dirs=["vendor/llhttp/include", "vendor", "src"],
-        extra_compile_args=["-O3"],
+        extra_compile_args=["-O3", "-fno-strict-aliasing"],
     ),
 ]
 

--- a/src/stario/http/app.py
+++ b/src/stario/http/app.py
@@ -20,6 +20,7 @@ from stario.exceptions import (
 )
 from stario.http.context import Context
 from stario.routing.locations import normalize_path
+from stario.telemetry.spans import NoOpSpan
 
 from .dispatch import Router
 from .writer import Writer
@@ -189,8 +190,12 @@ class App(Router):
         send a response on the success path.
         """
         span = c.span
-        span.start()
-        span.attrs({"request.method": c.req.method, "request.path": c.req.path})
+        # Cython (and benchmark) servers use NoOpTracer. Skip method calls and
+        # the attrs dict on that path; RecordingSpan and others still record.
+        record = type(span) is not NoOpSpan
+        if record:
+            span.start()
+            span.attrs({"request.method": c.req.method, "request.path": c.req.path})
         failed_after_start = False
 
         try:
@@ -236,14 +241,15 @@ class App(Router):
                         exc = handler_exc
                 if not handler_responded:
                     responses.text(w, "Internal Server Error", 500)
-            if not handler_responded:
+            if not handler_responded and record:
                 span.fail(str(exc))
                 span.exception(exc)
         finally:
             # After headers: abort the transport on failure; otherwise finish the message.
             if failed_after_start and not w.completed:
                 w.abort()
-            else:
+            elif not w.completed:
                 w.end()
-            span.attr("response.status_code", w.status_code)
-            span.end()
+            if record:
+                span.attr("response.status_code", w.status_code)
+                span.end()

--- a/src/stario/http/server.py
+++ b/src/stario/http/server.py
@@ -56,6 +56,10 @@ type LoopRun[T] = Callable[[Coroutine[Any, Any, T]], T]
 # Upper bound on the force-close loop after the graceful wait (see _drain_listener).
 _FORCE_CLOSE_CAP = 1.0
 
+# Keep in sync with ``stario_cython.protocol``: Cython skips its own sweeper
+# task when the Date tick already walks connections once a second.
+_DATE_TICK_SWEEPS_TIMEOUTS = "_stario_date_tick_sweeps_timeouts"
+
 # Yield to the event loop this many times while waiting for connection_made to register.
 _ACCEPT_REGISTER_YIELDS = 10
 
@@ -122,6 +126,7 @@ class Server:
         self._used = False
         self._date_box = [b""]
         self._urgent_drain = False
+        self._live_connections: set[Connection] | None = None
 
     def run(self) -> None:
         """Block until shutdown; picks the event loop from `config.event_loop`.
@@ -450,6 +455,7 @@ class Server:
     ) -> AsyncGenerator[asyncio.Server]:
         """Bind on enter; drain in-flight work on exit."""
         connections: set[Connection] = set()
+        self._live_connections = connections
         listener = await self._create_listener(listen_sock, app, connections)
 
         # Startup span ends once we are listening; shutdown span opens on exit.
@@ -464,10 +470,30 @@ class Server:
             self._open_shutdown_span(span, "expected_stop")  # signal or app.shutdown
         finally:
             await self._drain_listener(listener, app, connections, span)
+            self._live_connections = None
+
+    def _sweep_connection_timeouts(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Compare stored deadlines to one ``loop.time()`` (Date-tick cadence)."""
+        connections = self._live_connections
+        if not connections:
+            return
+        now = loop.time()
+        for proto in tuple(connections):
+            check = getattr(proto, "check_timeouts", None)
+            if check is None:
+                continue
+            try:
+                check(now)
+            except Exception:
+                continue
 
     @asynccontextmanager
     async def _date_tick(self) -> AsyncGenerator[None]:
-        """Refresh the shared Date header now, then once per second until exit."""
+        """Refresh Date, then once per second also sweep connection timeouts.
+
+        Header/idle/body-stall defaults are 5s/5s/30s. One-second granularity
+        matches Date and avoids a second timer on the event loop.
+        """
 
         def refresh() -> None:
             now = datetime.now(UTC)
@@ -476,16 +502,21 @@ class Server:
                 now, usegmt=True
             ).encode("ascii")
 
+        loop = asyncio.get_running_loop()
+        setattr(loop, _DATE_TICK_SWEEPS_TIMEOUTS, True)
+
         async def tick() -> None:
             while True:
                 await asyncio.sleep(1)
                 refresh()
+                self._sweep_connection_timeouts(loop)
 
         refresh()  # first value before any connection can read it
         task = asyncio.create_task(tick())
         try:
             yield
         finally:
+            setattr(loop, _DATE_TICK_SWEEPS_TIMEOUTS, False)
             task.cancel()
             with suppress(asyncio.CancelledError):
                 await task

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -95,7 +95,6 @@ cdef class RequestExchange:
     cdef object _chunks
     cdef object _cached
     cdef object _data_ready
-    cdef object _stall_handle
     cdef double _stall_deadline
     cdef uint64_t _stall_touch
     cdef uint64_t _stall_seen

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -1,5 +1,5 @@
 from libc.stddef cimport size_t
-from libc.stdint cimport uint32_t
+from libc.stdint cimport uint32_t, uint64_t
 
 from stario_cython.compression_buf cimport StarioBrotli, StarioGzip
 from stario_cython.headers cimport Headers
@@ -96,6 +96,9 @@ cdef class RequestExchange:
     cdef object _cached
     cdef object _data_ready
     cdef object _stall_handle
+    cdef double _stall_deadline
+    cdef uint64_t _stall_touch
+    cdef uint64_t _stall_seen
     cdef int _buffered
     cdef int _total_read
     cdef int _max_size
@@ -180,6 +183,7 @@ cdef class RequestExchange:
     cdef void _wake(self)
     cdef void _cancel_stall_timer(self) noexcept
     cdef void _reset_stall_timer(self) noexcept
+    cdef void fire_body_stall(self)
     cdef void _maybe_continue(self)
     cdef void _done(self)
     cdef void _maybe_pause(self)

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -122,6 +122,7 @@ cdef class RequestExchange:
         list date_box,
         object compression,
         int max_body_size,
+        double body_timeout,
     ) noexcept
     cdef void start_response(self)
     cdef void handler_finished(self)
@@ -206,4 +207,5 @@ cdef RequestExchange acquire_exchange(
     list date_box,
     object compression,
     int max_body_size,
+    double body_timeout,
 )

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -94,10 +94,9 @@ cdef int ABORT_NONE = 0
 cdef int ABORT_TOO_LARGE = 1
 cdef int ABORT_DISCONNECTED = 2
 cdef int ABORT_TIMEOUT = 3
-cdef int _TIMEOUT_MODE = 2
+cdef int _TIMEOUT_MODE = 1
 cdef int _TIMEOUT_OFF = 0
-cdef int _TIMEOUT_CALLBACK = 1
-cdef int _TIMEOUT_SWEEP = 2
+cdef int _TIMEOUT_SWEEP = 1
 
 
 def _bind_timeout_mode():
@@ -870,7 +869,6 @@ cdef class RequestExchange:
         self._chunks = None
         self._cached = None
         self._data_ready = None
-        self._stall_handle = None
         self._stall_deadline = 0.0
         self._stall_touch = 0
         self._stall_seen = 0
@@ -2060,10 +2058,6 @@ cdef class RequestExchange:
             self._data_ready.set()
 
     cdef void _cancel_stall_timer(self) noexcept:
-        cdef object handle = self._stall_handle
-        if handle is not None:
-            handle.cancel()
-            self._stall_handle = None
         self._stall_deadline = 0.0
         self._stall_seen = self._stall_touch
 
@@ -2074,31 +2068,15 @@ cdef class RequestExchange:
         stores ``now + timeout`` once per wake — body chunks do not call
         ``loop.time()`` or ``call_later``.
         """
-        cdef object loop
-        cdef object connection
-        cdef object handle
         if not self._waiting or self._body_complete or self._timeout <= 0:
             self._cancel_stall_timer()
             return
         if _TIMEOUT_MODE == _TIMEOUT_OFF:
             self._cancel_stall_timer()
             return
-        if _TIMEOUT_MODE == _TIMEOUT_SWEEP:
-            handle = self._stall_handle
-            if handle is not None:
-                handle.cancel()
-                self._stall_handle = None
-            self._stall_touch += 1
-            return
-        self._cancel_stall_timer()
-        connection = self._connection
-        if connection is None:
-            return
-        loop = connection.loop
-        self._stall_handle = loop.call_later(self._timeout, self._on_stall_timeout)
+        self._stall_touch += 1
 
     cdef void fire_body_stall(self):
-        self._stall_handle = None
         self._stall_deadline = 0.0
         self._stall_seen = self._stall_touch
         if self._abort_reason != ABORT_NONE or self._body_complete:
@@ -2108,9 +2086,6 @@ cdef class RequestExchange:
         if self._connection is not None:
             self._connection.set_body_paused(self, False)
         self._wake()
-
-    def _on_stall_timeout(self):
-        self.fire_body_stall()
 
     cdef void _maybe_continue(self):
         if self._expect_continue:

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -65,6 +65,7 @@ from stario_cython.headers cimport (
     _intern_name,
     _lower_copy,
 )
+from stario_cython.timeouts import TIMEOUT_MODE as _PY_TIMEOUT_MODE
 
 cdef int LOW_WATER = 128 * 1024
 cdef int HIGH_WATER = 512 * 1024
@@ -93,6 +94,18 @@ cdef int ABORT_NONE = 0
 cdef int ABORT_TOO_LARGE = 1
 cdef int ABORT_DISCONNECTED = 2
 cdef int ABORT_TIMEOUT = 3
+cdef int _TIMEOUT_MODE = 2
+cdef int _TIMEOUT_OFF = 0
+cdef int _TIMEOUT_CALLBACK = 1
+cdef int _TIMEOUT_SWEEP = 2
+
+
+def _bind_timeout_mode():
+    global _TIMEOUT_MODE
+    _TIMEOUT_MODE = <int>_PY_TIMEOUT_MODE
+
+
+_bind_timeout_mode()
 
 cdef bytes STATUS_200 = b"HTTP/1.1 200 OK\r\n"
 cdef bytes STATUS_204 = b"HTTP/1.1 204 No Content\r\n"
@@ -858,6 +871,9 @@ cdef class RequestExchange:
         self._cached = None
         self._data_ready = None
         self._stall_handle = None
+        self._stall_deadline = 0.0
+        self._stall_touch = 0
+        self._stall_seen = 0
         self._compression = _UNBOUND
         self._brotli_enabled = False
         self._gzip_enabled = False
@@ -2048,28 +2064,53 @@ cdef class RequestExchange:
         if handle is not None:
             handle.cancel()
             self._stall_handle = None
+        self._stall_deadline = 0.0
+        self._stall_seen = self._stall_touch
 
     cdef void _reset_stall_timer(self) noexcept:
-        """Arm/refresh slowloris stall timeout while a body consumer is waiting."""
+        """Arm/refresh slowloris stall timeout while a body consumer is waiting.
+
+        Sweep mode only bumps a generation counter. The connection sweeper
+        stores ``now + timeout`` once per wake — body chunks do not call
+        ``loop.time()`` or ``call_later``.
+        """
         cdef object loop
         cdef object connection
-        self._cancel_stall_timer()
+        cdef object handle
         if not self._waiting or self._body_complete or self._timeout <= 0:
+            self._cancel_stall_timer()
             return
+        if _TIMEOUT_MODE == _TIMEOUT_OFF:
+            self._cancel_stall_timer()
+            return
+        if _TIMEOUT_MODE == _TIMEOUT_SWEEP:
+            handle = self._stall_handle
+            if handle is not None:
+                handle.cancel()
+                self._stall_handle = None
+            self._stall_touch += 1
+            return
+        self._cancel_stall_timer()
         connection = self._connection
         if connection is None:
             return
         loop = connection.loop
         self._stall_handle = loop.call_later(self._timeout, self._on_stall_timeout)
 
-    def _on_stall_timeout(self):
+    cdef void fire_body_stall(self):
         self._stall_handle = None
+        self._stall_deadline = 0.0
+        self._stall_seen = self._stall_touch
         if self._abort_reason != ABORT_NONE or self._body_complete:
             return
         self._abort_reason = ABORT_TIMEOUT
         self._clear_body_storage()
-        self._connection.set_body_paused(self, False)
+        if self._connection is not None:
+            self._connection.set_body_paused(self, False)
         self._wake()
+
+    def _on_stall_timeout(self):
+        self.fire_body_stall()
 
     cdef void _maybe_continue(self):
         if self._expect_continue:

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -516,8 +516,15 @@ cdef class ParsedQuery:
         return [(k, v) for k, vals in self._data.items() for v in vals]
 
     def as_dict(self, *, last=False):
-        cdef int i = -1 if last else 0
-        return {k: vals[i] for k, vals in self._data.items()}
+        cdef dict out = {}
+        cdef list vals
+        cdef Py_ssize_t idx
+        for k, vals in self._data.items():
+            if not vals:
+                continue
+            idx = len(vals) - 1 if last else 0
+            out[k] = vals[idx]
+        return out
 
     def as_lists(self):
         return {k: list(v) for k, v in self._data.items()}
@@ -1449,6 +1456,10 @@ cdef class RequestExchange:
     cdef void start_response(self):
         self.handler_started = True
         self.reset_response(self._req_encoding)
+
+    def on_handler_done(self, task):
+        """``Task.add_done_callback`` entry; recycles after ``App.__call__``."""
+        self.handler_finished()
 
     cdef void handler_finished(self):
         self.handler_done = True

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -43,7 +43,7 @@ from stario.http.compression import (
     content_type_is_compressible,
 )
 from stario.http.context import EMPTY_ROUTE_MATCH, _Alive
-from stario.http.request import DEFAULT_BODY_TIMEOUT, host_without_port
+from stario.http.request import host_without_port
 from stario.http.writer import get_status_line
 
 from stario_cython.compression_buf cimport (
@@ -1391,6 +1391,7 @@ cdef class RequestExchange:
         list date_box,
         object compression,
         int max_body_size,
+        double body_timeout,
     ) noexcept:
         self.in_pool = False
         if self._connection is not connection:
@@ -1398,11 +1399,11 @@ cdef class RequestExchange:
             self.app = app
             self._transport = transport
             self._date_box = date_box
-            self._max_size = max_body_size
-            self._timeout = DEFAULT_BODY_TIMEOUT
             if self._compression is not compression:
                 self._compression = compression
                 self._apply_compression(compression)
+        self._max_size = max_body_size
+        self._timeout = body_timeout
         self.span = None
         self.route = EMPTY_ROUTE_MATCH
         self._state = None
@@ -2572,6 +2573,7 @@ cdef RequestExchange acquire_exchange(
     list date_box,
     object compression,
     int max_body_size,
+    double body_timeout,
 ):
     cdef RequestExchange exchange
     if _POOL:
@@ -2585,5 +2587,6 @@ cdef RequestExchange acquire_exchange(
         date_box,
         compression,
         max_body_size,
+        body_timeout,
     )
     return exchange

--- a/src/stario_cython/headers.pyx
+++ b/src/stario_cython/headers.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 """One Headers type: a retained pair list plus the intern table.
 
 Application ``get``/``set`` still see clean names and values. Internally each

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 """asyncio Protocol + llhttp: one TCP connection, pipelining, and dispatch.
 
 ``HttpProtocol`` owns parser callbacks, pause/resume, and request dispatch.
@@ -6,8 +6,13 @@ URL bytes and header fragments are written into the current exchange arena.
 Path/query decoding is cached here because it is connection-parse work.
 """
 
-from libc.stdint cimport uint16_t, uint64_t
+from collections import deque
+
+from libc.stdint cimport uint16_t, uint32_t, uint64_t
+from libc.stdlib cimport free, malloc
+from libc.string cimport memcmp, memcpy
 from cpython.bytes cimport PyBytes_FromStringAndSize
+from cpython.unicode cimport PyUnicode_DecodeASCII
 
 from stario.http.wire import decode_path
 from stario.telemetry.noop import NoOpTracer
@@ -15,30 +20,150 @@ from stario.telemetry.noop import NoOpTracer
 from stario_cython.exchange cimport Request, RequestExchange, acquire_exchange, _status_line
 from stario_cython.llhttp cimport *
 
-cdef dict _URL_CACHE = {}
-cdef int _URL_CACHE_MAX = 256
+cdef enum:
+    URL_CACHE_CAP = 256
+    URL_CACHE_MAX_KEY = 512
+    SMALL_BODY_COMPLETE_DISPATCH = 64 * 1024
+
+cdef char* _UC_KEY[256]
+cdef Py_ssize_t _UC_LEN[256]
+cdef uint32_t _UC_HASH[256]
+cdef list _UC_PATH = None
+cdef list _UC_QUERY = None
+cdef object Q_EMPTY = b""
+cdef object PATH_EMPTY = ""
 
 
-cdef tuple _split_request_target(object url):
-    cdef object cached
-    cdef Py_ssize_t question
-    cdef object path_bytes
+cdef uint32_t _url_hash(const char* s, Py_ssize_t n) noexcept:
+    cdef uint32_t value = <uint32_t>2166136261
+    cdef Py_ssize_t i
+    for i in range(n):
+        value = (value ^ <unsigned char>s[i]) * <uint32_t>16777619
+    return value
+
+
+cdef void _url_cache_init():
+    global _UC_PATH, _UC_QUERY
+    cdef int i
+    if _UC_PATH is not None:
+        return
+    _UC_PATH = [None] * URL_CACHE_CAP
+    _UC_QUERY = [None] * URL_CACHE_CAP
+    for i in range(URL_CACHE_CAP):
+        _UC_KEY[i] = NULL
+        _UC_LEN[i] = 0
+        _UC_HASH[i] = 0
+
+
+cdef void _url_cache_clear():
+    cdef int i
+    for i in range(URL_CACHE_CAP):
+        if _UC_KEY[i] != NULL:
+            free(_UC_KEY[i])
+            _UC_KEY[i] = NULL
+        _UC_LEN[i] = 0
+        _UC_HASH[i] = 0
+        _UC_PATH[i] = None
+        _UC_QUERY[i] = None
+
+
+cdef int _url_find(const char* url, Py_ssize_t n, uint32_t h) noexcept:
+    cdef int slot = <int>(h & (URL_CACHE_CAP - 1))
+    cdef int i
+    for i in range(URL_CACHE_CAP):
+        if _UC_KEY[slot] == NULL:
+            return -1
+        if (
+            _UC_HASH[slot] == h
+            and _UC_LEN[slot] == n
+            and memcmp(_UC_KEY[slot], url, <size_t>n) == 0
+        ):
+            return slot
+        slot = (slot + 1) & (URL_CACHE_CAP - 1)
+    return -1
+
+
+cdef void _url_store(
+    const char* url,
+    Py_ssize_t n,
+    uint32_t h,
+    object path,
+    object query,
+):
+    cdef int slot
+    cdef int i
+    cdef char* copy
+    slot = <int>(h & (URL_CACHE_CAP - 1))
+    for i in range(URL_CACHE_CAP):
+        if _UC_KEY[slot] == NULL:
+            copy = <char*>malloc(<size_t>n if n > 0 else 1)
+            if copy == NULL:
+                return
+            if n:
+                memcpy(copy, url, <size_t>n)
+            _UC_KEY[slot] = copy
+            _UC_LEN[slot] = n
+            _UC_HASH[slot] = h
+            _UC_PATH[slot] = path
+            _UC_QUERY[slot] = query
+            return
+        slot = (slot + 1) & (URL_CACHE_CAP - 1)
+    _url_cache_clear()
+    slot = <int>(h & (URL_CACHE_CAP - 1))
+    copy = <char*>malloc(<size_t>n if n > 0 else 1)
+    if copy == NULL:
+        return
+    if n:
+        memcpy(copy, url, <size_t>n)
+    _UC_KEY[slot] = copy
+    _UC_LEN[slot] = n
+    _UC_HASH[slot] = h
+    _UC_PATH[slot] = path
+    _UC_QUERY[slot] = query
+
+
+cdef object _decode_path_n(const char* s, Py_ssize_t n):
+    cdef Py_ssize_t i
+    cdef unsigned char c
+    if n <= 0:
+        return PATH_EMPTY
+    for i in range(n):
+        c = <unsigned char>s[i]
+        if c == 37 or c >= 128:
+            return decode_path(PyBytes_FromStringAndSize(s, n))
+    return PyUnicode_DecodeASCII(s, n, NULL)
+
+
+cdef tuple _split_request_target_n(const char* url, Py_ssize_t n):
+    cdef Py_ssize_t question = -1
+    cdef Py_ssize_t i
+    cdef uint32_t h = 0
+    cdef int slot
+    cdef object path
     cdef object query
-    cdef tuple result
-    cached = _URL_CACHE.get(url)
-    if cached is not None:
-        return <tuple>cached
-    question = url.find(b"?")
-    if question == -1:
-        path_bytes, query = url, b""
+    if n <= 0:
+        return (PATH_EMPTY, Q_EMPTY)
+    if n <= URL_CACHE_MAX_KEY:
+        h = _url_hash(url, n)
+        slot = _url_find(url, n, h)
+        if slot >= 0:
+            return (_UC_PATH[slot], _UC_QUERY[slot])
+    for i in range(n):
+        if url[i] == 63:
+            question = i
+            break
+    if question < 0:
+        path = _decode_path_n(url, n)
+        query = Q_EMPTY
     else:
-        path_bytes, query = url[:question], url[question + 1 :]
-    result = (decode_path(path_bytes), query)
-    if len(_URL_CACHE) >= _URL_CACHE_MAX:
-        _URL_CACHE.clear()
-    if <Py_ssize_t>len(url) <= 512:
-        _URL_CACHE[url] = result
-    return result
+        path = _decode_path_n(url, question)
+        if question + 1 < n:
+            query = PyBytes_FromStringAndSize(url + question + 1, n - question - 1)
+        else:
+            query = Q_EMPTY
+    if n <= URL_CACHE_MAX_KEY:
+        _url_store(url, n, h, path, query)
+    return (path, query)
 
 cdef int F_CONTENT_LENGTH = 0x20
 cdef int PAUSE_WRITE = 1
@@ -46,8 +171,8 @@ cdef int PAUSE_PIPELINE = 2
 cdef int PAUSE_BODY = 4
 cdef int PARSER_QUANTUM = 512 * 1024
 cdef int MAX_PENDING_EXCHANGES = 64
-# Handlers always start at headers-complete. Body bytes accumulate on the exchange;
-# body() awaits one completion Event, stream() drains with backpressure.
+# GET and large/chunked bodies dispatch at headers-complete. Small
+# Content-Length bodies dispatch at message-complete so body() is cached.
 
 cdef object METH_DELETE = "DELETE"
 cdef object METH_GET = "GET"
@@ -95,10 +220,11 @@ cdef object _version_str(int major, int minor):
 
 
 
-cdef void _bind_settings() noexcept:
+cdef void _bind_settings():
     global _SETTINGS
     if _SETTINGS != NULL:
         return
+    _url_cache_init()
     _SETTINGS = stario_settings_new()
     _SETTINGS.on_message_begin = _cb_message_begin
     _SETTINGS.on_url = _cb_url
@@ -185,6 +311,7 @@ cdef class HttpProtocol:
     cdef object held_data
     cdef Py_ssize_t held_offset
     cdef bint pump_scheduled
+    cdef object _create_task
 
     def __cinit__(self):
         _bind_settings()
@@ -229,8 +356,9 @@ cdef class HttpProtocol:
         self.date_box = date_box
         self.compression = compression
         self.connections = connections
+        self._create_task = app.create_task
         self.transport = None
-        self.pending_exchanges = []
+        self.pending_exchanges = deque()
         self.head_bytes = 0
         self.max_header_bytes = max_header_bytes
         self.max_body_bytes = max_body_bytes
@@ -486,7 +614,6 @@ cdef class HttpProtocol:
 
     cdef void _on_headers_complete(self) noexcept:
         cdef RequestExchange exchange
-        cdef Request request
         cdef uint16_t flags
         cdef uint64_t content_length
         if self.rejected or self.reading_exchange is None:
@@ -517,12 +644,21 @@ cdef class HttpProtocol:
         if self.transport is None or self.transport.is_closing():
             return
         try:
-            request = self._build_request(exchange, exchange)
             exchange.reset_body(
                 exchange._req_expect_continue,
                 <Py_ssize_t>content_length if flags & F_CONTENT_LENGTH else -1,
             )
-            self._dispatch(exchange, request)
+            # Small Content-Length bodies that fit in the current read complete
+            # before the handler runs, so body() hits the cached bytes instead
+            # of waiting on an Event during llhttp_execute. Expect: 100-continue
+            # and large/chunked bodies still dispatch at headers-complete.
+            if (
+                not exchange._req_expect_continue
+                and (flags & F_CONTENT_LENGTH)
+                and 0 < content_length <= <uint64_t>SMALL_BODY_COMPLETE_DISPATCH
+            ):
+                return
+            self._dispatch(exchange, self._build_request(exchange, exchange))
         except Exception:
             self._close_error(400, "Invalid HTTP request")
 
@@ -540,22 +676,39 @@ cdef class HttpProtocol:
         if exchange is not None and exchange._body_active:
             if exchange.c_complete() != 0:
                 self._close_error(400, "Invalid HTTP request")
+                self.reading_exchange = None
+                return
+        if (
+            not self.request_dispatched
+            and exchange is not None
+            and not self.rejected
+        ):
+            try:
+                if self.transport is None or self.transport.is_closing():
+                    self.reading_exchange = None
+                    return
+                self._dispatch(
+                    exchange,
+                    self._build_request(exchange, exchange),
+                )
+            except Exception:
+                self._close_error(400, "Invalid HTTP request")
+                self.reading_exchange = None
+                return
         self.reading_exchange = None
 
     cdef Request _build_request(self, RequestExchange exchange, object body):
         cdef object method
         cdef object version
-        cdef object url
         cdef tuple split
         cdef Request request = exchange.req
         if exchange._req_url_length > 0:
-            url = PyBytes_FromStringAndSize(
+            split = _split_request_target_n(
                 exchange._req_arena + exchange._req_url_offset,
                 exchange._req_url_length,
             )
         else:
-            url = b""
-        split = _split_request_target(url)
+            split = (PATH_EMPTY, Q_EMPTY)
         method = _method_str(<int>llhttp_get_method(self.parser))
         version = _version_str(
             <int>llhttp_get_http_major(self.parser),
@@ -590,19 +743,18 @@ cdef class HttpProtocol:
             self._set_pause_reason(PAUSE_PIPELINE, True)
 
     cdef void _start_exchange(self, RequestExchange exchange, bint eager_start):
+        cdef object task
         self.active_exchange = exchange
         exchange.start_response()
-        self.app.create_task(
-            self._run(exchange),
+        task = self._create_task(
+            self.app(exchange, exchange),
             loop=self.loop,
             eager_start=eager_start,
         )
-
-    async def _run(self, RequestExchange exchange):
-        try:
-            await self.app(exchange, exchange)
-        finally:
+        if task.done():
             exchange.handler_finished()
+        else:
+            task.add_done_callback(exchange.on_handler_done)
 
     cdef void _drop_pending(self):
         cdef RequestExchange exchange
@@ -640,7 +792,7 @@ cdef class HttpProtocol:
             self._drop_pending()
             return
         if self.pending_exchanges:
-            next_exchange = self.pending_exchanges.pop(0)
+            next_exchange = self.pending_exchanges.popleft()
             self._start_exchange(next_exchange, False)
             if not self.pending_exchanges:
                 self._set_pause_reason(PAUSE_PIPELINE, False)

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -189,10 +189,9 @@ cdef int TIMEOUT_NONE = 0
 cdef int TIMEOUT_HEADER = 1
 cdef int TIMEOUT_IDLE = 2
 cdef int CLEANUP_OFF = 0
-cdef int CLEANUP_CALLBACK = 1
-cdef int CLEANUP_SWEEP = 2
-cdef int TIMEOUT_MODE = 2
-cdef double TIMEOUT_SWEEP_INTERVAL = 0.01
+cdef int CLEANUP_SWEEP = 1
+cdef int TIMEOUT_MODE = 1
+cdef double TIMEOUT_SWEEP_INTERVAL = 0.05
 cdef object _SWEEPS_ATTR = "_stario_timeout_sweeps"
 # GET and large/chunked bodies dispatch at headers-complete. Small
 # Content-Length bodies dispatch at message-complete so body() is cached.
@@ -390,8 +389,6 @@ cdef class HttpProtocol:
     cdef double body_timeout
     cdef int timeout_kind
     cdef double timeout_deadline
-    cdef double timeout_handle_when
-    cdef object timeout_handle
     cdef bint header_timeout_reset
     cdef bint rejected
     cdef bint request_dispatched
@@ -422,8 +419,6 @@ cdef class HttpProtocol:
         self.pump_scheduled = False
         self.timeout_kind = TIMEOUT_NONE
         self.timeout_deadline = 0.0
-        self.timeout_handle_when = 0.0
-        self.timeout_handle = None
         self.header_timeout_reset = False
 
     def __dealloc__(self):
@@ -470,8 +465,6 @@ cdef class HttpProtocol:
         self.request_keep_alive = True
         self.timeout_kind = TIMEOUT_NONE
         self.timeout_deadline = 0.0
-        self.timeout_handle_when = 0.0
-        self.timeout_handle = None
         self.header_timeout_reset = False
 
     def connection_made(self, transport):
@@ -487,8 +480,8 @@ cdef class HttpProtocol:
         self.timeout_kind = TIMEOUT_NONE
         self.timeout_deadline = 0.0
         self.connections.add(self)
-        # First request: header deadline only. wrk keep-alive must not
-        # allocate a TimerHandle per request (see _arm_timeout).
+        # First request: header deadline only. Keep-alive stores a
+        # deadline; the sweeper compares it. No TimerHandle per request.
         self._arm_timeout(TIMEOUT_HEADER, self.header_timeout)
         _ensure_timeout_sweeper(self.loop, self.connections)
 
@@ -543,9 +536,8 @@ cdef class HttpProtocol:
         if self.rejected or self.parser == NULL or not data:
             return
         if self.timeout_kind == TIMEOUT_IDLE:
-            # Keep-alive traffic: drop the idle deadline. Sweep mode has
-            # nothing else to cancel; callback mode leaves the handle to
-            # no-op or reschedule when it fires.
+            # Keep-alive traffic: drop the idle deadline. The sweeper
+            # sees TIMEOUT_NONE on the next wake.
             self.timeout_kind = TIMEOUT_NONE
             self.timeout_deadline = 0.0
         if self.held_data is not None:
@@ -560,51 +552,23 @@ cdef class HttpProtocol:
         self._after_pump()
 
     cdef void _arm_timeout(self, int kind, double seconds):
-        """Arm header or idle deadline.
+        """Store a header or idle deadline on the connection.
 
-        Sweep mode (default): store ``loop.time() + seconds`` on the
-        connection. The sweeper compares that deadline to one ``now`` per
-        wake — no ``call_later`` on the keep-alive path.
-
-        Callback mode: reuse one TimerHandle per connection. wrk keep-alive
-        would die if we ``call_later`` per request. Store a deadline and only
-        allocate a handle when none exists, or when the new deadline is
-        *sooner* than the current fire time (slowloris tests with 10ms
-        headers after a 5s idle handle).
+        The sweeper compares ``timeout_deadline`` to one ``loop.time()``
+        per wake. wrk keep-alive is a double store, not ``call_later``.
         """
-        cdef object loop
         cdef object transport
-        cdef double now
-        cdef double deadline
         if TIMEOUT_MODE == CLEANUP_OFF:
             return
         transport = self.transport
         if transport is None or transport.is_closing() or seconds <= 0:
             return
         self.timeout_kind = kind
-        loop = self.loop
-        now = loop.time()
-        deadline = now + seconds
-        self.timeout_deadline = deadline
-        if TIMEOUT_MODE == CLEANUP_SWEEP:
-            return
-        if self.timeout_handle is None:
-            self.timeout_handle = loop.call_later(seconds, self._on_timeout)
-            self.timeout_handle_when = deadline
-        elif deadline < self.timeout_handle_when:
-            self.timeout_handle.cancel()
-            self.timeout_handle = loop.call_later(seconds, self._on_timeout)
-            self.timeout_handle_when = deadline
+        self.timeout_deadline = self.loop.time() + seconds
 
     cdef void _cancel_timeout(self):
-        cdef object handle
         self.timeout_kind = TIMEOUT_NONE
         self.timeout_deadline = 0.0
-        self.timeout_handle_when = 0.0
-        handle = self.timeout_handle
-        if handle is not None:
-            handle.cancel()
-            self.timeout_handle = None
 
     cdef void _check_body_stall(self, RequestExchange exchange, double now):
         if exchange is None or exchange._timeout <= 0 or not exchange._waiting:
@@ -647,31 +611,6 @@ cdef class HttpProtocol:
         self._check_body_stall(reading, now)
         if active is not None and active is not reading:
             self._check_body_stall(active, now)
-
-    def _on_timeout(self):
-        cdef object transport
-        cdef object loop
-        cdef double now
-        cdef double deadline
-        self.timeout_handle = None
-        self.timeout_handle_when = 0.0
-        if self.rejected:
-            return
-        transport = self.transport
-        if transport is None or transport.is_closing():
-            return
-        deadline = self.timeout_deadline
-        if self.timeout_kind == TIMEOUT_NONE or deadline <= 0:
-            return
-        loop = self.loop
-        now = loop.time()
-        if now < deadline:
-            self.timeout_handle = loop.call_later(deadline - now, self._on_timeout)
-            self.timeout_handle_when = deadline
-            return
-        self.timeout_kind = TIMEOUT_NONE
-        self.timeout_deadline = 0.0
-        transport.close()
 
     cdef void _after_pump(self):
         """Arm a header deadline only if this read left headers (or a deferred

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -4,8 +4,13 @@
 ``HttpProtocol`` owns parser callbacks, pause/resume, and request dispatch.
 URL bytes and header fragments are written into the current exchange arena.
 Path/query decoding is cached here because it is connection-parse work.
+
+Header, idle, and body-stall timeouts share one cleanup path. Default is a
+sweeper over the connection set: each wake calls ``loop.time()`` once, then
+compares stored deadlines. See ``stario_cython.timeouts``.
 """
 
+import asyncio
 from collections import deque
 
 from libc.stdint cimport uint16_t, uint32_t, uint64_t
@@ -25,6 +30,10 @@ from stario.telemetry.noop import NoOpTracer
 
 from stario_cython.exchange cimport Request, RequestExchange, acquire_exchange, _status_line
 from stario_cython.llhttp cimport *
+from stario_cython.timeouts import (
+    TIMEOUT_MODE as _PY_TIMEOUT_MODE,
+    sweep_interval as _py_sweep_interval,
+)
 
 cdef enum:
     URL_CACHE_CAP = 256
@@ -179,6 +188,12 @@ cdef int PARSER_QUANTUM = 512 * 1024
 cdef int TIMEOUT_NONE = 0
 cdef int TIMEOUT_HEADER = 1
 cdef int TIMEOUT_IDLE = 2
+cdef int CLEANUP_OFF = 0
+cdef int CLEANUP_CALLBACK = 1
+cdef int CLEANUP_SWEEP = 2
+cdef int TIMEOUT_MODE = 2
+cdef double TIMEOUT_SWEEP_INTERVAL = 0.01
+cdef object _SWEEPS_ATTR = "_stario_timeout_sweeps"
 # GET and large/chunked bodies dispatch at headers-complete. Small
 # Content-Length bodies dispatch at message-complete so body() is cached.
 
@@ -290,6 +305,64 @@ cdef int _cb_message_complete(llhttp_t* parser) noexcept:
     cdef HttpProtocol proto = <HttpProtocol>stario_parser_get_data(parser)
     proto._on_message_complete()
     return -1 if proto.rejected else 0
+
+
+def _bind_timeout_policy():
+    global TIMEOUT_MODE, TIMEOUT_SWEEP_INTERVAL
+    TIMEOUT_MODE = <int>_PY_TIMEOUT_MODE
+    TIMEOUT_SWEEP_INTERVAL = <double>_py_sweep_interval()
+
+
+_bind_timeout_policy()
+
+
+async def _timeout_sweep_loop(loop, connections, key):
+    """One ``loop.time()`` per wake, then compare every live connection."""
+    sleep = asyncio.sleep
+    interval = TIMEOUT_SWEEP_INTERVAL
+    try:
+        while True:
+            await sleep(interval)
+            if not connections:
+                continue
+            now = loop.time()
+            for proto in tuple(connections):
+                proto.check_timeouts(now)
+    except asyncio.CancelledError:
+        sweeps = getattr(loop, _SWEEPS_ATTR, None)
+        if sweeps is not None:
+            sweeps.pop(key, None)
+        raise
+
+
+def _ensure_timeout_sweeper(loop, connections):
+    if TIMEOUT_MODE != CLEANUP_SWEEP:
+        return
+    sweeps = getattr(loop, _SWEEPS_ATTR, None)
+    if sweeps is None:
+        sweeps = {}
+        setattr(loop, _SWEEPS_ATTR, sweeps)
+    key = id(connections)
+    task = sweeps.get(key)
+    if task is not None and not task.done():
+        return
+    coro = _timeout_sweep_loop(loop, connections, key)
+    try:
+        task = loop.create_task(coro, name="stario-timeout-sweep")
+    except TypeError:
+        task = loop.create_task(coro)
+    sweeps[key] = task
+
+
+def _stop_timeout_sweeper(loop, connections):
+    if connections:
+        return
+    sweeps = getattr(loop, _SWEEPS_ATTR, None)
+    if not sweeps:
+        return
+    task = sweeps.pop(id(connections), None)
+    if task is not None and not task.done():
+        task.cancel()
 
 
 cdef class HttpProtocol:
@@ -414,9 +487,10 @@ cdef class HttpProtocol:
         self.timeout_kind = TIMEOUT_NONE
         self.timeout_deadline = 0.0
         self.connections.add(self)
-        # First request: header timer only. wrk keep-alive must not re-arm
-        # a TimerHandle per request (see _arm_timeout).
+        # First request: header deadline only. wrk keep-alive must not
+        # allocate a TimerHandle per request (see _arm_timeout).
         self._arm_timeout(TIMEOUT_HEADER, self.header_timeout)
+        _ensure_timeout_sweeper(self.loop, self.connections)
 
     def ensure_disconnect(self):
         if self.disconnect is None:
@@ -430,6 +504,7 @@ cdef class HttpProtocol:
         self.closed = True
         self._cancel_timeout()
         self.connections.discard(self)
+        _stop_timeout_sweeper(self.loop, self.connections)
         if self.idle_exchange is not None:
             self.idle_exchange.release_global()
             self.idle_exchange = None
@@ -468,8 +543,9 @@ cdef class HttpProtocol:
         if self.rejected or self.parser == NULL or not data:
             return
         if self.timeout_kind == TIMEOUT_IDLE:
-            # Keep-alive traffic: drop the idle deadline without cancelling
-            # the TimerHandle. The watchdog reschedules or stops when it fires.
+            # Keep-alive traffic: drop the idle deadline. Sweep mode has
+            # nothing else to cancel; callback mode leaves the handle to
+            # no-op or reschedule when it fires.
             self.timeout_kind = TIMEOUT_NONE
             self.timeout_deadline = 0.0
         if self.held_data is not None:
@@ -484,25 +560,34 @@ cdef class HttpProtocol:
         self._after_pump()
 
     cdef void _arm_timeout(self, int kind, double seconds):
-        """Arm header or idle deadline. Reuses one TimerHandle per connection.
+        """Arm header or idle deadline.
 
-        wrk keep-alive would die if we ``call_later`` per request. Store a
-        deadline (cheap) and only allocate a handle when none exists, or when
-        the new deadline is *sooner* than the current fire time (slowloris
-        tests with 10ms headers after a 5s idle handle).
+        Sweep mode (default): store ``loop.time() + seconds`` on the
+        connection. The sweeper compares that deadline to one ``now`` per
+        wake — no ``call_later`` on the keep-alive path.
+
+        Callback mode: reuse one TimerHandle per connection. wrk keep-alive
+        would die if we ``call_later`` per request. Store a deadline and only
+        allocate a handle when none exists, or when the new deadline is
+        *sooner* than the current fire time (slowloris tests with 10ms
+        headers after a 5s idle handle).
         """
         cdef object loop
         cdef object transport
         cdef double now
         cdef double deadline
+        if TIMEOUT_MODE == CLEANUP_OFF:
+            return
         transport = self.transport
         if transport is None or transport.is_closing() or seconds <= 0:
             return
+        self.timeout_kind = kind
         loop = self.loop
         now = loop.time()
         deadline = now + seconds
-        self.timeout_kind = kind
         self.timeout_deadline = deadline
+        if TIMEOUT_MODE == CLEANUP_SWEEP:
+            return
         if self.timeout_handle is None:
             self.timeout_handle = loop.call_later(seconds, self._on_timeout)
             self.timeout_handle_when = deadline
@@ -520,6 +605,48 @@ cdef class HttpProtocol:
         if handle is not None:
             handle.cancel()
             self.timeout_handle = None
+
+    cdef void _check_body_stall(self, RequestExchange exchange, double now):
+        if exchange is None or exchange._timeout <= 0 or not exchange._waiting:
+            return
+        if exchange._stall_touch != exchange._stall_seen:
+            exchange._stall_seen = exchange._stall_touch
+            exchange._stall_deadline = now + exchange._timeout
+            return
+        if exchange._stall_deadline > 0.0 and now >= exchange._stall_deadline:
+            exchange.fire_body_stall()
+
+    cpdef void check_timeouts(self, double now):
+        """Compare stored deadlines against ``now`` (one value per sweep)."""
+        cdef RequestExchange reading
+        cdef RequestExchange active
+        cdef object transport
+        cdef double seconds
+        if self.rejected:
+            return
+        if self.timeout_kind != TIMEOUT_NONE:
+            if self.timeout_deadline <= 0.0:
+                if self.timeout_kind == TIMEOUT_HEADER:
+                    seconds = self.header_timeout
+                else:
+                    seconds = self.keep_alive_timeout
+                if seconds <= 0.0:
+                    self.timeout_kind = TIMEOUT_NONE
+                    self.timeout_deadline = 0.0
+                else:
+                    self.timeout_deadline = now + seconds
+            elif now >= self.timeout_deadline:
+                self.timeout_kind = TIMEOUT_NONE
+                self.timeout_deadline = 0.0
+                transport = self.transport
+                if transport is not None and not transport.is_closing():
+                    transport.close()
+                return
+        reading = self.reading_exchange
+        active = self.active_exchange
+        self._check_body_stall(reading, now)
+        if active is not None and active is not reading:
+            self._check_body_stall(active, now)
 
     def _on_timeout(self):
         cdef object transport
@@ -547,7 +674,7 @@ cdef class HttpProtocol:
         transport.close()
 
     cdef void _after_pump(self):
-        """Arm a header timer only if this read left headers (or a deferred
+        """Arm a header deadline only if this read left headers (or a deferred
         small body) unfinished. Full wrk requests dispatch inside the pump,
         so this is a no-op on the keep-alive hot path.
         """

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -14,6 +14,12 @@ from libc.string cimport memcmp, memcpy
 from cpython.bytes cimport PyBytes_FromStringAndSize
 from cpython.unicode cimport PyUnicode_DecodeASCII
 
+from stario.http.config import (
+    DEFAULT_HEADER_TIMEOUT,
+    DEFAULT_KEEP_ALIVE_TIMEOUT,
+    DEFAULT_MAX_PIPELINED_REQUESTS,
+)
+from stario.http.request import DEFAULT_BODY_TIMEOUT
 from stario.http.wire import decode_path
 from stario.telemetry.noop import NoOpTracer
 
@@ -170,7 +176,9 @@ cdef int PAUSE_WRITE = 1
 cdef int PAUSE_PIPELINE = 2
 cdef int PAUSE_BODY = 4
 cdef int PARSER_QUANTUM = 512 * 1024
-cdef int MAX_PENDING_EXCHANGES = 64
+cdef int TIMEOUT_NONE = 0
+cdef int TIMEOUT_HEADER = 1
+cdef int TIMEOUT_IDLE = 2
 # GET and large/chunked bodies dispatch at headers-complete. Small
 # Content-Length bodies dispatch at message-complete so body() is cached.
 
@@ -303,6 +311,15 @@ cdef class HttpProtocol:
     cdef int head_bytes
     cdef int max_header_bytes
     cdef int max_body_bytes
+    cdef int max_pipelined_requests
+    cdef double header_timeout
+    cdef double keep_alive_timeout
+    cdef double body_timeout
+    cdef int timeout_kind
+    cdef double timeout_deadline
+    cdef double timeout_handle_when
+    cdef object timeout_handle
+    cdef bint header_timeout_reset
     cdef bint rejected
     cdef bint request_dispatched
     cdef bint request_keep_alive
@@ -330,6 +347,11 @@ cdef class HttpProtocol:
         self.held_data = None
         self.held_offset = 0
         self.pump_scheduled = False
+        self.timeout_kind = TIMEOUT_NONE
+        self.timeout_deadline = 0.0
+        self.timeout_handle_when = 0.0
+        self.timeout_handle = None
+        self.header_timeout_reset = False
 
     def __dealloc__(self):
         if self.parser != NULL:
@@ -346,6 +368,10 @@ cdef class HttpProtocol:
         connections,
         max_header_bytes=64 * 1024,
         max_body_bytes=10 * 1024 * 1024,
+        header_timeout=DEFAULT_HEADER_TIMEOUT,
+        keep_alive_timeout=DEFAULT_KEEP_ALIVE_TIMEOUT,
+        body_timeout=DEFAULT_BODY_TIMEOUT,
+        max_pipelined_requests=DEFAULT_MAX_PIPELINED_REQUESTS,
     ):
         self.loop = loop
         self.app = app
@@ -362,9 +388,18 @@ cdef class HttpProtocol:
         self.head_bytes = 0
         self.max_header_bytes = max_header_bytes
         self.max_body_bytes = max_body_bytes
+        self.max_pipelined_requests = max_pipelined_requests
+        self.header_timeout = header_timeout
+        self.keep_alive_timeout = keep_alive_timeout
+        self.body_timeout = body_timeout
         self.rejected = False
         self.request_dispatched = False
         self.request_keep_alive = True
+        self.timeout_kind = TIMEOUT_NONE
+        self.timeout_deadline = 0.0
+        self.timeout_handle_when = 0.0
+        self.timeout_handle = None
+        self.header_timeout_reset = False
 
     def connection_made(self, transport):
         self.transport = transport
@@ -375,7 +410,13 @@ cdef class HttpProtocol:
         self.held_data = None
         self.held_offset = 0
         self.pump_scheduled = False
+        self.rejected = False
+        self.timeout_kind = TIMEOUT_NONE
+        self.timeout_deadline = 0.0
         self.connections.add(self)
+        # First request: header timer only. wrk keep-alive must not re-arm
+        # a TimerHandle per request (see _arm_timeout).
+        self._arm_timeout(TIMEOUT_HEADER, self.header_timeout)
 
     def ensure_disconnect(self):
         if self.disconnect is None:
@@ -387,6 +428,7 @@ cdef class HttpProtocol:
     def connection_lost(self, exc):
         cdef RequestExchange exchange
         self.closed = True
+        self._cancel_timeout()
         self.connections.discard(self)
         if self.idle_exchange is not None:
             self.idle_exchange.release_global()
@@ -425,6 +467,11 @@ cdef class HttpProtocol:
     def data_received(self, data):
         if self.rejected or self.parser == NULL or not data:
             return
+        if self.timeout_kind == TIMEOUT_IDLE:
+            # Keep-alive traffic: drop the idle deadline without cancelling
+            # the TimerHandle. The watchdog reschedules or stops when it fires.
+            self.timeout_kind = TIMEOUT_NONE
+            self.timeout_deadline = 0.0
         if self.held_data is not None:
             self.held_data = self.held_data[self.held_offset :] + data
             self.held_offset = 0
@@ -434,6 +481,85 @@ cdef class HttpProtocol:
             self.held_offset = 0
             return
         self._pump_data(data, 0)
+        self._after_pump()
+
+    cdef void _arm_timeout(self, int kind, double seconds):
+        """Arm header or idle deadline. Reuses one TimerHandle per connection.
+
+        wrk keep-alive would die if we ``call_later`` per request. Store a
+        deadline (cheap) and only allocate a handle when none exists, or when
+        the new deadline is *sooner* than the current fire time (slowloris
+        tests with 10ms headers after a 5s idle handle).
+        """
+        cdef object loop
+        cdef object transport
+        cdef double now
+        cdef double deadline
+        transport = self.transport
+        if transport is None or transport.is_closing() or seconds <= 0:
+            return
+        loop = self.loop
+        now = loop.time()
+        deadline = now + seconds
+        self.timeout_kind = kind
+        self.timeout_deadline = deadline
+        if self.timeout_handle is None:
+            self.timeout_handle = loop.call_later(seconds, self._on_timeout)
+            self.timeout_handle_when = deadline
+        elif deadline < self.timeout_handle_when:
+            self.timeout_handle.cancel()
+            self.timeout_handle = loop.call_later(seconds, self._on_timeout)
+            self.timeout_handle_when = deadline
+
+    cdef void _cancel_timeout(self):
+        cdef object handle
+        self.timeout_kind = TIMEOUT_NONE
+        self.timeout_deadline = 0.0
+        self.timeout_handle_when = 0.0
+        handle = self.timeout_handle
+        if handle is not None:
+            handle.cancel()
+            self.timeout_handle = None
+
+    def _on_timeout(self):
+        cdef object transport
+        cdef object loop
+        cdef double now
+        cdef double deadline
+        self.timeout_handle = None
+        self.timeout_handle_when = 0.0
+        if self.rejected:
+            return
+        transport = self.transport
+        if transport is None or transport.is_closing():
+            return
+        deadline = self.timeout_deadline
+        if self.timeout_kind == TIMEOUT_NONE or deadline <= 0:
+            return
+        loop = self.loop
+        now = loop.time()
+        if now < deadline:
+            self.timeout_handle = loop.call_later(deadline - now, self._on_timeout)
+            self.timeout_handle_when = deadline
+            return
+        self.timeout_kind = TIMEOUT_NONE
+        self.timeout_deadline = 0.0
+        transport.close()
+
+    cdef void _after_pump(self):
+        """Arm a header timer only if this read left headers (or a deferred
+        small body) unfinished. Full wrk requests dispatch inside the pump,
+        so this is a no-op on the keep-alive hot path.
+        """
+        if not self.header_timeout_reset:
+            return
+        self.header_timeout_reset = False
+        if (
+            not self.rejected
+            and self.reading_exchange is not None
+            and not self.request_dispatched
+        ):
+            self._arm_timeout(TIMEOUT_HEADER, self.header_timeout)
 
     cdef void _pump_data(self, object data, Py_ssize_t offset) noexcept:
         cdef const char* ptr
@@ -501,6 +627,7 @@ cdef class HttpProtocol:
         self.held_data = None
         self.held_offset = 0
         self._pump_data(data, offset)
+        self._after_pump()
         if self.pause_reasons == 0 and self.held_data is None:
             transport = self.transport
             if transport is not None and not transport.is_closing():
@@ -533,6 +660,7 @@ cdef class HttpProtocol:
         if transport is None or transport.is_closing():
             return False
         transport.close()
+        self._cancel_timeout()
         return True
 
     def pause_writing(self):
@@ -563,6 +691,7 @@ cdef class HttpProtocol:
                 self.date_box,
                 self.compression,
                 self.max_body_bytes,
+                self.body_timeout,
             )
         else:
             # Pool miss: constructing an exchange can raise. Keepalive reuse
@@ -575,6 +704,7 @@ cdef class HttpProtocol:
                     self.date_box,
                     self.compression,
                     self.max_body_bytes,
+                    self.body_timeout,
                 )
             except Exception:
                 self._close_error(400, "Invalid HTTP request")
@@ -582,6 +712,7 @@ cdef class HttpProtocol:
         self.head_bytes = 40
         self.request_dispatched = False
         self.request_keep_alive = True
+        self.header_timeout_reset = True
 
     cdef void _on_url(self, const char* at, size_t length) noexcept:
         if self.rejected or self.reading_exchange is None:
@@ -728,6 +859,9 @@ cdef class HttpProtocol:
     cdef void _dispatch(self, RequestExchange exchange, Request request):
         cdef object span
         self.request_dispatched = True
+        if self.timeout_kind == TIMEOUT_HEADER:
+            self.timeout_kind = TIMEOUT_NONE
+            self.timeout_deadline = 0.0
         if self.noop_span is not None:
             span = self.noop_span
         else:
@@ -736,7 +870,7 @@ cdef class HttpProtocol:
         if self.active_exchange is None:
             self._start_exchange(exchange, True)
         else:
-            if len(self.pending_exchanges) >= MAX_PENDING_EXCHANGES:
+            if len(self.pending_exchanges) >= self.max_pipelined_requests:
                 self._close_error(429, "Too many pipelined requests")
                 return
             self.pending_exchanges.append(exchange)
@@ -798,6 +932,7 @@ cdef class HttpProtocol:
                 self._set_pause_reason(PAUSE_PIPELINE, False)
             return
         self._set_pause_reason(PAUSE_PIPELINE, False)
+        self._arm_timeout(TIMEOUT_IDLE, self.keep_alive_timeout)
 
     cdef void _close_error(self, int status, object message) noexcept:
         cdef object transport
@@ -806,6 +941,7 @@ cdef class HttpProtocol:
         if self.rejected:
             return
         self.rejected = True
+        self._cancel_timeout()
         transport = self.transport
         try:
             if transport is None or transport.is_closing():

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -5,9 +5,10 @@
 URL bytes and header fragments are written into the current exchange arena.
 Path/query decoding is cached here because it is connection-parse work.
 
-Header, idle, and body-stall timeouts share one cleanup path. Default is a
-sweeper over the connection set: each wake calls ``loop.time()`` once, then
-compares stored deadlines. See ``stario_cython.timeouts``.
+Header, idle, and body-stall timeouts share one cleanup path. Under Server
+that path is the Date-header tick (once a second): one ``loop.time()``, then
+compare stored deadlines. Tests and raw ``create_server`` use a fallback
+sweeper at the same period. See ``stario_cython.timeouts``.
 """
 
 import asyncio
@@ -31,6 +32,7 @@ from stario.telemetry.noop import NoOpTracer
 from stario_cython.exchange cimport Request, RequestExchange, acquire_exchange, _status_line
 from stario_cython.llhttp cimport *
 from stario_cython.timeouts import (
+    DATE_TICK_SWEEP_ATTR as _PY_DATE_TICK_SWEEP_ATTR,
     TIMEOUT_MODE as _PY_TIMEOUT_MODE,
     sweep_interval as _py_sweep_interval,
 )
@@ -191,7 +193,7 @@ cdef int TIMEOUT_IDLE = 2
 cdef int CLEANUP_OFF = 0
 cdef int CLEANUP_SWEEP = 1
 cdef int TIMEOUT_MODE = 1
-cdef double TIMEOUT_SWEEP_INTERVAL = 0.05
+cdef double TIMEOUT_SWEEP_INTERVAL = 1.0
 cdef object _SWEEPS_ATTR = "_stario_timeout_sweeps"
 # GET and large/chunked bodies dispatch at headers-complete. Small
 # Content-Length bodies dispatch at message-complete so body() is cached.
@@ -336,6 +338,9 @@ async def _timeout_sweep_loop(loop, connections, key):
 
 def _ensure_timeout_sweeper(loop, connections):
     if TIMEOUT_MODE != CLEANUP_SWEEP:
+        return
+    # Server Date tick already walks this loop's connections once a second.
+    if getattr(loop, _PY_DATE_TICK_SWEEP_ATTR, False):
         return
     sweeps = getattr(loop, _SWEEPS_ATTR, None)
     if sweeps is None:

--- a/src/stario_cython/serve.py
+++ b/src/stario_cython/serve.py
@@ -13,8 +13,9 @@ the exchange — chunks do not ``call_later``. ``RequestPolicy.max_pipelined_req
 (default 8) caps the pipeline queue.
 
 ``STARIO_CYTHON_TIMEOUTS=off`` disables header/idle/body-stall cleanup
-(profiling hatch). ``STARIO_CYTHON_TIMEOUT_SWEEP`` sets the sweeper period
-(default 50ms).
+(profiling hatch). Under Server the sweep rides the Date-header tick (1s).
+``STARIO_CYTHON_TIMEOUT_SWEEP`` overrides the fallback sweeper period used
+without Server (default 1s).
 """
 
 from __future__ import annotations

--- a/src/stario_cython/serve.py
+++ b/src/stario_cython/serve.py
@@ -12,9 +12,9 @@ connection has no in-flight request. Body stall is a generation counter on
 the exchange — chunks do not ``call_later``. ``RequestPolicy.max_pipelined_requests``
 (default 8) caps the pipeline queue.
 
-``STARIO_CYTHON_TIMEOUTS=callback`` restores per-connection TimerHandles for
-wrk A/B. ``STARIO_CYTHON_TIMEOUTS=off`` disables header/idle/body-stall
-cleanup (profiling).
+``STARIO_CYTHON_TIMEOUTS=off`` disables header/idle/body-stall cleanup
+(profiling hatch). ``STARIO_CYTHON_TIMEOUT_SWEEP`` sets the sweeper period
+(default 50ms).
 """
 
 from __future__ import annotations

--- a/src/stario_cython/serve.py
+++ b/src/stario_cython/serve.py
@@ -4,12 +4,17 @@ Lifecycle (signal handling, graceful drain, date-header refresh) is the
 standard ``stario.http.server.Server``. This module injects the compiled
 protocol factory and keeps the Cython defaults (uvloop + NoOpTracer).
 
-Header timeout is armed only while headers (or a deferred small body) are
-still arriving. Idle/keep-alive timeout is armed only when the connection
-has no in-flight request. One TimerHandle is reused per connection so wrk
-keep-alive does not ``call_later`` per request. Body stall timeout lives on
-the exchange. ``RequestPolicy.max_pipelined_requests`` (default 8) caps the
-pipeline queue.
+Header, idle, and body-stall timeouts share one cleanup: a sweeper over the
+connection set calls ``loop.time()`` once per wake and compares stored
+deadlines. Header timeout is armed only while headers (or a deferred small
+body) are still arriving. Idle/keep-alive timeout is armed only when the
+connection has no in-flight request. Body stall is a generation counter on
+the exchange — chunks do not ``call_later``. ``RequestPolicy.max_pipelined_requests``
+(default 8) caps the pipeline queue.
+
+``STARIO_CYTHON_TIMEOUTS=callback`` restores per-connection TimerHandles for
+wrk A/B. ``STARIO_CYTHON_TIMEOUTS=off`` disables header/idle/body-stall
+cleanup (profiling).
 """
 
 from __future__ import annotations

--- a/src/stario_cython/serve.py
+++ b/src/stario_cython/serve.py
@@ -3,8 +3,13 @@
 Lifecycle (signal handling, graceful drain, date-header refresh) is the
 standard ``stario.http.server.Server``. This module injects the compiled
 protocol factory and keeps the Cython defaults (uvloop + NoOpTracer).
-Request-policy knobs the compiled parser does not implement (header/idle
-timeouts, the 8-request pipeline cap) stay unwired.
+
+Header timeout is armed only while headers (or a deferred small body) are
+still arriving. Idle/keep-alive timeout is armed only when the connection
+has no in-flight request. One TimerHandle is reused per connection so wrk
+keep-alive does not ``call_later`` per request. Body stall timeout lives on
+the exchange. ``RequestPolicy.max_pipelined_requests`` (default 8) caps the
+pipeline queue.
 """
 
 from __future__ import annotations
@@ -38,6 +43,10 @@ def _make_cython_protocol(
         connections,
         max_header_bytes=requests.max_header_bytes,
         max_body_bytes=requests.max_body_bytes,
+        header_timeout=requests.header_timeout,
+        keep_alive_timeout=requests.keep_alive_timeout,
+        body_timeout=requests.body_timeout,
+        max_pipelined_requests=requests.max_pipelined_requests,
     )
 
 

--- a/src/stario_cython/timeouts.py
+++ b/src/stario_cython/timeouts.py
@@ -1,17 +1,22 @@
 """Timeout cleanup for the Cython HTTP protocol.
 
-Header, idle, and body-stall timeouts share **one** mechanism: a sweeper
-over the connection set. Each wake calls ``loop.time()`` once, then
-compares deadlines stored on the protocol / exchange.
+Header, idle, and body-stall timeouts share **one** mechanism: compare
+deadlines stored on the connection to ``loop.time()`` computed once per
+wake.
+
+Under ``stario.http.server.Server`` that wake is the Date-header tick
+(once a second). Header/idle/body-stall defaults are 5s/5s/30s, so 1s
+granularity is enough and adds no extra timer. Protocols constructed
+without Server (tests, raw ``create_server``) start a fallback sweeper
+with the same period.
 
 ``STARIO_CYTHON_TIMEOUTS`` (process env, read at import):
 
-- ``sweep`` (default) — one sweeper task per ``connections`` set
+- ``sweep`` (default)
 - ``off`` / ``0`` — no header, idle, or body-stall cleanup (profiling hatch)
 
-``STARIO_CYTHON_TIMEOUT_SWEEP`` is the sweeper period in seconds (default
-``0.05``). Expiry is that period at worst. 10ms was measurable on 2MB
-streaming wrk; 50ms is still tight for the 5s/30s production timeouts.
+``STARIO_CYTHON_TIMEOUT_SWEEP`` overrides the fallback sweeper period
+(default ``1``). Tests set ``0.05`` so slowloris cases finish quickly.
 """
 
 from __future__ import annotations
@@ -22,6 +27,8 @@ MODE_OFF = 0
 MODE_SWEEP = 1
 
 _SWEEP_ATTR = "_stario_timeout_sweeps"
+# Keep in sync with ``stario.http.server._DATE_TICK_SWEEPS_TIMEOUTS``.
+DATE_TICK_SWEEP_ATTR = "_stario_date_tick_sweeps_timeouts"
 
 
 def parse_timeout_mode(raw: str | None = None) -> int:
@@ -43,11 +50,11 @@ def timeout_cleanup_mode() -> str:
 
 
 def sweep_interval() -> float:
-    raw = os.environ.get("STARIO_CYTHON_TIMEOUT_SWEEP", "0.05")
+    raw = os.environ.get("STARIO_CYTHON_TIMEOUT_SWEEP", "1")
     try:
         value = float(raw)
     except ValueError:
-        value = 0.05
+        value = 1.0
     if value < 0.001:
         return 0.001
     if value > 1.0:

--- a/src/stario_cython/timeouts.py
+++ b/src/stario_cython/timeouts.py
@@ -1,0 +1,61 @@
+"""Timeout cleanup mode for the Cython HTTP protocol.
+
+Header, idle, and body-stall timeouts share one mechanism. Default is a
+per-event-loop sweeper: each wake calls ``loop.time()`` once, then compares
+deadlines stored on the connection / exchange.
+
+``STARIO_CYTHON_TIMEOUTS`` (process env, read at import):
+
+- ``sweep`` (default) — one sweeper task per ``connections`` set
+- ``callback`` — per-connection ``TimerHandle`` + per-exchange stall
+  ``call_later`` (kept for A/B wrk; not the long-term path)
+- ``off`` / ``0`` — no header, idle, or body-stall cleanup (profiling hatch)
+
+``STARIO_CYTHON_TIMEOUT_SWEEP`` is the sweeper period in seconds (default
+``0.01``). Timeout expiry is that period at worst.
+"""
+
+from __future__ import annotations
+
+import os
+
+MODE_OFF = 0
+MODE_CALLBACK = 1
+MODE_SWEEP = 2
+
+_SWEEP_ATTR = "_stario_timeout_sweeps"
+
+
+def parse_timeout_mode(raw: str | None = None) -> int:
+    if raw is None:
+        raw = os.environ.get("STARIO_CYTHON_TIMEOUTS", "sweep")
+    value = raw.strip().lower()
+    if value in ("0", "off", "none", "false", "no"):
+        return MODE_OFF
+    if value in ("1", "callback", "timer", "call_later"):
+        return MODE_CALLBACK
+    return MODE_SWEEP
+
+
+TIMEOUT_MODE = parse_timeout_mode()
+
+
+def timeout_cleanup_mode() -> str:
+    if TIMEOUT_MODE == MODE_OFF:
+        return "off"
+    if TIMEOUT_MODE == MODE_CALLBACK:
+        return "callback"
+    return "sweep"
+
+
+def sweep_interval() -> float:
+    raw = os.environ.get("STARIO_CYTHON_TIMEOUT_SWEEP", "0.01")
+    try:
+        value = float(raw)
+    except ValueError:
+        value = 0.01
+    if value < 0.001:
+        return 0.001
+    if value > 1.0:
+        return 1.0
+    return value

--- a/src/stario_cython/timeouts.py
+++ b/src/stario_cython/timeouts.py
@@ -1,18 +1,17 @@
-"""Timeout cleanup mode for the Cython HTTP protocol.
+"""Timeout cleanup for the Cython HTTP protocol.
 
-Header, idle, and body-stall timeouts share one mechanism. Default is a
-per-event-loop sweeper: each wake calls ``loop.time()`` once, then compares
-deadlines stored on the connection / exchange.
+Header, idle, and body-stall timeouts share **one** mechanism: a sweeper
+over the connection set. Each wake calls ``loop.time()`` once, then
+compares deadlines stored on the protocol / exchange.
 
 ``STARIO_CYTHON_TIMEOUTS`` (process env, read at import):
 
 - ``sweep`` (default) — one sweeper task per ``connections`` set
-- ``callback`` — per-connection ``TimerHandle`` + per-exchange stall
-  ``call_later`` (kept for A/B wrk; not the long-term path)
 - ``off`` / ``0`` — no header, idle, or body-stall cleanup (profiling hatch)
 
 ``STARIO_CYTHON_TIMEOUT_SWEEP`` is the sweeper period in seconds (default
-``0.01``). Timeout expiry is that period at worst.
+``0.05``). Expiry is that period at worst. 10ms was measurable on 2MB
+streaming wrk; 50ms is still tight for the 5s/30s production timeouts.
 """
 
 from __future__ import annotations
@@ -20,8 +19,7 @@ from __future__ import annotations
 import os
 
 MODE_OFF = 0
-MODE_CALLBACK = 1
-MODE_SWEEP = 2
+MODE_SWEEP = 1
 
 _SWEEP_ATTR = "_stario_timeout_sweeps"
 
@@ -32,8 +30,6 @@ def parse_timeout_mode(raw: str | None = None) -> int:
     value = raw.strip().lower()
     if value in ("0", "off", "none", "false", "no"):
         return MODE_OFF
-    if value in ("1", "callback", "timer", "call_later"):
-        return MODE_CALLBACK
     return MODE_SWEEP
 
 
@@ -43,17 +39,15 @@ TIMEOUT_MODE = parse_timeout_mode()
 def timeout_cleanup_mode() -> str:
     if TIMEOUT_MODE == MODE_OFF:
         return "off"
-    if TIMEOUT_MODE == MODE_CALLBACK:
-        return "callback"
     return "sweep"
 
 
 def sweep_interval() -> float:
-    raw = os.environ.get("STARIO_CYTHON_TIMEOUT_SWEEP", "0.01")
+    raw = os.environ.get("STARIO_CYTHON_TIMEOUT_SWEEP", "0.05")
     try:
         value = float(raw)
     except ValueError:
-        value = 0.01
+        value = 0.05
     if value < 0.001:
         return 0.001
     if value > 1.0:

--- a/tests/cython/conftest.py
+++ b/tests/cython/conftest.py
@@ -5,4 +5,10 @@ re-enters the partial module (App → Writer → Headers). Completing the packag
 init first makes collection order-independent.
 """
 
+import os
+
+# Production sweeps with the Date header (1s). Tests use 50ms so header/idle
+# cases finish in a few hundred milliseconds. Must be set before protocol import.
+os.environ.setdefault("STARIO_CYTHON_TIMEOUT_SWEEP", "0.05")
+
 import stario as _stario  # noqa: F401

--- a/tests/cython/conftest.py
+++ b/tests/cython/conftest.py
@@ -1,0 +1,8 @@
+"""Load ``stario`` before Cython extensions.
+
+Importing ``stario_cython.headers`` while ``stario.__init__`` is still running
+re-enters the partial module (App → Writer → Headers). Completing the package
+init first makes collection order-independent.
+"""
+
+import stario as _stario  # noqa: F401

--- a/tests/cython/http.py
+++ b/tests/cython/http.py
@@ -63,6 +63,10 @@ def make_protocol(
     compression: CompressionConfig | None = None,
     max_header_bytes: int = 64 * 1024,
     max_body_bytes: int = 10 * 1024 * 1024,
+    header_timeout: float = 5.0,
+    keep_alive_timeout: float = 5.0,
+    body_timeout: float = 30.0,
+    max_pipelined_requests: int = 8,
 ) -> HttpProtocol:
     if connections is None:
         connections = set()
@@ -75,6 +79,10 @@ def make_protocol(
         connections,
         max_header_bytes=max_header_bytes,
         max_body_bytes=max_body_bytes,
+        header_timeout=header_timeout,
+        keep_alive_timeout=keep_alive_timeout,
+        body_timeout=body_timeout,
+        max_pipelined_requests=max_pipelined_requests,
     )
 
 
@@ -86,6 +94,10 @@ async def running_server(
     compression: CompressionConfig | None = None,
     max_header_bytes: int = 64 * 1024,
     max_body_bytes: int = 10 * 1024 * 1024,
+    header_timeout: float = 5.0,
+    keep_alive_timeout: float = 5.0,
+    body_timeout: float = 30.0,
+    max_pipelined_requests: int = 8,
 ) -> AsyncIterator[int]:
     loop = asyncio.get_running_loop()
     connections: set[HttpProtocol] = set()
@@ -98,6 +110,10 @@ async def running_server(
             compression=compression,
             max_header_bytes=max_header_bytes,
             max_body_bytes=max_body_bytes,
+            header_timeout=header_timeout,
+            keep_alive_timeout=keep_alive_timeout,
+            body_timeout=body_timeout,
+            max_pipelined_requests=max_pipelined_requests,
         ),
         "127.0.0.1",
         free_port(),

--- a/tests/cython/test_hardening.py
+++ b/tests/cython/test_hardening.py
@@ -18,8 +18,8 @@ from tests.cython.http import (
     response_statuses,
 )
 
-# Default sweeper period is 50ms. Timeouts here must exceed two periods;
-# waits must exceed timeout + one period.
+# Production sweeps with the Date tick (1s). Tests force 50ms via conftest.
+# Timeouts here must exceed two periods; waits must exceed timeout + one period.
 _TIMEOUT = 0.15
 _WAIT = 0.40
 _TRICKLE_PAUSE = 0.08
@@ -694,6 +694,28 @@ async def test_timeout_sweeper_is_one_task_per_connection_set() -> None:
         if not transport.is_closing():
             transport.close()
         await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_server_date_tick_skips_fallback_sweeper() -> None:
+    from stario_cython.timeouts import DATE_TICK_SWEEP_ATTR, timeout_cleanup_mode
+
+    if timeout_cleanup_mode() != "sweep":
+        pytest.skip("default cleanup is the connection sweeper")
+    loop = asyncio.get_running_loop()
+    setattr(loop, DATE_TICK_SWEEP_ATTR, True)
+    proto = app = transport = None
+    try:
+        proto, app, transport = _attach(header_timeout=5.0)
+        sweeps = getattr(loop, "_stario_timeout_sweeps", None) or {}
+        live = [task for task in sweeps.values() if task is not None and not task.done()]
+        assert live == []
+    finally:
+        setattr(loop, DATE_TICK_SWEEP_ATTR, False)
+        if transport is not None and not transport.is_closing():
+            transport.close()
+        if app is not None:
+            await _drain(app)
 
 
 @pytest.mark.asyncio

--- a/tests/cython/test_hardening.py
+++ b/tests/cython/test_hardening.py
@@ -1,4 +1,4 @@
-"""Cython protocol edge cases. Header/idle timeouts are not implemented."""
+"""Cython protocol edge cases, including header/idle timeouts and pipeline cap."""
 
 from __future__ import annotations
 
@@ -497,6 +497,178 @@ async def test_close_if_idle_skips_in_flight_handler() -> None:
         assert not transport.is_closing()
     finally:
         hang.set()
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_connection_with_no_data_times_out_headers() -> None:
+    proto, app, transport = _attach(header_timeout=0.01)
+    try:
+        await asyncio.sleep(0.03)
+        assert transport.is_closing()
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_partial_headers_time_out() -> None:
+    proto, app, transport = _attach(header_timeout=0.01)
+    try:
+        proto.data_received(b"GET / HTTP/1.1\r\n")
+        await asyncio.sleep(0.03)
+        assert transport.is_closing()
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_trickle_headers_do_not_reset_header_timeout() -> None:
+    proto, app, transport = _attach(header_timeout=0.04)
+    try:
+        proto.data_received(b"GET / HTTP/1.1\r\n")
+        await asyncio.sleep(0.025)
+        proto.data_received(b"Host: t\r\n")
+        await asyncio.sleep(0.025)
+        assert transport.is_closing()
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_stalled_deferred_small_body_times_out() -> None:
+    """Small Content-Length bodies dispatch at message-complete. Incomplete
+    bodies must not hang: the header timer stays armed until dispatch."""
+    app = App()
+    hits = 0
+
+    async def handler(c, w) -> None:
+        nonlocal hits
+        hits += 1
+        await c.req.body()
+        responses.text(w, "ok")
+
+    app.post("/", handler)
+    proto, app, transport = _attach(app=app, header_timeout=0.01)
+    try:
+        proto.data_received(
+            b"POST / HTTP/1.1\r\nHost: t\r\nContent-Length: 8\r\n\r\n"
+        )
+        await asyncio.sleep(0.03)
+        assert transport.is_closing()
+        assert hits == 0
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_complete_request_does_not_keep_header_timer() -> None:
+    app = App()
+
+    async def handler(_c, w) -> None:
+        responses.text(w, "ok")
+
+    app.get("/", handler)
+    proto, app, transport = _attach(
+        app=app, header_timeout=0.01, keep_alive_timeout=5.0
+    )
+    try:
+        proto.data_received(b"GET / HTTP/1.1\r\nHost: t\r\n\r\n")
+        await _drain(app)
+        assert response_status(transport.writes) == 200
+        await asyncio.sleep(0.03)
+        assert not transport.is_closing()
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_idle_keep_alive_times_out() -> None:
+    app = App()
+
+    async def handler(_c, w) -> None:
+        responses.text(w, "ok")
+
+    app.get("/", handler)
+    proto, app, transport = _attach(
+        app=app, header_timeout=5.0, keep_alive_timeout=0.01
+    )
+    try:
+        proto.data_received(b"GET / HTTP/1.1\r\nHost: t\r\n\r\n")
+        await _drain(app)
+        assert response_status(transport.writes) == 200
+        assert not transport.is_closing()
+        await asyncio.sleep(0.03)
+        assert transport.is_closing()
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_in_flight_handler_is_not_header_timed_out() -> None:
+    app = App()
+    started = asyncio.Event()
+    hang = asyncio.Event()
+
+    async def handler(_c, w) -> None:
+        started.set()
+        await hang.wait()
+        responses.text(w, "ok")
+
+    app.get("/", handler)
+    proto, app, transport = _attach(app=app, header_timeout=0.01)
+    try:
+        proto.data_received(b"GET / HTTP/1.1\r\nHost: t\r\n\r\n")
+        await started.wait()
+        await asyncio.sleep(0.03)
+        assert not transport.is_closing()
+    finally:
+        hang.set()
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_cap_rejects_ninth_queued_request() -> None:
+    app = App()
+    release = asyncio.Event()
+    handled: list[int] = []
+
+    async def endpoint(c, w) -> None:
+        index = int(c.req.query_bytes)
+        handled.append(index)
+        if index == 0:
+            await release.wait()
+        responses.text(w, str(index))
+
+    app.get("/", endpoint)
+    proto, app, transport = _attach(app=app, max_pipelined_requests=8)
+    try:
+        chunks = [
+            b"GET /?" + str(i).encode("ascii") + b" HTTP/1.1\r\nHost: t\r\n\r\n"
+            for i in range(10)
+        ]
+        proto.data_received(b"".join(chunks))
+        await asyncio.sleep(0)
+        assert response_status(transport.writes) == 429
+        release.set()
+        await _drain(app)
+        assert handled == [0]
+    finally:
         if not transport.is_closing():
             transport.close()
         await _drain(app)

--- a/tests/cython/test_hardening.py
+++ b/tests/cython/test_hardening.py
@@ -18,6 +18,12 @@ from tests.cython.http import (
     response_statuses,
 )
 
+# Default sweeper period is 50ms. Timeouts here must exceed two periods;
+# waits must exceed timeout + one period.
+_TIMEOUT = 0.15
+_WAIT = 0.40
+_TRICKLE_PAUSE = 0.08
+
 
 def _attach(app: App | None = None, **kwargs):
     loop = asyncio.get_running_loop()
@@ -504,9 +510,9 @@ async def test_close_if_idle_skips_in_flight_handler() -> None:
 
 @pytest.mark.asyncio
 async def test_connection_with_no_data_times_out_headers() -> None:
-    proto, app, transport = _attach(header_timeout=0.01)
+    proto, app, transport = _attach(header_timeout=_TIMEOUT)
     try:
-        await asyncio.sleep(0.03)
+        await asyncio.sleep(_WAIT)
         assert transport.is_closing()
     finally:
         if not transport.is_closing():
@@ -516,10 +522,10 @@ async def test_connection_with_no_data_times_out_headers() -> None:
 
 @pytest.mark.asyncio
 async def test_partial_headers_time_out() -> None:
-    proto, app, transport = _attach(header_timeout=0.01)
+    proto, app, transport = _attach(header_timeout=_TIMEOUT)
     try:
         proto.data_received(b"GET / HTTP/1.1\r\n")
-        await asyncio.sleep(0.03)
+        await asyncio.sleep(_WAIT)
         assert transport.is_closing()
     finally:
         if not transport.is_closing():
@@ -529,12 +535,12 @@ async def test_partial_headers_time_out() -> None:
 
 @pytest.mark.asyncio
 async def test_trickle_headers_do_not_reset_header_timeout() -> None:
-    proto, app, transport = _attach(header_timeout=0.04)
+    proto, app, transport = _attach(header_timeout=_TIMEOUT)
     try:
         proto.data_received(b"GET / HTTP/1.1\r\n")
-        await asyncio.sleep(0.025)
+        await asyncio.sleep(_TRICKLE_PAUSE)
         proto.data_received(b"Host: t\r\n")
-        await asyncio.sleep(0.025)
+        await asyncio.sleep(_WAIT)
         assert transport.is_closing()
     finally:
         if not transport.is_closing():
@@ -545,7 +551,7 @@ async def test_trickle_headers_do_not_reset_header_timeout() -> None:
 @pytest.mark.asyncio
 async def test_stalled_deferred_small_body_times_out() -> None:
     """Small Content-Length bodies dispatch at message-complete. Incomplete
-    bodies must not hang: the header timer stays armed until dispatch."""
+    bodies must not hang: the header deadline stays armed until dispatch."""
     app = App()
     hits = 0
 
@@ -556,12 +562,12 @@ async def test_stalled_deferred_small_body_times_out() -> None:
         responses.text(w, "ok")
 
     app.post("/", handler)
-    proto, app, transport = _attach(app=app, header_timeout=0.01)
+    proto, app, transport = _attach(app=app, header_timeout=_TIMEOUT)
     try:
         proto.data_received(
             b"POST / HTTP/1.1\r\nHost: t\r\nContent-Length: 8\r\n\r\n"
         )
-        await asyncio.sleep(0.03)
+        await asyncio.sleep(_WAIT)
         assert transport.is_closing()
         assert hits == 0
     finally:
@@ -579,13 +585,13 @@ async def test_complete_request_does_not_keep_header_timer() -> None:
 
     app.get("/", handler)
     proto, app, transport = _attach(
-        app=app, header_timeout=0.01, keep_alive_timeout=5.0
+        app=app, header_timeout=_TIMEOUT, keep_alive_timeout=5.0
     )
     try:
         proto.data_received(b"GET / HTTP/1.1\r\nHost: t\r\n\r\n")
         await _drain(app)
         assert response_status(transport.writes) == 200
-        await asyncio.sleep(0.03)
+        await asyncio.sleep(_WAIT)
         assert not transport.is_closing()
     finally:
         if not transport.is_closing():
@@ -602,14 +608,14 @@ async def test_idle_keep_alive_times_out() -> None:
 
     app.get("/", handler)
     proto, app, transport = _attach(
-        app=app, header_timeout=5.0, keep_alive_timeout=0.01
+        app=app, header_timeout=5.0, keep_alive_timeout=_TIMEOUT
     )
     try:
         proto.data_received(b"GET / HTTP/1.1\r\nHost: t\r\n\r\n")
         await _drain(app)
         assert response_status(transport.writes) == 200
         assert not transport.is_closing()
-        await asyncio.sleep(0.03)
+        await asyncio.sleep(_WAIT)
         assert transport.is_closing()
     finally:
         if not transport.is_closing():
@@ -629,11 +635,11 @@ async def test_in_flight_handler_is_not_header_timed_out() -> None:
         responses.text(w, "ok")
 
     app.get("/", handler)
-    proto, app, transport = _attach(app=app, header_timeout=0.01)
+    proto, app, transport = _attach(app=app, header_timeout=_TIMEOUT)
     try:
         proto.data_received(b"GET / HTTP/1.1\r\nHost: t\r\n\r\n")
         await started.wait()
-        await asyncio.sleep(0.03)
+        await asyncio.sleep(_WAIT)
         assert not transport.is_closing()
     finally:
         hang.set()
@@ -645,8 +651,7 @@ async def test_in_flight_handler_is_not_header_timed_out() -> None:
 @pytest.mark.asyncio
 async def test_stalled_chunked_body_returns_408() -> None:
     """Chunked / large bodies dispatch at headers-complete. A stalled
-    ``body()`` wait must 408 via the shared connection sweeper (or the
-    callback stall handle), not hang the handler.
+    ``body()`` wait must 408 via the shared connection sweeper, not hang.
     """
     app = App()
 
@@ -656,14 +661,14 @@ async def test_stalled_chunked_body_returns_408() -> None:
 
     app.post("/", handler)
     proto, app, transport = _attach(
-        app=app, body_timeout=0.02, header_timeout=5.0
+        app=app, body_timeout=_TIMEOUT, header_timeout=5.0
     )
     try:
         proto.data_received(
             b"POST / HTTP/1.1\r\nHost: t\r\nTransfer-Encoding: chunked\r\n\r\n"
             b"5\r\nhello"
         )
-        await asyncio.sleep(0.08)
+        await asyncio.sleep(_WAIT)
         await _drain(app)
         assert response_status(transport.writes) == 408
     finally:

--- a/tests/cython/test_hardening.py
+++ b/tests/cython/test_hardening.py
@@ -643,6 +643,55 @@ async def test_in_flight_handler_is_not_header_timed_out() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stalled_chunked_body_returns_408() -> None:
+    """Chunked / large bodies dispatch at headers-complete. A stalled
+    ``body()`` wait must 408 via the shared connection sweeper (or the
+    callback stall handle), not hang the handler.
+    """
+    app = App()
+
+    async def handler(c, w) -> None:
+        await c.req.body()
+        responses.text(w, "ok")
+
+    app.post("/", handler)
+    proto, app, transport = _attach(
+        app=app, body_timeout=0.02, header_timeout=5.0
+    )
+    try:
+        proto.data_received(
+            b"POST / HTTP/1.1\r\nHost: t\r\nTransfer-Encoding: chunked\r\n\r\n"
+            b"5\r\nhello"
+        )
+        await asyncio.sleep(0.08)
+        await _drain(app)
+        assert response_status(transport.writes) == 408
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_timeout_sweeper_is_one_task_per_connection_set() -> None:
+    from stario_cython.timeouts import timeout_cleanup_mode
+
+    if timeout_cleanup_mode() != "sweep":
+        pytest.skip("default cleanup is the connection sweeper")
+    proto, app, transport = _attach(header_timeout=5.0)
+    try:
+        loop = asyncio.get_running_loop()
+        sweeps = getattr(loop, "_stario_timeout_sweeps", None)
+        assert sweeps, "connection_made should start a sweeper"
+        live = [task for task in sweeps.values() if task is not None and not task.done()]
+        assert len(live) == 1
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
 async def test_pipeline_cap_rejects_ninth_queued_request() -> None:
     app = App()
     release = asyncio.Event()

--- a/tests/cython/test_headers_writer.py
+++ b/tests/cython/test_headers_writer.py
@@ -5,8 +5,8 @@ import brotli
 import pytest
 from stario_cython.headers import Headers
 
-from stario import App
 import stario.cookies as cookies
+from stario import App
 from stario.exceptions import StarioError, StarioRuntime
 from stario.http.compression import CompressionConfig
 from stario.http.headers import Headers as PublicHeaders

--- a/tests/cython/test_protocol.py
+++ b/tests/cython/test_protocol.py
@@ -84,6 +84,51 @@ async def test_plaintext_and_post_and_keepalive() -> None:
 
 
 @pytest.mark.asyncio
+async def test_small_content_length_body_is_complete_when_handler_runs() -> None:
+    """Content-Length bodies <= 64KiB dispatch after llhttp finishes the message."""
+    loop = asyncio.get_running_loop()
+    app = App()
+
+    async def echo(c, w):
+        # Deferred dispatch: body() is already complete (no Event wait).
+        payload = await c.req.body()
+        assert payload == b"x" * 1024
+        w.respond(payload, b"text/plain; charset=utf-8")
+
+    app.post("/echo", echo)
+    connections: set[HttpProtocol] = set()
+    server = await loop.create_server(
+        lambda: HttpProtocol(
+            loop,
+            app,
+            NoOpTracer(),
+            [b"date: Tue, 18 Aug 2026 00:00:00 GMT\r\n"],
+            CompressionConfig(),
+            connections,
+        ),
+        "127.0.0.1",
+        free_port(),
+    )
+    port = server.sockets[0].getsockname()[1]
+    payload = b"x" * 1024
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(
+            b"POST /echo HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Content-Length: 1024\r\n\r\n" + payload
+        )
+        await writer.drain()
+        response = await read_response(reader)
+        assert payload in response
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
 async def test_fragmented_headers_materialize_correctly() -> None:
     loop = asyncio.get_running_loop()
     app = App()
@@ -714,9 +759,11 @@ async def test_exchange_pool_reuses_across_connections() -> None:
 
 @pytest.mark.asyncio
 async def test_handler_starts_before_content_length_body_arrives() -> None:
+    """Bodies larger than 64KiB still dispatch at headers-complete."""
     loop = asyncio.get_running_loop()
     app = App()
     started = asyncio.Event()
+    payload = b"x" * (65 * 1024)
 
     async def echo(c, w):
         started.set()
@@ -743,13 +790,15 @@ async def test_handler_starts_before_content_length_body_arrives() -> None:
         writer.write(
             b"POST /echo HTTP/1.1\r\n"
             b"Host: localhost\r\n"
-            b"Content-Length: 5\r\n\r\n"
+            b"Content-Length: "
+            + str(len(payload)).encode("ascii")
+            + b"\r\n\r\n"
         )
         await writer.drain()
         await asyncio.wait_for(started.wait(), timeout=1.0)
-        writer.write(b"hello")
+        writer.write(payload)
         await writer.drain()
-        assert b"hello" in await read_response(reader)
+        assert payload in await read_response(reader)
         writer.close()
         await writer.wait_closed()
     finally:
@@ -786,7 +835,7 @@ async def test_body_wait_survives_multi_segment_upload() -> None:
     port = server.sockets[0].getsockname()[1]
     try:
         reader, writer = await asyncio.open_connection("127.0.0.1", port)
-        payload = b"abcdefghij" * 1000  # 10 KiB
+        payload = b"abcdefghij" * 7000  # 70 KiB: above the small-body deferral cap
         writer.write(
             b"POST /echo HTTP/1.1\r\n"
             b"Host: localhost\r\n"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`cython-core` parses with llhttp but small POSTs still blocked `body()` on an `asyncio.Event` nested in `llhttp_execute`, and connection timeouts were two mechanisms (per-connection `TimerHandle` + stall `call_later` on every chunk). This PR ships the hot path from closed PR #33 **and** one timeout cleanup: store deadlines, sweep the live set, call `loop.time()` once per wake.

App/Router stay Python.

## All servers (this host)

Median req/s ± sample stdev. Official knobs, one worker. **Not** one sequential suite: Stario `20260828T193136Z`; Granian / Socketify / Robyn / Django-Bolt `20260828T183308Z`; BlackSheep+Granian `20260828T180757Z`. Sorted by plaintext. Bold is best in that column. Granian is RSGI, no framework. Robyn and Django-Bolt buffer the stream route.

| Server | Plaintext | JSON | Params | Validate | Form | JSON 1KB | 64KB | 2MB buf | 2MB stream | Multipart |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Granian RSGI | **146,875 ± 713** | **144,111 ± 269** | **146,201 ± 3,838** | 106,610 ± 1,068 | 118,928 ± 1,581 | **114,517 ± 1,516** | 31,212 ± 198 | 1,429 ± 12 | 3,108 ± 20 | 3,138 ± 77 |
| Stario Cython | 132,903 ± 3,484 | 133,817 ± 7,033 | 126,707 ± 5,128 | **112,068 ± 4,145** | **123,813 ± 1,677** | 110,946 ± 4,462 | **37,772 ± 487** | **3,441 ± 20** | 3,652 ± 16 | **3,563 ± 99** |
| Socketify | 122,497 ± 62 | 103,563 ± 332 | 79,977 ± 812 | 13,267 ± 66 | 19,556 ± 195 | 13,293 ± 179 | 12,365 ± 220 | 674 ± 20 | **4,062 ± 74** | 663 ± 6 |
| BlackSheep+Granian | 113,487 ± 627 | 102,801 ± 10,478 | 105,259 ± 1,539 | 42,628 ± 37 | 46,420 ± 496 | 42,622 ± 246 | 21,029 ± 91 | 1,214 ± 26 | 3,155 ± 53 | 1,228 ± 35 |
| Stario Python | 74,752 ± 274 | 72,983 ± 1,742 | 70,804 ± 95 | 56,566 ± 619 | 60,305 ± 106 | 55,945 ± 431 | 20,065 ± 202 | 1,981 ± 33 | 2,969 ± 7 | 2,007 ± 80 |
| Django-Bolt | 30,071 ± 147 | 31,946 ± 168 | 30,310 ± 255 | 25,585 ± 184 | 26,272 ± 157 | 26,252 ± 953 | 20,037 ± 1,936 | 1,499 ± 11 | 1,478 ± 14 | 1,488 ± 20 |
| Robyn | 25,780 ± 74 | 25,206 ± 64 | 19,351 ± 49 | 18,382 ± 60 | 4,721 ± 5 | 18,270 ± 52 | 15,629 ± 32 | 735 ± 48 | 751 ± 13 | 498 ± 37 |

## Current Cython (`cython-core`) vs this branch

Sequential, same host. Unmodified `cython-core` `f80d6f0` (`20260828T153450Z`) → this branch (`20260828T154518Z`).

| Endpoint | Current (`cython-core`) | This branch | Ratio |
| --- | ---: | ---: | ---: |
| Plaintext | 125,495 ± 879 | 130,032 ± 602 | **1.04×** |
| JSON | 121,997 ± 2,671 | 119,338 ± 4,601 | 0.98× |
| Params | 117,005 ± 211 | 122,350 ± 1,991 | **1.05×** |
| Validate JSON | 67,425 ± 512 | 106,918 ± 1,108 | **1.59×** |
| Form POST | 75,089 ± 1,124 | 126,328 ± 3,486 | **1.68×** |
| JSON 1KB | 68,866 ± 93 | 108,776 ± 781 | **1.58×** |
| Octet 64KB | 22,013 ± 390 | 37,948 ± 406 | **1.72×** |
| Octet 2MB (buffer) | 3,004 ± 14 | 3,172 ± 71 | **1.06×** |
| Octet 2MB (stream) | 3,435 ± 48 | 3,391 ± 120 | 0.99× |
| Multipart 2MB | 2,998 ± 59 | 3,178 ± 18 | **1.06×** |

Small POST and the 64KiB fixture are the move. GET / 2MB stream are noise. Timeouts did not kill plaintext (**+3.6%**).

## Current Python Stario vs this Cython

Same suite `20260828T193136Z`. Python: `stario.cli serve` + httptools. Cython: `python -m stario_cython` + llhttp. GET ~**1.8×**. Small POST ~**2.0×** (was ~1.2× on 27 Aug).

## What lands

- Skip `NoOpSpan` start/attrs/fail/end in `App.__call__`.
- Defer Content-Length bodies ≤64KiB until `message_complete`.
- Arena URL cache; eager-start `App.__call__`; `-fno-strict-aliasing`.
- **One timeout sweep on the Date tick (1s).** Header / idle / body-stall 5s / 5s / 30s. Idle only when idle. Body stall is a generation counter.
- Pipeline cap 8. `STARIO_CYTHON_TIMEOUTS=off` hatch.

## Decisions

| Question | Decision | Why |
| --- | --- | --- |
| Callbacks vs sweep | **Sweep** | wrk wash on plaintext (~1%); one mechanism |
| Extra 10ms sweeper | **No** | −7% on 2MB stream |
| Extra 50ms sweeper vs Date tick (1s) | **Date tick** | wrk wash; Date refresh already wakes once a second |
| Compile timeouts out | **No** | off is only ~+5% plaintext |
| Cythonize App/Router | **No** | PR #28 |
| Static / pre-serialized handlers | **No** | official suite policy |

## Tests

`pytest tests`: **750 passed**.

Lab log: [`benchmarks/server/baseline-20260828.md`](benchmarks/server/baseline-20260828.md). Short copy: [`CYTHON.md`](CYTHON.md).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fcc1a61-0f01-495e-8856-122942958736?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fcc1a61-0f01-495e-8856-122942958736&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

