### PR TITLE
PoC: Cython App/Router + sync GET (ahead of Granian plaintext)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Added
 
-- **PoC:** Cython `Router` + `App` (`stario_cython.router` / `stario_cython.app`) used by `python -m stario_cython`. Hostless exact routes use a static method map; parameterized routes keep a nested match cache and walk path/host in place. Set `STARIO_CYTHON_PYTHON_APP=1` to keep the Python App on the Cython protocol (benchmark baseline). `benchmarks/server/run.sh` target `stario-cython-pyapp` does that.
+- **PoC:** Cython `Router` + `App` (`stario_cython.router` / `stario_cython.app`) used by `python -m stario_cython`. Hostless exact routes use a static method map; parameterized routes keep a nested match cache and walk path/host in place. Set `STARIO_CYTHON_PYTHON_APP=1` to keep the Python App on the Cython protocol (benchmark baseline). `benchmarks/server/run.sh` target `stario-cython-pyapp` does that. Same-host capture: [`baseline-20260828-app-router.md`](benchmarks/server/baseline-20260828-app-router.md) (~5% GET vs Python App; Granian RSGI still ~11% ahead on plaintext).
 
 ## 4.1.0 - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## Unreleased
 
+### Added
+
+- **PoC:** Cython `Router` + `App` (`stario_cython.router` / `stario_cython.app`) used by `python -m stario_cython`. Hostless exact routes use a static method map; parameterized routes keep a nested match cache and walk path/host in place. Set `STARIO_CYTHON_PYTHON_APP=1` to keep the Python App on the Cython protocol (benchmark baseline). `benchmarks/server/run.sh` target `stario-cython-pyapp` does that.
+
 ## 4.1.0 - 2026-08-17
 
 ### Added

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -93,7 +93,8 @@ server cannot be reused by accident.
 | Target | Server |
 | --- | --- |
 | `stario` | Python httptools protocol |
-| `stario-cython` | Cython llhttp protocol (`cython-core`) |
+| `stario-cython` | Cython llhttp protocol + Cython App/Router (`cython-core`) |
+| `stario-cython-pyapp` | Cython llhttp + Python App (`STARIO_CYTHON_PYTHON_APP=1`) |
 
 **Native HTTP servers**
 
@@ -257,8 +258,10 @@ Each run writes a timestamped directory under `benchmarks/server/results/`:
 - `config.txt` — run settings.
 
 A committed reference baseline (hardware, methodology, Python vs Cython tables)
-lives at `benchmarks/server/baseline-20260827.md`. The previous capture with
-native/ASGI competitor rows is `benchmarks/server/baseline-20260824.md`.
+lives at `benchmarks/server/baseline-20260827.md`. Cython App/Router vs Python
+App vs Granian RSGI is `benchmarks/server/baseline-20260828-app-router.md`.
+The previous capture with native/ASGI competitor rows is
+`benchmarks/server/baseline-20260824.md`.
 Timestamped `results/` dirs remain gitignored.
 
 Successful runs keep only `summary.md` and `config.txt` by default. Use

--- a/benchmarks/server/apps/stario_app.py
+++ b/benchmarks/server/apps/stario_app.py
@@ -13,15 +13,15 @@ def json_response(w, value, status: int = 200) -> None:
     w.respond(ujson.dumps(value).encode("utf-8"), JSON_CONTENT_TYPE, status)
 
 
-async def plaintext(c, w):
+def plaintext(c, w):
     responses.text(w, HELLO)
 
 
-async def json_endpoint(c, w):
+def json_endpoint(c, w):
     json_response(w, {"message": HELLO})
 
 
-async def get_user(c, w):
+def get_user(c, w):
     user_id = c.route.params["user_id"]
     json_response(w, {"id": user_id, "name": f"User {user_id}"})
 

--- a/benchmarks/server/baseline-20260828-app-router.md
+++ b/benchmarks/server/baseline-20260828-app-router.md
@@ -1,0 +1,82 @@
+# Server benchmark: Cython App/Router PoC (2026-08-28)
+
+Relative numbers on one host — not lab-grade absolutes. Sequential suite
+`20260828T210831Z` on commit `6616720` (`cursor/cython-app-router-poc-b193`).
+
+Three targets only:
+
+| Target | Stack |
+| --- | --- |
+| `stario-cython-pyapp` | Cython llhttp + **Python** App/Router (`STARIO_CYTHON_PYTHON_APP=1`) |
+| `stario-cython` | Cython llhttp + **Cython** App/Router (this branch) |
+| `granian-rsgi` | Granian RSGI, no framework |
+
+Same protocol binary for the two Stario rows. The only variable is App/Router.
+
+## Reproduce
+
+```bash
+WRK=wrk PYTHON=3.14 RUNS=5 WARMUP=1 DURATION=10s THREADS=2 \
+  CONNECTIONS=128 UPLOAD_CONNECTIONS=32 ENDPOINT_TIER=all \
+  benchmarks/server/run.sh stario-cython-pyapp stario-cython granian-rsgi
+```
+
+## Environment
+
+| | |
+|---|---|
+| CPU | Intel Xeon (KVM), x86_64 |
+| OS | Linux 6.12.94+ |
+| Python | 3.14.7 |
+| Client | wrk 4.2.0, `-t2 -c128` (read/small upload), `-c32` (64KB/2MB) |
+| Topology | wrk and servers on same host, `127.0.0.1` loopback |
+| Commit | `6616720` |
+| Run | `20260828T210831Z` |
+
+## Methodology
+
+Official suite knobs: **5 measured + 1 warmup**, `DURATION=10s`, IQR trimming.
+One worker. Handlers compute responses per request.
+
+## Cython App vs Python App (same llhttp protocol)
+
+| Endpoint | Python App | Cython App | Cython / Python |
+| --- | ---: | ---: | ---: |
+| Plaintext | 129,546 ± 1,234 | 136,005 ± 1,885 | **1.05×** |
+| JSON | 126,669 ± 757 | 129,740 ± 2,188 | 1.02× |
+| Params | 119,373 ± 2,553 | 126,230 ± 836 | **1.06×** |
+| Validate JSON | 104,429 ± 1,330 | 111,633 ± 4,893 | **1.07×** |
+| Form POST | 127,101 ± 3,516 | 129,556 ± 2,880 | 1.02× |
+| JSON 1KB | 117,458 ± 4,112 | 113,879 ± 5,955 | 0.97× |
+| Octet 64KB | 38,242 ± 241 | 39,349 ± 2,664 | 1.03× |
+| Octet 2MB (buffer) | 3,495 ± 49 | 3,493 ± 56 | 1.00× |
+| Octet 2MB (stream) | 3,658 ± 6 | 3,526 ± 74 | 0.96× |
+| Multipart 2MB | 3,624 ± 34 | 3,469 ± 66 | 0.96× |
+
+GET `/plaintext` and `/user/{id}` pick up **~5%**. Validate is **~7%**. Large
+body paths sit in run-to-run noise (JSON 1KB stdev is 4–6k req/s). Compiling
+App/Router is real on the header-dispatch path and does not move 2MB ingest.
+
+## vs Granian RSGI
+
+| Endpoint | Cython App | Granian RSGI | Granian / Cython App |
+| --- | ---: | ---: | ---: |
+| Plaintext | 136,005 ± 1,885 | **151,270 ± 4,067** | **1.11×** |
+| JSON | 129,740 ± 2,188 | **150,927 ± 2,728** | **1.16×** |
+| Params | 126,230 ± 836 | **150,602 ± 6,209** | **1.19×** |
+| Validate JSON | **111,633 ± 4,893** | 103,908 ± 677 | 0.93× |
+| Form POST | **129,556 ± 2,880** | 119,612 ± 966 | 0.92× |
+| JSON 1KB | **113,879 ± 5,955** | 108,588 ± 499 | 0.95× |
+| Octet 64KB | **39,349 ± 2,664** | 31,869 ± 212 | 0.81× |
+| Octet 2MB (buffer) | **3,493 ± 56** | 1,470 ± 8 | 0.42× |
+| Octet 2MB (stream) | **3,526 ± 74** | 3,230 ± 53 | 0.92× |
+| Multipart 2MB | **3,469 ± 66** | 3,141 ± 98 | 0.91× |
+
+Granian remains **~11–19%** ahead on GET. That gap is not App/Router: Python
+App → Cython App closed about a third of a 15k plaintext delta (129.5k →
+136.0k vs Granian 151.3k). Remaining GET cost is more likely the App
+wrapper coroutine, `responses.text`/`ujson` from Python, and protocol
+`create_task` / writer framing.
+
+Stario already leads Granian on validate, form, and all upload/body cases
+in this run (same as the 2026-08-28 Cython protocol snapshot).

--- a/benchmarks/server/baseline-20260828-app-router.md
+++ b/benchmarks/server/baseline-20260828-app-router.md
@@ -83,3 +83,5 @@ in this run (same as the 2026-08-28 Cython protocol snapshot).
 
 Profiler follow-up (what would close the remaining GET gap):
 [`baseline-20260829-granian-gap.md`](baseline-20260829-granian-gap.md).
+Sync GET handlers + `dispatch_exchange` later crossed ahead of Granian on
+plaintext in `20260829T062337Z` / `20260829T062546Z` (see that note).

--- a/benchmarks/server/baseline-20260828-app-router.md
+++ b/benchmarks/server/baseline-20260828-app-router.md
@@ -80,3 +80,6 @@ wrapper coroutine, `responses.text`/`ujson` from Python, and protocol
 
 Stario already leads Granian on validate, form, and all upload/body cases
 in this run (same as the 2026-08-28 Cython protocol snapshot).
+
+Profiler follow-up (what would close the remaining GET gap):
+[`baseline-20260829-granian-gap.md`](baseline-20260829-granian-gap.md).

--- a/benchmarks/server/baseline-20260829-granian-gap.md
+++ b/benchmarks/server/baseline-20260829-granian-gap.md
@@ -1,0 +1,220 @@
+# What would beat Granian on GET `/plaintext`
+
+Profiler notes on commit `9e428a3` plus follow-up captures on
+`cursor/cython-app-router-poc-b193`. Official suite numbers stay in
+[`baseline-20260828-app-router.md`](baseline-20260828-app-router.md).
+
+The remaining Granian lead on tiny GET is **not I/O and not the router**.
+Stario already does **one `read` + one `writev` per request**. Granian pays
+extra `write` / `futex` / `epoll` for a Rust→Python thread hop and still
+wins because each Stario request spends ~700–900 ns more in Python/Cython
+userspace: `asyncio.Task` + the App coroutine + the handler coroutine.
+
+## The gap
+
+Official sequential suite (`20260828T210831Z`, `RUNS=5`, `DURATION=10s`):
+
+| | req/s | ns/req |
+| --- | ---: | ---: |
+| Stario Cython App | 136,005 | ~7,350 |
+| Granian RSGI | 151,270 | ~6,610 |
+| **Gap** | **~11%** | **~740 ns** |
+
+Cython App/Router already closed about a third of the previous plaintext
+delta (Python App 129.5k → 136.0k). Stario **leads** Granian on validate,
+form, and every upload/body route in that run. This note is only about
+jumping GET `/plaintext` / `/json` / `/user/{id}`.
+
+## How Granian spends a request
+
+Granian 2.8.2 RSGI, `--workers 1 --runtime-threads 1 --loop uvloop`:
+
+1. **Rust thread** parses HTTP (httparse/hyper) and writes the response.
+2. It wakes **uvloop** with `call_soon_threadsafe` / `uv_async_send`
+   (`granian/_futures.py` `_cbsched_schedule`).
+3. uvloop runs `future_watcher` → one `async def app(scope, proto)` with
+   `if path == "/plaintext"` → `proto.response_str(...)`.
+4. No framework App/Router. No `asyncio.Task` per request — a stub
+   `_CBSchedulerTask` plus Rust `CallbackScheduler._run`.
+
+py-spy on the spawn worker (need `--idle` and the `spawn_main` child, not
+the resource tracker): uvloop thread ~44% `epoll_pwait`, ~20%
+`future_watcher` / app; Rust thread ~46% `syscall` plus `sched_yield` /
+`call_soon_threadsafe`.
+
+## How Stario spends a request
+
+Keep-alive GET `/plaintext` finishes **on the `data_received` stack**
+(`eager_start=True`). Then uvloop `writev`s the 8-buffer `writelines`
+tuple. py-spy native (no GIL filter, 12 s wrk, ~137k req/s):
+
+| Unique samples | What |
+| --- | --- |
+| **51.5% `writev`** | one syscall per response (`uv__try_write`) |
+| **19.3% `read`** | one syscall per request |
+| **3.0% `epoll_pwait`** | idle/wait |
+| **23.5% `data_received`** | parse + dispatch + App + handler + `respond` |
+
+`writev` ∩ `data_received` = 0%. Two phases: handle on read, send later.
+
+Under `data_received` (~23.5% of wall ≈ **~1.7 µs**, matches the FakeTransport
+keepalive microbench):
+
+| Frame / file | Unique % of wall | Notes |
+| --- | ---: | --- |
+| `create_task` | 19.0% | entire Task+App+handler+respond |
+| `plaintext` handler | 10.2% | includes `text` + `respond` |
+| `responses.text` | 8.7% | Python helper |
+| `respond` | 7.8% | Cython `RequestExchange.respond` |
+| `writelines` | 4.7% | uvloop queue (not the syscall) |
+| `Router_find_handler` | **1.5%** | done |
+
+cProfile on the same keepalive path only sees Python: `responses.text` and
+`str.encode`. Cython/Task/llhttp are invisible — do not use cProfile alone.
+
+## Syscalls (strace, ratios still valid even though strace tanks absolute req/s)
+
+Per request during wrk `-c128` GET `/plaintext`:
+
+| | Stario | Granian worker |
+| --- | ---: | ---: |
+| `read` / `recvfrom` | **1.00** | **1.00** `recvfrom` |
+| `writev` | **1.00** | **1.00** |
+| extra `write` | 0 | **~1.07** (async wake / eventfd) |
+| `futex` | 0 | **~0.86** |
+| `epoll_pwait` | ~0.008 | **~0.13** |
+| `sched_yield` | 0 | **~0.18** |
+
+Stario is the cheaper I/O shape. Chasing `writev` coalescing or a Rust HTTP
+core will not close a 740 ns userspace gap; Granian already does *more*
+syscalls per GET and still wins.
+
+## Microbench (uvloop, FakeTransport keepalive)
+
+`PYTHONPATH=src:. .venv/bin/python benchmarks/server/profile_plaintext.py`
+
+| Piece | ns |
+| ---: | ---: |
+| router static `/plaintext` | 57 |
+| `str.encode("Hello, World!")` | 23 |
+| empty coroutine alloc | 53 |
+| `asyncio.Task` empty eager | **303** |
+| `responses.text` DummyWriter | 396 |
+| handler `send` + `find_handler` (no App) | 665 |
+| App `send` DummyWriter (no Task) | 1002 |
+| App+Task DummyWriter `text` | 1278 |
+| protocol keepalive GET `/plaintext` | **1525–1730** |
+
+Additive:
+
+- **Task ≈ 280–300 ns** (1278 − 1002)
+- **App `__call__` wrapper ≈ 340 ns** (1002 − 665) — try/except/finally,
+  type checks, `await handler`
+- **handler coroutine vs `text()` ≈ 270 ns** (665 − 396)
+- **llhttp + real `respond` + recycle ≈ 250–410 ns** vs dummy
+
+Task + App wrapper ≈ **620 ns**. That is most of the 740 ns Granian gap.
+Dropping the inner `async def` as well (~270 ns) overshoots.
+
+## What would jump ahead (ranked)
+
+### 1. Do not allocate `asyncio.Task` on non-suspending GET (~300 ns)
+
+`HttpProtocol._start_exchange` always does `asyncio.Task(app(...), eager_start=True)`
+even when the handler never awaits. The Task is `.done()` before
+`_start_exchange` returns; the object still costs ~300 ns.
+
+**Do not** hand-roll `coro.send(None)` + a home-grown resume. A first
+`send()` that yields must follow `asyncio.Task.__step` exactly
+(`_asyncio_future_blocking`, bare `yield` from `asyncio.sleep(0)`,
+`send(None)` not `send(result)`, `c.alive()` / cancel, pipelined recycle).
+A partial clone 500s streaming POST, breaks `sleep(0)` pipeline tests, and
+deadlocks `connection_lost` + `c.alive()`.
+
+Cleaner shapes:
+
+- Keep `asyncio.Task` as the suspend path. For the complete-immediately
+  case, drive with the same stepper CPython uses, or
+- Register **sync** handlers (`def plaintext(c, w)` / cdef) and call them
+  from `_start_exchange` with no Task and no App coroutine.
+
+Either path should land ~5–8k req/s on this host if the rest stays equal
+(~141–144k). Still behind Granian alone.
+
+### 2. Flatten App `__call__` off the hot path (~340 ns)
+
+`App.__call__` is a coroutine: trailing-slash 308, `find_handler`,
+`await handler`, “handler forgot to respond”, error handlers, `finally: end()`.
+On GET `/plaintext` that is a second generator plus try/except for work that
+is already a cdef lookup.
+
+Move routing + `end()`/`abort()` into a **cdef protocol callback**. Keep
+`async def __call__` for the Python httptools server and for handlers that
+suspend. Combined with (1) this is roughly **match Granian** on plaintext
+(~620 ns of the ~740 ns gap).
+
+### 3. Sync (or cdef) handlers (~270 ns more → ahead)
+
+Benchmark `async def plaintext` only exists so `await handler` has something
+to await. `responses.text` is synchronous. Granian’s app is still `async def`
+but it is **one** coroutine, not App + handler.
+
+`def plaintext(c, w): responses.text(w, HELLO)` called from C skips the
+inner generator. (1)+(2)+(3) is ~890 ns — enough to go **through** Granian
+on this box if I/O stays 1×`writev`.
+
+Fair vs handler policy: still encode `"Hello, World!"` every request; do not
+pre-serialize the body.
+
+### 4. Cheaper `respond` / `responses.text` (100–300 ns, second wave)
+
+`responses.text` is still Python. `respond()` builds an 8-tuple of interned
+buffers (`STATUS_200`, date box, `CT_PREFIX`, …) and `writelines`. Header
+**templates** (not cached body bytes) are fair under
+`benchmarks/README.md` handler policy. Joining the header block into 1–2
+iovecs is optional; strace already shows a single `writev`. The win is fewer
+Python tuple/object ops, not fewer syscalls.
+
+Pre-encoded `HELLO_B` vs `text()` was only ~55 ns in the DummyWriter
+microbench. Encode is not the gap.
+
+### 5. Do not spend more on Router, registration, or `Request.host`
+
+57 ns static match, 1.5% of wall. Host routing is unused on this bench.
+`handle` / `use` is cold.
+
+### 6. Do not rewrite HTTP in Rust to beat this GET
+
+Granian’s Rust I/O is why they can afford a thread hop and a slower syscall
+mix. Stario’s uvloop path is already 1 read + 1 writev. The GET deficit is
+Python scheduling, not libuv.
+
+A native HTTP core is a different product goal (HTTP/2, TLS, multi-thread).
+It is not the 740 ns plaintext lever.
+
+## Suggested order of work
+
+1. **Sync/cdef dispatch on the protocol callback** for handlers that do not
+   suspend: no Task, no App coroutine, no inner `async def`. Biggest jump,
+   one design, avoids cloning `Task.__step`.
+2. Keep `asyncio.Task(eager_start=True)` for `await req.body()` / streaming /
+   `c.alive()`.
+3. Optionally cdef `responses.text` or inline encode+`respond` for the
+   helper.
+4. Re-measure only GET `/plaintext`, `/json`, `/user/{id}` against Granian
+   RSGI with the same wrk knobs as the official suite.
+
+## Reproduce the profiles
+
+```bash
+# Isolate userspace pieces (needs tests/ on PYTHONPATH):
+PYTHONPATH=src:. .venv/bin/python benchmarks/server/profile_plaintext.py
+
+# Live wrk + py-spy (Stario + Granian). Granian needs --idle and the
+# spawn_main worker PID; --nonblocking produced empty captures.
+DURATION=12s PROFILE_PYTHON=1 benchmarks/server/profile_load.sh
+```
+
+Python-only py-spy (no `--native`) attributes almost everything to
+`uvloop.run` / `responses.text` because App/protocol are compiled. Use
+`--native` for Cython frames.

--- a/benchmarks/server/baseline-20260829-granian-gap.md
+++ b/benchmarks/server/baseline-20260829-granian-gap.md
@@ -4,11 +4,15 @@ Profiler notes on commit `9e428a3` plus follow-up captures on
 `cursor/cython-app-router-poc-b193`. Official suite numbers stay in
 [`baseline-20260828-app-router.md`](baseline-20260828-app-router.md).
 
-The remaining Granian lead on tiny GET is **not I/O and not the router**.
+The remaining Granian lead on tiny GET was **not I/O and not the router**.
 Stario already does **one `read` + one `writev` per request**. Granian pays
 extra `write` / `futex` / `epoll` for a Rust→Python thread hop and still
-wins because each Stario request spends ~700–900 ns more in Python/Cython
+won because each Stario request spent ~700–900 ns more in Python/Cython
 userspace: `asyncio.Task` + the App coroutine + the handler coroutine.
+
+That path is now implemented: **`App.dispatch` / `dispatch_exchange`** for
+sync handlers. Measured GET plaintext **crossed ahead** of Granian RSGI on
+this host (see [Measured](#measured-sync-get-dispatch-vs-granian)).
 
 ## The gap
 
@@ -118,7 +122,7 @@ Dropping the inner `async def` as well (~270 ns) overshoots.
 
 ## What would jump ahead (ranked)
 
-### 1. Do not allocate `asyncio.Task` on non-suspending GET (~300 ns)
+### 1. Do not allocate `asyncio.Task` on non-suspending GET (~300 ns) — **done**
 
 `HttpProtocol._start_exchange` always does `asyncio.Task(app(...), eager_start=True)`
 even when the handler never awaits. The Task is `.done()` before
@@ -192,17 +196,43 @@ Python scheduling, not libuv.
 A native HTTP core is a different product goal (HTTP/2, TLS, multi-thread).
 It is not the 740 ns plaintext lever.
 
-## Suggested order of work
+## Measured: sync GET dispatch vs Granian
 
-1. **Sync/cdef dispatch on the protocol callback** for handlers that do not
-   suspend: no Task, no App coroutine, no inner `async def`. Biggest jump,
-   one design, avoids cloning `Task.__step`.
-2. Keep `asyncio.Task(eager_start=True)` for `await req.body()` / streaming /
-   `c.alive()`.
-3. Optionally cdef `responses.text` or inline encode+`respond` for the
-   helper.
-4. Re-measure only GET `/plaintext`, `/json`, `/user/{id}` against Granian
-   RSGI with the same wrk knobs as the official suite.
+`App.dispatch` / `dispatch_exchange` run plain `def` handlers inline. The
+protocol does not allocate `asyncio.Task` when `dispatch` returns `None`.
+Benchmark GET `/plaintext`, `/json`, `/user/{id}` are now sync (`ujson` /
+`str.encode` still per request). POST stays `async def`.
+
+Same wrk knobs as the official App/Router suite (`RUNS=5 WARMUP=1 DURATION=10s
+THREADS=2 CONNECTIONS=128`). Sequential same-host runs; medians ± stdev after
+IQR trim.
+
+| Run | Stario plaintext | Granian plaintext | Stario / Granian |
+| --- | ---: | ---: | ---: |
+| Official App/Router (async GET, `20260828T210831Z`) | 136,005 | **151,270** | 0.90× |
+| Sync `dispatch` (`20260829T061538Z`) | 144,802 | **150,019** | 0.97× |
+| + `dispatch_exchange` (`20260829T062337Z`) | **152,836** | 150,095 | **1.02×** |
+| GET trio (`20260829T062546Z`) | **163,892** | 146,041 | **1.12×** |
+
+GET trio (`20260829T062546Z`, same knobs, `ENDPOINTS=plaintext,json,params`):
+
+| Endpoint | Stario | Granian RSGI | Stario / Granian |
+| --- | ---: | ---: | ---: |
+| Plaintext | **163,892 ± 3,512** | 146,041 ± 967 | **1.12×** |
+| JSON | **152,699 ± 4,089** | 151,269 ± 2,267 | 1.01× |
+| Params | **158,827 ± 1,004** | 150,484 ± 3,349 | **1.06×** |
+
+Same-host wrk moves around (plaintext 145k–164k across these runs). The
+direction is stable: skipping Task + App/handler coroutines on GET closed the
+~11% Granian lead and, with the RequestExchange-specialized `dispatch_exchange`,
+crossed ahead on this box.
+
+```bash
+RUNS=5 WARMUP=1 DURATION=10s THREADS=2 CONNECTIONS=128 \
+  ENDPOINTS=plaintext,json,params \
+  benchmarks/server/run.sh stario-cython granian-rsgi
+```
+
 
 ## Reproduce the profiles
 

--- a/benchmarks/server/profile_load.sh
+++ b/benchmarks/server/profile_load.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Profile Stario Cython and Granian RSGI on GET /plaintext under wrk.
+#
+# Native speedscope (default) + optional Python-only stacks:
+#   PROFILE_PYTHON=1 benchmarks/server/profile_load.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
+PYSPY="${PYSPY:-$ROOT/.venv/bin/py-spy}"
+if [[ ! -x "$PYSPY" ]]; then
+  PYSPY="$(command -v py-spy)"
+fi
+WRK="${WRK:-$(command -v wrk)}"
+OUT="${OUT:-$ROOT/benchmarks/server/results/profile-$(date -u +%Y%m%dT%H%M%SZ)}"
+STARIO_PY="${STARIO_PY:-$ROOT/benchmarks/server/.venvs/stario-cython/bin/python}"
+GRANIAN_PY="${GRANIAN_PY:-$ROOT/benchmarks/server/.venvs/granian-rsgi/bin/python}"
+HOST=127.0.0.1
+DURATION="${DURATION:-12s}"
+THREADS=2
+CONNECTIONS=128
+PROFILE_PYTHON="${PROFILE_PYTHON:-1}"
+RATE="${RATE:-400}"
+
+mkdir -p "$OUT"
+
+start_stario() {
+  local port="$1"
+  export STARIO_HOST="$HOST" STARIO_PORT="$port" STARIO_LOOP=uvloop STARIO_TRACER=noop
+  export STARIO_COMPRESS_ZSTD_LEVEL=-1 STARIO_COMPRESS_BROTLI_LEVEL=-1 STARIO_COMPRESS_GZIP_LEVEL=-1
+  unset STARIO_CYTHON_PYTHON_APP || true
+  (cd "$ROOT" && exec env PYTHONPATH="$ROOT/src:$ROOT/benchmarks/server" \
+    "$STARIO_PY" -m stario_cython apps.stario_app:bootstrap) \
+    >"$OUT/stario.server.log" 2>&1 &
+  echo $!
+}
+
+start_granian() {
+  local port="$1"
+  (cd "$ROOT/benchmarks/server" && exec "$GRANIAN_PY" -m granian apps.granian_rsgi_app:app \
+    --interface rsgi --host "$HOST" --port "$port" --workers 1 --runtime-threads 1 \
+    --loop uvloop --no-access-log --log-level warning) \
+    >"$OUT/granian.server.log" 2>&1 &
+  echo $!
+}
+
+wait_ready() {
+  local url="$1"
+  local deadline=$((SECONDS + 20))
+  until curl -fsS --max-time 1 "$url" >/dev/null 2>&1; do
+    if ((SECONDS >= deadline)); then
+      echo "not ready: $url" >&2
+      [[ -f "$OUT/stario.server.log" ]] && tail -20 "$OUT/stario.server.log" >&2 || true
+      [[ -f "$OUT/granian.server.log" ]] && tail -20 "$OUT/granian.server.log" >&2 || true
+      return 1
+    fi
+    sleep 0.05
+  done
+}
+
+# Granian may fork a worker; attach py-spy to the busiest child if present.
+resolve_profile_pid() {
+  local parent="$1"
+  local child
+  child="$(pgrep -P "$parent" 2>/dev/null | head -1 || true)"
+  if [[ -n "$child" ]]; then
+    echo "$child"
+  else
+    echo "$parent"
+  fi
+}
+
+spy_record() {
+  local pid="$1" dest="$2" extra=()
+  shift 2
+  extra=("$@")
+  # Do not use --nonblocking: it produced empty captures with --native.
+  "$PYSPY" record \
+    --pid "$pid" \
+    --subprocesses \
+    --gil \
+    --rate "$RATE" \
+    --duration "${DURATION%s}" \
+    --format speedscope \
+    --output "$dest" \
+    "${extra[@]}"
+}
+
+profile_one() {
+  local name="$1" parent_pid="$2" port="$3"
+  local pid
+  pid="$(resolve_profile_pid "$parent_pid")"
+  echo "== warmup $name parent=$parent_pid spy_pid=$pid =="
+  "$WRK" -t "$THREADS" -c "$CONNECTIONS" -d 3s "http://$HOST:$port/plaintext" >/dev/null
+  echo "== wrk+py-spy native $name =="
+  spy_record "$pid" "$OUT/$name.native.speedscope.json" --native &
+  local spy=$!
+  "$WRK" -t "$THREADS" -c "$CONNECTIONS" -d "$DURATION" "http://$HOST:$port/plaintext" \
+    | tee "$OUT/$name.wrk.txt"
+  wait "$spy" || true
+  if [[ "$PROFILE_PYTHON" == "1" ]]; then
+    echo "== wrk+py-spy python $name =="
+    spy_record "$pid" "$OUT/$name.python.speedscope.json" &
+    spy=$!
+    "$WRK" -t "$THREADS" -c "$CONNECTIONS" -d "$DURATION" "http://$HOST:$port/plaintext" \
+      | tee "$OUT/$name.python.wrk.txt"
+    wait "$spy" || true
+  fi
+}
+
+STARIO_PORT="${STARIO_PORT:-4011}"
+GRANIAN_PORT="${GRANIAN_PORT:-4012}"
+
+echo "Writing profiles to $OUT"
+SPID=$(start_stario "$STARIO_PORT")
+wait_ready "http://$HOST:$STARIO_PORT/plaintext"
+profile_one stario-cython "$SPID" "$STARIO_PORT"
+kill "$SPID" 2>/dev/null || true
+wait "$SPID" 2>/dev/null || true
+sleep 0.3
+
+GPID=$(start_granian "$GRANIAN_PORT")
+wait_ready "http://$HOST:$GRANIAN_PORT/plaintext"
+profile_one granian-rsgi "$GPID" "$GRANIAN_PORT"
+kill "$GPID" 2>/dev/null || true
+# granian worker children
+pkill -P "$GPID" 2>/dev/null || true
+wait "$GPID" 2>/dev/null || true
+
+echo "done: $OUT"
+ls -la "$OUT"

--- a/benchmarks/server/profile_plaintext.py
+++ b/benchmarks/server/profile_plaintext.py
@@ -1,0 +1,255 @@
+"""Isolate GET /plaintext costs on a running uvloop.
+
+    PYTHONPATH=src:. .venv/bin/python benchmarks/server/profile_plaintext.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+
+import uvloop
+
+import stario.responses as responses
+from stario_cython.app import App
+from stario_cython.router import Router
+from tests.cython.http import make_protocol
+from tests.helpers import DummyWriter, make_context
+
+HELLO = "Hello, World!"
+HELLO_B = HELLO.encode("utf-8")
+CT = b"text/plain; charset=utf-8"
+
+
+def _bench(name: str, fn: Callable[[], None], n: int) -> None:
+    fn()
+    t0 = time.perf_counter()
+    for _ in range(n):
+        fn()
+    dt = time.perf_counter() - t0
+    print(f"{name:52s}  {n / dt:10,.0f}/s   {1e9 * dt / n:7.0f} ns")
+
+
+async def _plain(_c, w) -> None:
+    responses.text(w, HELLO)
+
+
+async def _plain_bytes(_c, w) -> None:
+    w.respond(HELLO_B, CT, 200)
+
+
+async def _empty() -> None:
+    return None
+
+
+async def _nested() -> None:
+    await _empty()
+
+
+async def main() -> None:
+    loop = asyncio.get_running_loop()
+    print(f"loop {type(loop).__module__}.{type(loop).__name__}")
+
+    router = Router()
+    router.get("/plaintext", _plain)
+    router.get("/user/{user_id}", _plain)
+
+    _bench("router static /plaintext", lambda: router.find_handler("", "/plaintext", "GET"), 300_000)
+    _bench("router param /user/42", lambda: router.find_handler("", "/user/42", "GET"), 300_000)
+    _bench("str.encode Hello, World!", HELLO.encode, 300_000)
+
+    import ujson
+
+    def dumps() -> None:
+        ujson.dumps({"message": HELLO}).encode("utf-8")
+
+    _bench("ujson.dumps json body", dumps, 200_000)
+
+    n = 80_000
+    done = 0
+    t0 = time.perf_counter()
+    for _ in range(n):
+        t = asyncio.Task(_empty(), loop=loop, eager_start=True)
+        if t.done():
+            done += 1
+    dt = time.perf_counter() - t0
+    print(
+        f"{'asyncio.Task empty eager':52s}  {n / dt:10,.0f}/s   {1e9 * dt / n:7.0f} ns"
+        f"  (done={done}/{n})"
+    )
+
+    done = 0
+    t0 = time.perf_counter()
+    for _ in range(n):
+        t = asyncio.Task(_nested(), loop=loop, eager_start=True)
+        if t.done():
+            done += 1
+    dt = time.perf_counter() - t0
+    print(
+        f"{'asyncio.Task nested await eager':52s}  {n / dt:10,.0f}/s   {1e9 * dt / n:7.0f} ns"
+        f"  (done={done}/{n})"
+    )
+
+    def alloc_coro() -> None:
+        _empty().close()
+
+    _bench("alloc empty coroutine", alloc_coro, 300_000)
+
+    app = App()
+    app.get("/plaintext", _plain)
+    app.get("/plain-bytes", _plain_bytes)
+    ctx = make_context("/plaintext", app=app, loop=loop)
+    ctx_b = make_context("/plain-bytes", app=app, loop=loop)
+    dummy = DummyWriter()
+
+    async def call(ctx_obj) -> None:
+        dummy.started = False
+        dummy.ended = False
+        dummy._completed = False
+        dummy.status = None
+        dummy.body = None
+        dummy._status_code = None
+        await app(ctx_obj, dummy)
+
+    # Drive through the same Task path the protocol uses.
+    def call_text() -> None:
+        dummy.started = False
+        dummy.ended = False
+        dummy._completed = False
+        dummy.status = None
+        dummy.body = None
+        dummy._status_code = None
+        t = app.create_task(app(ctx, dummy), loop=loop, eager_start=True)
+        if not t.done():
+            raise RuntimeError("expected eager completion")
+
+    def call_bytes() -> None:
+        dummy.started = False
+        dummy.ended = False
+        dummy._completed = False
+        dummy.status = None
+        dummy.body = None
+        dummy._status_code = None
+        t = app.create_task(app(ctx_b, dummy), loop=loop, eager_start=True)
+        if not t.done():
+            raise RuntimeError("expected eager completion")
+
+    _bench("App+Task DummyWriter responses.text", call_text, 60_000)
+    _bench("App+Task DummyWriter preencoded respond", call_bytes, 60_000)
+
+    def drive_send() -> None:
+        dummy.started = False
+        dummy.ended = False
+        dummy._completed = False
+        dummy.status = None
+        dummy.body = None
+        dummy._status_code = None
+        coro = app(ctx, dummy)
+        try:
+            coro.send(None)
+        except StopIteration:
+            pass
+
+    _bench("App coro.send DummyWriter (no Task)", drive_send, 60_000)
+
+    def drive_handler_only() -> None:
+        dummy.started = False
+        dummy.ended = False
+        dummy._completed = False
+        dummy.status = None
+        dummy.body = None
+        dummy._status_code = None
+        handler, route = app.find_handler("", "/plaintext", "GET")
+        ctx.route = route
+        coro = handler(ctx, dummy)
+        try:
+            coro.send(None)
+        except StopIteration:
+            pass
+
+    _bench("handler coro.send + find_handler (no App)", drive_handler_only, 60_000)
+
+    def drive_text_only() -> None:
+        dummy.started = False
+        dummy.ended = False
+        dummy._completed = False
+        dummy.status = None
+        dummy.body = None
+        dummy._status_code = None
+        responses.text(dummy, HELLO)
+
+    _bench("responses.text DummyWriter only", drive_text_only, 200_000)
+
+    # Live protocol: parse one GET and dispatch (includes llhttp + respond + uvloop transport).
+    connections: set = set()
+    date = [b"date: Tue, 18 Aug 2026 00:00:00 GMT\r\n"]
+    proto = make_protocol(loop, app, connections=connections, date=date[0])
+
+    class FakeTransport:
+        def __init__(self) -> None:
+            self.writes = 0
+            self._closing = False
+
+        def write(self, data) -> None:
+            self.writes += 1
+
+        def writelines(self, lines) -> None:
+            self.writes += 1
+
+        def is_closing(self) -> bool:
+            return self._closing
+
+        def close(self) -> None:
+            self._closing = True
+
+        def get_extra_info(self, name, default=None):
+            return default
+
+        def pause_reading(self) -> None:
+            return None
+
+        def resume_reading(self) -> None:
+            return None
+
+    req = (
+        b"GET /plaintext HTTP/1.1\r\n"
+        b"Host: 127.0.0.1\r\n"
+        b"\r\n"
+    )
+
+    def one_http() -> None:
+        transport = FakeTransport()
+        proto.connection_made(transport)
+        proto.data_received(req)
+        proto.connection_lost(None)
+
+    # connection_made each time is heavier than keepalive. Time keepalive reuse:
+    transport = FakeTransport()
+    proto.connection_made(transport)
+    proto.data_received(req)  # warmup
+
+    def keepalive_get() -> None:
+        proto.data_received(req)
+
+    _bench("protocol keepalive GET /plaintext", keepalive_get, 40_000)
+    print(f"fake transport writes after bench: {transport.writes}")
+
+    import cProfile
+    import pstats
+    from io import StringIO
+
+    profiler = cProfile.Profile()
+    profiler.enable()
+    for _ in range(20_000):
+        keepalive_get()
+    profiler.disable()
+    stream = StringIO()
+    stats = pstats.Stats(profiler, stream=stream).sort_stats("tottime")
+    stats.print_stats(35)
+    print("\n--- cProfile keepalive GET /plaintext (20k) ---")
+    print(stream.getvalue())
+
+
+if __name__ == "__main__":
+    uvloop.run(main())

--- a/benchmarks/server/run.sh
+++ b/benchmarks/server/run.sh
@@ -18,13 +18,14 @@ KEEP_RAW="${KEEP_RAW:-0}"
 WRK="${WRK:-wrk}"
 BROTLI_PKG_CONFIG="${BROTLI_PKG_CONFIG:-}"
 TARGETS=(
-  stario stario-cython
+  stario stario-cython stario-cython-pyapp
   socketify robyn granian-rsgi sanic django-bolt
   blacksheep-granian blacksheep-uvicorn fastapi
 )
 TARGET_LABELS=(
   "stario|Stario (Python httptools)"
-  "stario-cython|Stario (Cython llhttp)"
+  "stario-cython|Stario (Cython llhttp, Cython App)"
+  "stario-cython-pyapp|Stario (Cython llhttp, Python App)"
   "socketify|Socketify (uWebSockets/libuv)"
   "robyn|Robyn (Rust/Actix)"
   "granian-rsgi|Granian RSGI (Rust, no framework)"
@@ -35,7 +36,7 @@ TARGET_LABELS=(
   "fastapi|FastAPI + Uvicorn ASGI"
 )
 SUMMARY_GROUPS=(
-  "Stario (this checkout)|stario stario-cython"
+  "Stario (this checkout)|stario stario-cython stario-cython-pyapp"
   "Native HTTP servers|socketify robyn granian-rsgi sanic django-bolt"
   "ASGI framework stacks|blacksheep-granian blacksheep-uvicorn fastapi"
 )
@@ -73,7 +74,7 @@ usage() {
 Usage: benchmarks/server/run.sh [target ...]
 
 Targets (default: all):
-  Stario:              stario, stario-cython
+  Stario:              stario, stario-cython, stario-cython-pyapp
   Native HTTP servers: socketify, robyn, granian-rsgi, sanic, django-bolt
   ASGI stacks:         blacksheep-granian, blacksheep-uvicorn, fastapi
 
@@ -226,7 +227,12 @@ format_int() {
   printf '%s%s' "$value" "$out"
 }
 
-python_for() { echo "$ENVS_DIR/$1/bin/python"; }
+python_for() {
+  case "$1" in
+    stario-cython-pyapp) echo "$ENVS_DIR/stario-cython/bin/python" ;;
+    *) echo "$ENVS_DIR/$1/bin/python" ;;
+  esac
+}
 
 require_port_free() {
   local python="$1" target="$2" port="$3"
@@ -302,6 +308,9 @@ ensure_target() {
       ensure_env stario-cython "stario @ file://$ROOT" uvloop ujson cython setuptools wheel
       build_stario_cython "$(python_for stario-cython)"
       ;;
+    stario-cython-pyapp)
+      ensure_target stario-cython
+      ;;
     socketify) ensure_env socketify socketify ujson ;;
     robyn) ensure_env robyn robyn ujson ;;
     granian-rsgi) ensure_env granian-rsgi granian uvloop ujson ;;
@@ -328,7 +337,7 @@ uvicorn_cmd() {
 
 command_for() {
   case "$1" in
-    stario|stario-cython)
+    stario|stario-cython|stario-cython-pyapp)
       export STARIO_HOST="$HOST"
       export STARIO_PORT="$SERVER_PORT"
       export STARIO_LOOP=uvloop
@@ -336,10 +345,14 @@ command_for() {
       export STARIO_COMPRESS_ZSTD_LEVEL=-1
       export STARIO_COMPRESS_BROTLI_LEVEL=-1
       export STARIO_COMPRESS_GZIP_LEVEL=-1
-      if [[ "$1" == stario-cython ]]; then
+      if [[ "$1" == stario-cython || "$1" == stario-cython-pyapp ]]; then
+        local app_env=()
+        if [[ "$1" == stario-cython-pyapp ]]; then
+          app_env=(STARIO_CYTHON_PYTHON_APP=1)
+        fi
         SERVER_CMD=(
-          env PYTHONPATH="$ROOT/src:$BENCHMARK_DIR"
-          "$(python_for stario-cython)" -m stario_cython apps.stario_app:bootstrap
+          env PYTHONPATH="$ROOT/src:$BENCHMARK_DIR" "${app_env[@]}"
+          "$(python_for "$1")" -m stario_cython apps.stario_app:bootstrap
         )
       else
         # This branch's Headers live in stario_cython; load inplace .so via src.

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,17 @@ extensions = [
         extra_compile_args=["-O3", "-fno-strict-aliasing"],
     ),
     Extension(
+        "stario_cython.router",
+        sources=["src/stario_cython/router.pyx"],
+        extra_compile_args=["-O3", "-fno-strict-aliasing"],
+    ),
+    Extension(
+        "stario_cython.app",
+        sources=["src/stario_cython/app.pyx"],
+        include_dirs=["vendor", "src"],
+        extra_compile_args=["-O3", "-fno-strict-aliasing"],
+    ),
+    Extension(
         "stario_cython.exchange",
         sources=[
             "src/stario_cython/exchange.pyx",

--- a/src/stario/http/app.py
+++ b/src/stario/http/app.py
@@ -8,6 +8,7 @@ structure. `create_task` registers work the server can wait on during shutdownâ€
 import asyncio
 from collections.abc import Awaitable, Callable, Coroutine
 from functools import lru_cache
+from inspect import isawaitable
 from typing import Any
 
 import stario.responses as responses
@@ -25,20 +26,20 @@ from stario.telemetry.spans import NoOpSpan
 from .dispatch import Router
 from .writer import Writer
 
-type ErrorHandler[E: Exception] = Callable[[Context, Writer, E], Awaitable[None]]
+type ErrorHandler[E: Exception] = Callable[[Context, Writer, E], Awaitable[None] | None]
 
 
-async def _default_http_exception(_c: Context, w: Writer, exc: HttpException) -> None:
+def _default_http_exception(_c: Context, w: Writer, exc: HttpException) -> None:
     responses.text(w, exc.detail or "Error", exc.status_code)
 
 
-async def _default_redirect_exception(
+def _default_redirect_exception(
     _c: Context, w: Writer, exc: RedirectException
 ) -> None:
     responses.redirect(w, exc.location, exc.status_code)
 
 
-async def _default_client_disconnected(
+def _default_client_disconnected(
     _c: Context, w: Writer, _exc: ClientDisconnected
 ) -> None:
     w.abort()
@@ -104,7 +105,7 @@ class App(Router):
         """Register a handler for uncaught exceptions of type `exc_type` (subclasses use MRO; most specific wins).
 
         - `exc_type`: Exception class to match.
-        - `handler`: Async callable receiving `(context, writer, exc)`.
+        - `handler`: Callable receiving `(context, writer, exc)` (sync or async).
 
         Only runs while the writer has not started (`w.started` is false); after
         headers are sent, failures use `w.abort()` in the `finally` block.
@@ -172,6 +173,14 @@ class App(Router):
 
     # --- protocol entrypoint (called once per HTTP request) ---
 
+    def dispatch(self, c: Context, w: Writer) -> Coroutine[Any, Any, None] | None:
+        """Run one request without wrapping sync handlers in `asyncio.Task`.
+
+        Returns `None` when the handler finished immediately (plain `def`), or a
+        coroutine the HTTP protocol should schedule when the handler is async.
+        """
+        return _dispatch(self, c, w)
+
     async def __call__(self, c: Context, w: Writer) -> None:
         """Protocol entrypoint: open a span, resolve routes, handle errors, and finish started responses.
 
@@ -188,31 +197,93 @@ class App(Router):
         raises, the request span is marked failed and 500 is sent when the
         handler did not start or complete the writer. Handlers must explicitly
         send a response on the success path.
+
+        Sync handlers (`def plaintext(c, w)`) are supported: they run inline
+        and do not need `await`.
         """
-        span = c.span
-        # Cython (and benchmark) servers use NoOpTracer. Skip method calls and
-        # the attrs dict on that path; RecordingSpan and others still record.
-        record = type(span) is not NoOpSpan
-        if record:
-            span.start()
-            span.attrs({"request.method": c.req.method, "request.path": c.req.path})
-        failed_after_start = False
+        pending = self.dispatch(c, w)
+        if pending is not None:
+            await pending
 
-        try:
-            path = c.req.path
-            # Canonicalize trailing slashes before routing (query string preserved).
-            if path != "/" and path.endswith("/"):
-                target = normalize_path(path)
-                if c.req.query_bytes:
-                    target = f"{target}?{c.req.query_bytes.decode('latin-1')}"
-                responses.redirect(w, target, 308)
-                return
 
-            # If it's a valid path, find the handler and call it.
-            host = c.req.host if self.host_routing else ""
-            handler, c.route = self.find_handler(host, path, c.req.method)
-            await handler(c, w)
-            # Success path must leave the writer started or explicitly completed.
+def _finish_writer(
+    c: Context, w: Writer, failed_after_start: bool, record: bool
+) -> None:
+    if failed_after_start and not w.completed:
+        w.abort()
+    elif not w.completed:
+        w.end()
+    if record:
+        c.span.attr("response.status_code", w.status_code)
+        c.span.end()
+
+
+async def _continue_async(
+    app: App,
+    c: Context,
+    w: Writer,
+    pending: Awaitable[None],
+    record: bool,
+) -> None:
+    failed_after_start = False
+    try:
+        await pending
+        if not w.started and not w.completed:
+            raise StarioRuntime(
+                "Handler returned without sending a response",
+                context={
+                    "method": c.req.method,
+                    "path": c.req.path,
+                    "route": c.route.pattern or None,
+                },
+                help_text=(
+                    "Call a response helper such as responses.text/json/html/empty, "
+                    "or explicitly use Writer.write_headers()/write()/end()."
+                ),
+            )
+    except Exception as exc:
+        handler_responded = False
+        failed_after_start = w.started
+        if not w.started:
+            if handler := app._find_error_handler(type(exc)):
+                try:
+                    err_result = handler(c, w, exc)
+                    if isawaitable(err_result):
+                        await err_result
+                    handler_responded = w.started or w.completed
+                except Exception as handler_exc:
+                    failed_after_start = w.started
+                    exc = handler_exc
+            if not handler_responded:
+                responses.text(w, "Internal Server Error", 500)
+        if not handler_responded and record:
+            c.span.fail(str(exc))
+            c.span.exception(exc)
+    finally:
+        _finish_writer(c, w, failed_after_start, record)
+
+
+def _dispatch(app: App, c: Context, w: Writer) -> Coroutine[Any, Any, None] | None:
+    span = c.span
+    record = type(span) is not NoOpSpan
+    if record:
+        span.start()
+        span.attrs({"request.method": c.req.method, "request.path": c.req.path})
+    failed_after_start = False
+
+    try:
+        path = c.req.path
+        if path != "/" and path.endswith("/"):
+            target = normalize_path(path)
+            if c.req.query_bytes:
+                target = f"{target}?{c.req.query_bytes.decode('latin-1')}"
+            responses.redirect(w, target, 308)
+        else:
+            host = c.req.host if app.host_routing else ""
+            handler, c.route = app.find_handler(host, path, c.req.method)
+            result = handler(c, w)
+            if isawaitable(result):
+                return _continue_async(app, c, w, result, record)
             if not w.started and not w.completed:
                 raise StarioRuntime(
                     "Handler returned without sending a response",
@@ -226,30 +297,23 @@ class App(Router):
                         "or explicitly use Writer.write_headers()/write()/end()."
                     ),
                 )
-
-        except Exception as exc:
-            handler_responded = False
-            failed_after_start = w.started
-            if not w.started:
-                # Headers not sent yet: try typed error handlers, then generic 500.
-                if handler := self._find_error_handler(type(exc)):
-                    try:
-                        await handler(c, w, exc)
-                        handler_responded = w.started or w.completed
-                    except Exception as handler_exc:
-                        failed_after_start = w.started
-                        exc = handler_exc
-                if not handler_responded:
-                    responses.text(w, "Internal Server Error", 500)
-            if not handler_responded and record:
-                span.fail(str(exc))
-                span.exception(exc)
-        finally:
-            # After headers: abort the transport on failure; otherwise finish the message.
-            if failed_after_start and not w.completed:
-                w.abort()
-            elif not w.completed:
-                w.end()
-            if record:
-                span.attr("response.status_code", w.status_code)
-                span.end()
+    except Exception as exc:
+        handler_responded = False
+        failed_after_start = w.started
+        if not w.started:
+            if handler := app._find_error_handler(type(exc)):
+                try:
+                    err_result = handler(c, w, exc)
+                    if isawaitable(err_result):
+                        return _continue_async(app, c, w, err_result, record)
+                    handler_responded = w.started or w.completed
+                except Exception as handler_exc:
+                    failed_after_start = w.started
+                    exc = handler_exc
+            if not handler_responded:
+                responses.text(w, "Internal Server Error", 500)
+        if not handler_responded and record:
+            span.fail(str(exc))
+            span.exception(exc)
+    _finish_writer(c, w, failed_after_start, record)
+    return None

--- a/src/stario/http/context.py
+++ b/src/stario/http/context.py
@@ -144,6 +144,6 @@ class _Alive[T]:
         )
 
 
-type Handler = Callable[[Context, Writer], Awaitable[None]]
+type Handler = Callable[[Context, Writer], Awaitable[None] | None]
 
 type Middleware = Callable[[Handler], Handler]

--- a/src/stario/http/server.py
+++ b/src/stario/http/server.py
@@ -107,6 +107,7 @@ class Server:
         *,
         config: ServerConfig | None = None,
         make_protocol: ProtocolMaker | None = None,
+        app_factory: Callable[[], Any] | None = None,
     ) -> None:
         """Configure listening, bootstrap, telemetry, and per-connection compression.
 
@@ -116,12 +117,15 @@ class Server:
         - `make_protocol`: Optional factory for a non-default HTTP protocol
           (used by the Cython core). Receives the shared date box so the
           writer can read `date_box[0]` without a per-response call.
+        - `app_factory`: Constructs the `App` (or Cython App drop-in) for this
+          serve. Defaults to `stario.http.app.App`.
         """
 
         self.bootstrap = bootstrap
         self.config = config if config is not None else ServerConfig()
         self.tracer = tracer
         self.make_protocol = make_protocol
+        self.app_factory = app_factory or App
 
         self._used = False
         self._date_box = [b""]
@@ -147,7 +151,7 @@ class Server:
             )
         self._used = True
 
-        app = App()
+        app = self.app_factory()
         span = self._open_startup_span()  # ProxySpan: startup → shutdown via replace()
 
         # Signal handlers stay active through span.end(); see _signal_handlers.
@@ -275,11 +279,7 @@ class Server:
             max(self.config.graceful_shutdown_timeout, 0.0), _FORCE_CLOSE_CAP
         )
         close_deadline = loop.time() + force_close_budget
-        while (
-            connections
-            and not self._urgent_drain
-            and loop.time() < close_deadline
-        ):
+        while connections and not self._urgent_drain and loop.time() < close_deadline:
             force_closed += await self._force_close_open_transports(connections)
             await asyncio.sleep(0)
 

--- a/src/stario_cython/__init__.py
+++ b/src/stario_cython/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-__all__ = ["run", "serve"]
+__all__ = ["App", "Router", "run", "serve"]
 
 
 def __getattr__(name: str) -> Any:
@@ -12,4 +12,12 @@ def __getattr__(name: str) -> Any:
         from stario_cython.serve import run, serve
 
         return run if name == "run" else serve
+    if name == "App":
+        from stario_cython.app import App
+
+        return App
+    if name == "Router":
+        from stario_cython.router import Router
+
+        return Router
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/stario_cython/app.pxd
+++ b/src/stario_cython/app.pxd
@@ -6,3 +6,4 @@ cdef class App(Router):
     cdef dict _error_handlers
     cdef object _find_error_handler
     cdef object _task_discard
+    cpdef object dispatch(self, object c, object w)

--- a/src/stario_cython/app.pxd
+++ b/src/stario_cython/app.pxd
@@ -1,4 +1,5 @@
 from stario_cython.router cimport Router
+from stario_cython.exchange cimport RequestExchange
 
 cdef class App(Router):
     cdef public object shutdown
@@ -7,3 +8,4 @@ cdef class App(Router):
     cdef object _find_error_handler
     cdef object _task_discard
     cpdef object dispatch(self, object c, object w)
+    cpdef object dispatch_exchange(self, RequestExchange ex)

--- a/src/stario_cython/app.pxd
+++ b/src/stario_cython/app.pxd
@@ -1,0 +1,8 @@
+from stario_cython.router cimport Router
+
+cdef class App(Router):
+    cdef public object shutdown
+    cdef public object tasks
+    cdef dict _error_handlers
+    cdef object _find_error_handler
+    cdef object _task_discard

--- a/src/stario_cython/app.pyx
+++ b/src/stario_cython/app.pyx
@@ -9,6 +9,7 @@ server and tests still go through the generic attribute path.
 
 import asyncio
 from functools import lru_cache
+from inspect import isawaitable as _isawaitable
 
 from cpython.unicode cimport PyUnicode_GET_LENGTH, PyUnicode_READ_CHAR
 
@@ -31,15 +32,15 @@ cdef object EXCHANGE_TYPE = RequestExchange
 cdef object EMPTY_HOST = ""
 
 
-async def _default_http_exception(_c, w, exc):
+def _default_http_exception(_c, w, exc):
     responses.text(w, exc.detail or "Error", exc.status_code)
 
 
-async def _default_redirect_exception(_c, w, exc):
+def _default_redirect_exception(_c, w, exc):
     responses.redirect(w, exc.location, exc.status_code)
 
 
-async def _default_client_disconnected(_c, w, _exc):
+def _default_client_disconnected(_c, w, _exc):
     w.abort()
 
 
@@ -53,6 +54,27 @@ cdef inline bint _writer_completed(bint is_ex, RequestExchange ex, object w):
     if is_ex:
         return ex._completed
     return w.completed
+
+
+cdef void _finish_writer(
+    bint is_ex,
+    RequestExchange ex,
+    object w,
+    bint failed_after_start,
+    bint traced,
+    object span,
+):
+    cdef bint completed = _writer_completed(is_ex, ex, w)
+    if failed_after_start and not completed:
+        w.abort()
+    elif not completed:
+        w.end()
+    if traced:
+        if is_ex:
+            span.attr("response.status_code", ex.status_code)
+        else:
+            span.attr("response.status_code", w.status_code)
+        span.end()
 
 
 cdef class App(Router):
@@ -129,7 +151,72 @@ cdef class App(Router):
                 return
             await asyncio.wait(pending, return_when=asyncio.ALL_COMPLETED)
 
-    async def __call__(self, object c, object w):
+    async def _continue_async(
+        self,
+        object c,
+        object w,
+        object pending,
+        bint is_ex,
+        RequestExchange ex,
+        bint traced,
+        object span,
+        object method,
+        object path,
+        object route,
+    ):
+        cdef object err_handler
+        cdef object err_result
+        cdef bint failed_after_start = False
+        cdef bint handler_responded
+        cdef bint started
+        try:
+            await pending
+            if not _writer_started(is_ex, ex, w) and not _writer_completed(is_ex, ex, w):
+                raise StarioRuntime(
+                    "Handler returned without sending a response",
+                    context={
+                        "method": method,
+                        "path": path,
+                        "route": route.pattern or None,
+                    },
+                    help_text=(
+                        "Call a response helper such as responses.text/json/html/empty, "
+                        "or explicitly use Writer.write_headers()/write()/end()."
+                    ),
+                )
+        except Exception as exc:
+            handler_responded = False
+            started = _writer_started(is_ex, ex, w)
+            failed_after_start = started
+            if not started:
+                err_handler = self._find_error_handler(type(exc))
+                if err_handler is not None:
+                    try:
+                        err_result = err_handler(c, w, exc)
+                        if _isawaitable(err_result):
+                            await err_result
+                        handler_responded = (
+                            _writer_started(is_ex, ex, w)
+                            or _writer_completed(is_ex, ex, w)
+                        )
+                    except Exception as handler_exc:
+                        failed_after_start = _writer_started(is_ex, ex, w)
+                        exc = handler_exc
+                if not handler_responded:
+                    responses.text(w, "Internal Server Error", 500)
+            if not handler_responded and traced:
+                span.fail(str(exc))
+                span.exception(exc)
+        finally:
+            _finish_writer(is_ex, ex, w, failed_after_start, traced, span)
+
+    cpdef object dispatch(self, object c, object w):
+        """Run one request. Returns None when finished, or a coroutine to Task.
+
+        Sync handlers (``def plaintext(c, w)``) complete here with no
+        ``asyncio.Task`` and no App coroutine. Async handlers return a
+        continuation the protocol schedules with ``eager_start``.
+        """
         cdef RequestExchange ex = None
         cdef Request req
         cdef object span
@@ -141,12 +228,13 @@ cdef class App(Router):
         cdef object target
         cdef object query_bytes
         cdef object err_handler
+        cdef object result
+        cdef object err_result
         cdef bint is_ex = type(c) is EXCHANGE_TYPE
         cdef bint traced
         cdef bint failed_after_start = False
         cdef bint handler_responded
         cdef bint started
-        cdef bint completed
         cdef Py_ssize_t n
 
         if is_ex:
@@ -176,34 +264,36 @@ cdef class App(Router):
                 if query_bytes:
                     target = f"{target}?{query_bytes.decode('latin-1')}"
                 responses.redirect(w, target, 308)
-                return
-
-            if not self._has_hosts:
-                host = EMPTY_HOST
-            elif is_ex:
-                host = req.host
             else:
-                host = c.req.host
-            handler, route = self.find_handler(host, path, method)
-            if is_ex:
-                ex.route = route
-            else:
-                c.route = route
-            await handler(c, w)
-            if not _writer_started(is_ex, ex, w) and not _writer_completed(is_ex, ex, w):
-                raise StarioRuntime(
-                    "Handler returned without sending a response",
-                    context={
-                        "method": method,
-                        "path": path,
-                        "route": route.pattern or None,
-                    },
-                    help_text=(
-                        "Call a response helper such as responses.text/json/html/empty, "
-                        "or explicitly use Writer.write_headers()/write()/end()."
-                    ),
-                )
-
+                if not self._has_hosts:
+                    host = EMPTY_HOST
+                elif is_ex:
+                    host = req.host
+                else:
+                    host = c.req.host
+                handler, route = self.find_handler(host, path, method)
+                if is_ex:
+                    ex.route = route
+                else:
+                    c.route = route
+                result = handler(c, w)
+                if _isawaitable(result):
+                    return self._continue_async(
+                        c, w, result, is_ex, ex, traced, span, method, path, route
+                    )
+                if not _writer_started(is_ex, ex, w) and not _writer_completed(is_ex, ex, w):
+                    raise StarioRuntime(
+                        "Handler returned without sending a response",
+                        context={
+                            "method": method,
+                            "path": path,
+                            "route": route.pattern or None,
+                        },
+                        help_text=(
+                            "Call a response helper such as responses.text/json/html/empty, "
+                            "or explicitly use Writer.write_headers()/write()/end()."
+                        ),
+                    )
         except Exception as exc:
             handler_responded = False
             started = _writer_started(is_ex, ex, w)
@@ -212,7 +302,20 @@ cdef class App(Router):
                 err_handler = self._find_error_handler(type(exc))
                 if err_handler is not None:
                     try:
-                        await err_handler(c, w, exc)
+                        err_result = err_handler(c, w, exc)
+                        if _isawaitable(err_result):
+                            return self._continue_async(
+                                c,
+                                w,
+                                err_result,
+                                is_ex,
+                                ex,
+                                traced,
+                                span,
+                                method,
+                                path,
+                                getattr(c, "route", None),
+                            )
                         handler_responded = (
                             _writer_started(is_ex, ex, w)
                             or _writer_completed(is_ex, ex, w)
@@ -225,18 +328,13 @@ cdef class App(Router):
             if not handler_responded and traced:
                 span.fail(str(exc))
                 span.exception(exc)
-        finally:
-            completed = _writer_completed(is_ex, ex, w)
-            if failed_after_start and not completed:
-                w.abort()
-            elif not completed:
-                w.end()
-            if traced:
-                if is_ex:
-                    span.attr("response.status_code", ex.status_code)
-                else:
-                    span.attr("response.status_code", w.status_code)
-                span.end()
+        _finish_writer(is_ex, ex, w, failed_after_start, traced, span)
+        return None
+
+    async def __call__(self, object c, object w):
+        cdef object pending = self.dispatch(c, w)
+        if pending is not None:
+            await pending
 
 
 __all__ = ["App"]

--- a/src/stario_cython/app.pyx
+++ b/src/stario_cython/app.pyx
@@ -277,7 +277,7 @@ cdef class App(Router):
                 else:
                     c.route = route
                 result = handler(c, w)
-                if _isawaitable(result):
+                if result is not None:
                     return self._continue_async(
                         c, w, result, is_ex, ex, traced, span, method, path, route
                     )
@@ -329,6 +329,89 @@ cdef class App(Router):
                 span.fail(str(exc))
                 span.exception(exc)
         _finish_writer(is_ex, ex, w, failed_after_start, traced, span)
+        return None
+
+    cpdef object dispatch_exchange(self, RequestExchange ex):
+        """RequestExchange hot path: no type check, no DummyWriter branches."""
+        cdef Request req = ex.req
+        cdef object span = ex.span
+        cdef object path = req.path
+        cdef object method = req.method
+        cdef object host
+        cdef object handler
+        cdef object route
+        cdef object target
+        cdef object query_bytes
+        cdef object err_handler
+        cdef object result
+        cdef object err_result
+        cdef bint traced = type(span) is not NOOP_SPAN_TYPE
+        cdef bint failed_after_start = False
+        cdef bint handler_responded
+        cdef bint started
+        cdef Py_ssize_t n
+        cdef object w = ex
+
+        if traced:
+            span.start()
+            span.attrs({"request.method": method, "request.path": path})
+
+        try:
+            n = PyUnicode_GET_LENGTH(path)
+            if n > 1 and PyUnicode_READ_CHAR(path, n - 1) == 47:
+                target = normalize_path(path)
+                query_bytes = req.query_bytes
+                if query_bytes:
+                    target = f"{target}?{query_bytes.decode('latin-1')}"
+                responses.redirect(w, target, 308)
+            else:
+                if not self._has_hosts:
+                    host = EMPTY_HOST
+                else:
+                    host = req.host
+                handler, route = self.find_handler(host, path, method)
+                ex.route = route
+                result = handler(ex, w)
+                if result is not None:
+                    return self._continue_async(
+                        ex, w, result, True, ex, traced, span, method, path, route
+                    )
+                if ex._status_code < 0 and not ex._completed:
+                    raise StarioRuntime(
+                        "Handler returned without sending a response",
+                        context={
+                            "method": method,
+                            "path": path,
+                            "route": route.pattern or None,
+                        },
+                        help_text=(
+                            "Call a response helper such as responses.text/json/html/empty, "
+                            "or explicitly use Writer.write_headers()/write()/end()."
+                        ),
+                    )
+        except Exception as exc:
+            handler_responded = False
+            started = ex._status_code >= 0
+            failed_after_start = started
+            if not started:
+                err_handler = self._find_error_handler(type(exc))
+                if err_handler is not None:
+                    try:
+                        err_result = err_handler(ex, w, exc)
+                        if _isawaitable(err_result):
+                            return self._continue_async(
+                                ex, w, err_result, True, ex, traced, span, method, path, route
+                            )
+                        handler_responded = ex._status_code >= 0 or ex._completed
+                    except Exception as handler_exc:
+                        failed_after_start = ex._status_code >= 0
+                        exc = handler_exc
+                if not handler_responded:
+                    responses.text(w, "Internal Server Error", 500)
+            if not handler_responded and traced:
+                span.fail(str(exc))
+                span.exception(exc)
+        _finish_writer(True, ex, w, failed_after_start, traced, span)
         return None
 
     async def __call__(self, object c, object w):

--- a/src/stario_cython/app.pyx
+++ b/src/stario_cython/app.pyx
@@ -1,0 +1,242 @@
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+"""Cython App: compiled request entry on the Cython Router trie.
+
+``__call__`` is the protocol entrypoint. When the context is a
+``RequestExchange`` (Cython HTTP server), path/method/started/completed are
+read from cdef fields instead of Python properties. The Python httptools
+server and tests still go through the generic attribute path.
+"""
+
+import asyncio
+from functools import lru_cache
+
+from cpython.unicode cimport PyUnicode_GET_LENGTH, PyUnicode_READ_CHAR
+
+import stario.responses as responses
+from stario.exceptions import (
+    ClientDisconnected,
+    HttpException,
+    RedirectException,
+    StarioError,
+    StarioRuntime,
+)
+from stario.routing.locations import normalize_path
+from stario.telemetry.spans import NoOpSpan
+
+from stario_cython.exchange cimport Request, RequestExchange
+from stario_cython.router cimport Router
+
+cdef object NOOP_SPAN_TYPE = NoOpSpan
+cdef object EXCHANGE_TYPE = RequestExchange
+cdef object EMPTY_HOST = ""
+
+
+async def _default_http_exception(_c, w, exc):
+    responses.text(w, exc.detail or "Error", exc.status_code)
+
+
+async def _default_redirect_exception(_c, w, exc):
+    responses.redirect(w, exc.location, exc.status_code)
+
+
+async def _default_client_disconnected(_c, w, _exc):
+    w.abort()
+
+
+cdef inline bint _writer_started(bint is_ex, RequestExchange ex, object w):
+    if is_ex:
+        return ex._status_code >= 0
+    return w.started
+
+
+cdef inline bint _writer_completed(bint is_ex, RequestExchange ex, object w):
+    if is_ex:
+        return ex._completed
+    return w.completed
+
+
+cdef class App(Router):
+    """Concrete app type: everything on `Router` plus errors and shutdown-aware tasks."""
+
+    def __init__(self):
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError as exc:
+            raise StarioError(
+                "App() requires a running event loop",
+                help_text="Create App inside serve(), bootstrap, or async test code.",
+            ) from exc
+
+        self.shutdown = loop.create_future()
+        self.tasks = set()
+        self._task_discard = self.tasks.discard
+        self._error_handlers = {
+            HttpException: _default_http_exception,
+            RedirectException: _default_redirect_exception,
+            ClientDisconnected: _default_client_disconnected,
+        }
+
+        @lru_cache(maxsize=64)
+        def find_handler(exc_type):
+            for t in exc_type.__mro__:
+                if t is Exception:
+                    return None
+                handler = self._error_handlers.get(t)
+                if handler is not None:
+                    return handler
+            return None
+
+        self._find_error_handler = find_handler
+
+    @property
+    def shutting_down(self):
+        return self.shutdown.done()
+
+    def signal_shutdown(self):
+        if not self.shutdown.done():
+            self.shutdown.set_result(None)
+
+    def on_error(self, exc_type, handler):
+        self._error_handlers[exc_type] = handler
+        self._find_error_handler.cache_clear()
+
+    def create_task(self, coro, *, loop=None, name=None, eager_start=False):
+        """Schedule a coroutine on the running loop and retain the task until it completes."""
+        cdef object task
+        if loop is None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError as exc:
+                raise StarioError(
+                    "app.create_task() requires a running event loop",
+                    help_text="Call app.create_task() from async code while the app is running.",
+                ) from exc
+        task = asyncio.Task(
+            coro,
+            loop=loop,
+            name=name,
+            eager_start=eager_start,
+        )
+        if not task.done():
+            self.tasks.add(task)
+            task.add_done_callback(self._task_discard)
+        return task
+
+    async def drain_tasks(self):
+        while True:
+            pending = set(self.tasks)
+            if not pending:
+                return
+            await asyncio.wait(pending, return_when=asyncio.ALL_COMPLETED)
+
+    async def __call__(self, object c, object w):
+        cdef RequestExchange ex = None
+        cdef Request req
+        cdef object span
+        cdef object path
+        cdef object method
+        cdef object host
+        cdef object handler
+        cdef object route
+        cdef object target
+        cdef object query_bytes
+        cdef object err_handler
+        cdef bint is_ex = type(c) is EXCHANGE_TYPE
+        cdef bint traced
+        cdef bint failed_after_start = False
+        cdef bint handler_responded
+        cdef bint started
+        cdef bint completed
+        cdef Py_ssize_t n
+
+        if is_ex:
+            ex = <RequestExchange>c
+            req = ex.req
+            path = req.path
+            method = req.method
+            span = ex.span
+        else:
+            path = c.req.path
+            method = c.req.method
+            span = c.span
+
+        traced = type(span) is not NOOP_SPAN_TYPE
+        if traced:
+            span.start()
+            span.attrs({"request.method": method, "request.path": path})
+
+        try:
+            n = PyUnicode_GET_LENGTH(path)
+            if n > 1 and PyUnicode_READ_CHAR(path, n - 1) == 47:
+                target = normalize_path(path)
+                if is_ex:
+                    query_bytes = req.query_bytes
+                else:
+                    query_bytes = c.req.query_bytes
+                if query_bytes:
+                    target = f"{target}?{query_bytes.decode('latin-1')}"
+                responses.redirect(w, target, 308)
+                return
+
+            if not self._has_hosts:
+                host = EMPTY_HOST
+            elif is_ex:
+                host = req.host
+            else:
+                host = c.req.host
+            handler, route = self.find_handler(host, path, method)
+            if is_ex:
+                ex.route = route
+            else:
+                c.route = route
+            await handler(c, w)
+            if not _writer_started(is_ex, ex, w) and not _writer_completed(is_ex, ex, w):
+                raise StarioRuntime(
+                    "Handler returned without sending a response",
+                    context={
+                        "method": method,
+                        "path": path,
+                        "route": route.pattern or None,
+                    },
+                    help_text=(
+                        "Call a response helper such as responses.text/json/html/empty, "
+                        "or explicitly use Writer.write_headers()/write()/end()."
+                    ),
+                )
+
+        except Exception as exc:
+            handler_responded = False
+            started = _writer_started(is_ex, ex, w)
+            failed_after_start = started
+            if not started:
+                err_handler = self._find_error_handler(type(exc))
+                if err_handler is not None:
+                    try:
+                        await err_handler(c, w, exc)
+                        handler_responded = (
+                            _writer_started(is_ex, ex, w)
+                            or _writer_completed(is_ex, ex, w)
+                        )
+                    except Exception as handler_exc:
+                        failed_after_start = _writer_started(is_ex, ex, w)
+                        exc = handler_exc
+                if not handler_responded:
+                    responses.text(w, "Internal Server Error", 500)
+            if not handler_responded and traced:
+                span.fail(str(exc))
+                span.exception(exc)
+        finally:
+            completed = _writer_completed(is_ex, ex, w)
+            if failed_after_start and not completed:
+                w.abort()
+            elif not completed:
+                w.end()
+            if traced:
+                if is_ex:
+                    span.attr("response.status_code", ex.status_code)
+                else:
+                    span.attr("response.status_code", w.status_code)
+                span.end()
+
+
+__all__ = ["App"]

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -405,6 +405,7 @@ cdef class HttpProtocol:
     cdef bint pump_scheduled
     cdef object _create_task
     cdef object _app_dispatch
+    cdef object _dispatch_exchange
 
     def __cinit__(self):
         _bind_settings()
@@ -458,6 +459,7 @@ cdef class HttpProtocol:
         self.connections = connections
         self._create_task = app.create_task
         self._app_dispatch = getattr(app, "dispatch", None)
+        self._dispatch_exchange = getattr(app, "dispatch_exchange", None)
         self.transport = None
         self.pending_exchanges = deque()
         self.head_bytes = 0
@@ -955,9 +957,9 @@ cdef class HttpProtocol:
         cdef object dispatch
         self.active_exchange = exchange
         exchange.start_response()
-        dispatch = self._app_dispatch
+        dispatch = self._dispatch_exchange
         if dispatch is not None:
-            pending = dispatch(exchange, exchange)
+            pending = dispatch(exchange)
             if pending is None:
                 exchange.handler_finished()
                 return
@@ -967,11 +969,23 @@ cdef class HttpProtocol:
                 eager_start=eager_start,
             )
         else:
-            task = self._create_task(
-                self.app(exchange, exchange),
-                loop=self.loop,
-                eager_start=eager_start,
-            )
+            dispatch = self._app_dispatch
+            if dispatch is not None:
+                pending = dispatch(exchange, exchange)
+                if pending is None:
+                    exchange.handler_finished()
+                    return
+                task = self._create_task(
+                    pending,
+                    loop=self.loop,
+                    eager_start=eager_start,
+                )
+            else:
+                task = self._create_task(
+                    self.app(exchange, exchange),
+                    loop=self.loop,
+                    eager_start=eager_start,
+                )
         if task.done():
             exchange.handler_finished()
         else:

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -404,6 +404,7 @@ cdef class HttpProtocol:
     cdef Py_ssize_t held_offset
     cdef bint pump_scheduled
     cdef object _create_task
+    cdef object _app_dispatch
 
     def __cinit__(self):
         _bind_settings()
@@ -456,6 +457,7 @@ cdef class HttpProtocol:
         self.compression = compression
         self.connections = connections
         self._create_task = app.create_task
+        self._app_dispatch = getattr(app, "dispatch", None)
         self.transport = None
         self.pending_exchanges = deque()
         self.head_bytes = 0
@@ -949,13 +951,27 @@ cdef class HttpProtocol:
 
     cdef void _start_exchange(self, RequestExchange exchange, bint eager_start):
         cdef object task
+        cdef object pending
+        cdef object dispatch
         self.active_exchange = exchange
         exchange.start_response()
-        task = self._create_task(
-            self.app(exchange, exchange),
-            loop=self.loop,
-            eager_start=eager_start,
-        )
+        dispatch = self._app_dispatch
+        if dispatch is not None:
+            pending = dispatch(exchange, exchange)
+            if pending is None:
+                exchange.handler_finished()
+                return
+            task = self._create_task(
+                pending,
+                loop=self.loop,
+                eager_start=eager_start,
+            )
+        else:
+            task = self._create_task(
+                self.app(exchange, exchange),
+                loop=self.loop,
+                eager_start=eager_start,
+            )
         if task.done():
             exchange.handler_finished()
         else:

--- a/src/stario_cython/router.pxd
+++ b/src/stario_cython/router.pxd
@@ -1,0 +1,35 @@
+cdef class Node:
+    cdef public object not_found_handler
+    cdef public object method_not_allowed_handler
+    cdef public tuple middleware
+    cdef public int host_depth
+    cdef public dict exact
+    cdef public object wildcard_name
+    cdef public Node wildcard
+    cdef public object catchall_name
+    cdef public Node catchall
+    cdef public dict endpoints
+    cdef public object methods
+
+
+cdef class Endpoint:
+    cdef public object handler
+    cdef public object route_match
+
+
+cdef class Router:
+    cdef Node _path
+    cdef Node _hosts
+    cdef bint _has_hosts
+    cdef dict _static
+    cdef dict _cache
+    cdef int _cache_n
+    cdef dict __dict__
+
+    cpdef tuple find_handler(self, object host, object path, object method)
+    cdef tuple _match(self, object host, object path, object method)
+    cdef void _clear_match_cache(self)
+    cdef Node _registration_tree(self, object pattern)
+    cdef Node _leaf_node(self, object pattern)
+    cdef Node _policy_node(self, object pattern)
+    cdef void _remember_static(self, object pattern, object method, object result)

--- a/src/stario_cython/router.pyx
+++ b/src/stario_cython/router.pyx
@@ -1,0 +1,728 @@
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+"""Cython route table: static exact map, in-place host/path walks, nested cache.
+
+Registration stays compatible with ``stario.http.dispatch.Router``. The request
+hot path avoids ``UrlPath.request_path`` / ``request_host`` tuple splits and
+``functools.lru_cache`` wrapper overhead:
+
+- hostless exact routes (``/plaintext``, ``/json``, …) hit ``_static[path][method]``
+- parameterized routes use a nested ``host -> path -> method`` dict (cap 1024)
+- cache misses walk the unicode path/host in place
+"""
+
+from functools import lru_cache
+from types import MappingProxyType
+
+from cpython.dict cimport PyDict_GetItem, PyDict_SetItem
+from cpython.object cimport PyObject
+from cpython.unicode cimport PyUnicode_GET_LENGTH, PyUnicode_READ_CHAR
+
+import stario.responses as responses
+from stario.exceptions import StarioError
+from stario.http.context import (
+    EMPTY_ROUTE_MATCH,
+    Context,
+    RouteMatch,
+)
+from stario.http.writer import Writer
+from stario.routing import Route, UrlPath
+
+cdef int CACHE_MAX = 1024
+cdef int ST_FOUND = 0
+cdef int ST_MNA = 1
+cdef int ST_NF = 2
+
+cdef object KIND_CATCHALL = "catchall"
+cdef object KIND_WILDCARD = "wildcard"
+cdef object KIND_EXACT = "exact"
+cdef object EMPTY_METHODS = frozenset()
+cdef object EMPTY_HOST = ""
+cdef object SLASH = "/"
+
+
+cdef class Node:
+    def __cinit__(self):
+        self.not_found_handler = None
+        self.method_not_allowed_handler = None
+        self.middleware = ()
+        self.host_depth = 0
+        self.exact = {}
+        self.wildcard_name = None
+        self.wildcard = None
+        self.catchall_name = None
+        self.catchall = None
+        self.endpoints = None
+        self.methods = EMPTY_METHODS
+
+    def __init__(self, host_depth=0):
+        self.host_depth = host_depth
+
+
+cdef class Endpoint:
+    def __init__(self, handler, route_match):
+        self.handler = handler
+        self.route_match = route_match
+
+
+cdef inline object _as_pattern(object path):
+    return path if isinstance(path, UrlPath) else UrlPath(path)
+
+
+cdef inline bint _kind_is(object kind, object interned):
+    return kind is interned or kind == interned
+
+
+cdef Node _pattern_child(Node current, object segment):
+    cdef object kind = segment.kind
+    cdef object child
+    cdef PyObject *p
+    if _kind_is(kind, KIND_CATCHALL):
+        if current.catchall is None or current.catchall_name != segment.name:
+            return None
+        return current.catchall
+    if _kind_is(kind, KIND_WILDCARD):
+        if current.wildcard is None or current.wildcard_name != segment.name:
+            return None
+        return current.wildcard
+    p = PyDict_GetItem(current.exact, segment.name)
+    if p == NULL:
+        return None
+    return <Node>p
+
+
+cdef Node trie_descend(Node root, object pattern, bint create, bint host_tree):
+    cdef Node current = root
+    cdef Node child
+    cdef object segment
+    for segment in pattern.host_trie():
+        if create:
+            current = _descend_or_create(current, segment, host_tree)
+        else:
+            child = _pattern_child(current, segment)
+            if child is None:
+                return current
+            current = child
+    for segment in pattern.path:
+        if create:
+            current = _descend_or_create(current, segment, False)
+        else:
+            child = _pattern_child(current, segment)
+            if child is None:
+                return current
+            current = child
+    return current
+
+
+cdef list _collect_middleware(Node tree, object pattern, bint path_only):
+    cdef list middlewares = list(tree.middleware)
+    cdef Node current = tree
+    cdef Node child
+    cdef object segment
+    if not path_only:
+        for segment in pattern.host_trie():
+            child = _pattern_child(current, segment)
+            if child is None:
+                return middlewares
+            current = child
+            middlewares.extend(current.middleware)
+    for segment in pattern.path:
+        child = _pattern_child(current, segment)
+        if child is None:
+            break
+        current = child
+        middlewares.extend(current.middleware)
+    return middlewares
+
+
+cdef bint _branch_has_endpoints(Node node):
+    cdef object child
+    if node.endpoints:
+        return True
+    if node.wildcard is not None and _branch_has_endpoints(node.wildcard):
+        return True
+    if node.catchall is not None and _branch_has_endpoints(node.catchall):
+        return True
+    for child in node.exact.values():
+        if _branch_has_endpoints(<Node>child):
+            return True
+    return False
+
+
+cdef bint _pattern_is_static(object pattern):
+    cdef object segment
+    if pattern.host:
+        return False
+    for segment in pattern.path:
+        if not _kind_is(segment.kind, KIND_EXACT):
+            return False
+    return True
+
+
+async def default_not_found(_c: Context, w: Writer):
+    responses.text(w, "Not Found", 404)
+
+
+@lru_cache(maxsize=256)
+def method_not_allowed_handler(allowed):
+    allow_header = ", ".join(sorted(allowed))
+
+    async def respond(_c, w):
+        w.headers.set("Allow", allow_header)
+        responses.text(w, "Method Not Allowed", 405)
+
+    return respond
+
+
+cdef object _walk_path(
+    Node current,
+    object path,
+    object params,
+    object not_found,
+    bint not_found_custom,
+    object method_na,
+):
+    cdef Py_ssize_t n = PyUnicode_GET_LENGTH(path)
+    cdef Py_ssize_t start
+    cdef Py_ssize_t slash
+    cdef Py_ssize_t path_off
+    cdef object seg
+    cdef object name
+    cdef object nf
+    cdef object mna
+    cdef PyObject *p
+    cdef Node node = current
+    cdef Node nxt
+
+    if n == 1 and PyUnicode_READ_CHAR(path, 0) == 47:
+        return (node, params, not_found, not_found_custom, method_na)
+
+    start = 1
+    path_off = 1
+    while start < n:
+        slash = path.find(SLASH, start)
+        if slash == -1:
+            seg = path[start:]
+        else:
+            seg = path[start:slash]
+        p = PyDict_GetItem(node.exact, seg)
+        if p != NULL:
+            nxt = <Node>p
+            if slash == -1:
+                start = n
+            else:
+                start = slash + 1
+            path_off = start
+        elif node.wildcard is not None:
+            if params is None:
+                params = {}
+            params[node.wildcard_name] = seg
+            nxt = node.wildcard
+            if slash == -1:
+                start = n
+            else:
+                start = slash + 1
+            path_off = start
+        elif node.catchall is not None:
+            name = node.catchall_name
+            if name is not None:
+                if params is None:
+                    params = {}
+                params[name] = path[path_off:]
+            nxt = node.catchall
+            start = n
+        else:
+            return None
+        nf = nxt.not_found_handler
+        if nf is not None:
+            not_found = nf
+            not_found_custom = True
+        mna = nxt.method_not_allowed_handler
+        if mna is not None:
+            method_na = mna
+        node = nxt
+    return (node, params, not_found, not_found_custom, method_na)
+
+
+cdef object _walk_host(
+    Node current,
+    object host,
+    object params,
+    object not_found,
+    bint not_found_custom,
+    object method_na,
+):
+    cdef Py_ssize_t n = PyUnicode_GET_LENGTH(host)
+    cdef Py_ssize_t end
+    cdef Py_ssize_t dot
+    cdef Py_ssize_t rest_end
+    cdef object seg
+    cdef object name
+    cdef object nf
+    cdef object mna
+    cdef PyObject *p
+    cdef Node node = current
+    cdef Node nxt
+
+    if n == 0:
+        return (node, params, not_found, not_found_custom, method_na)
+
+    end = n
+    while end > 0:
+        rest_end = end
+        dot = host.rfind(".", 0, end)
+        if dot == -1:
+            seg = host[:end]
+        else:
+            seg = host[dot + 1:end]
+        p = PyDict_GetItem(node.exact, seg)
+        if p != NULL:
+            nxt = <Node>p
+            end = 0 if dot == -1 else dot
+        elif node.wildcard is not None:
+            if params is None:
+                params = {}
+            params[node.wildcard_name] = seg
+            nxt = node.wildcard
+            end = 0 if dot == -1 else dot
+        elif node.catchall is not None:
+            name = node.catchall_name
+            if name is not None:
+                if params is None:
+                    params = {}
+                params[name] = host[:rest_end]
+            nxt = node.catchall
+            end = 0
+        else:
+            return None
+        nf = nxt.not_found_handler
+        if nf is not None:
+            not_found = nf
+            not_found_custom = True
+        mna = nxt.method_not_allowed_handler
+        if mna is not None:
+            method_na = mna
+        node = nxt
+    return (node, params, not_found, not_found_custom, method_na)
+
+
+cdef tuple _finish_resolve(
+    Node current,
+    object params,
+    object not_found,
+    bint not_found_custom,
+    object method_na,
+    object method,
+):
+    cdef Endpoint endpoint
+    cdef PyObject *p
+    cdef dict endpoints = current.endpoints
+
+    if endpoints is not None:
+        p = PyDict_GetItem(endpoints, method)
+        if p != NULL:
+            endpoint = <Endpoint>p
+            if params is None:
+                return (
+                    endpoint.handler,
+                    endpoint.route_match,
+                    ST_FOUND,
+                    not_found_custom,
+                )
+            return (
+                endpoint.handler,
+                RouteMatch(
+                    pattern=endpoint.route_match.pattern,
+                    params=MappingProxyType(params),
+                ),
+                ST_FOUND,
+                not_found_custom,
+            )
+
+    if current.methods:
+        return (
+            (method_na or method_not_allowed_handler)(current.methods),
+            EMPTY_ROUTE_MATCH,
+            ST_MNA,
+            not_found_custom,
+        )
+    return not_found, EMPTY_ROUTE_MATCH, ST_NF, not_found_custom
+
+
+cdef tuple _resolve(Node root, object host, object path, object method):
+    cdef object params = None
+    cdef object not_found = root.not_found_handler
+    cdef bint not_found_custom = not_found is not None
+    cdef object method_na = root.method_not_allowed_handler
+    cdef object walked
+    cdef Node current = root
+
+    if not_found is None:
+        not_found = default_not_found
+
+    if host:
+        walked = _walk_host(
+            current, host, params, not_found, not_found_custom, method_na
+        )
+        if walked is None:
+            return not_found, EMPTY_ROUTE_MATCH, ST_NF, not_found_custom
+        current = <Node>walked[0]
+        params = walked[1]
+        not_found = walked[2]
+        not_found_custom = walked[3]
+        method_na = walked[4]
+
+    walked = _walk_path(
+        current, path, params, not_found, not_found_custom, method_na
+    )
+    if walked is None:
+        return not_found, EMPTY_ROUTE_MATCH, ST_NF, not_found_custom
+    current = <Node>walked[0]
+    params = walked[1]
+    not_found = walked[2]
+    not_found_custom = walked[3]
+    method_na = walked[4]
+    return _finish_resolve(
+        current, params, not_found, not_found_custom, method_na, method
+    )
+
+
+cdef Node _descend_or_create(Node current, object segment, bint host_label):
+    cdef Node child = _pattern_child(current, segment)
+    cdef object kind
+    cdef object name
+    cdef int child_host_depth
+    if child is not None:
+        return child
+
+    kind = segment.kind
+    name = segment.name
+    child_host_depth = current.host_depth + (1 if host_label else 0)
+
+    if _kind_is(kind, KIND_CATCHALL):
+        if current.catchall is not None:
+            raise StarioError(
+                "Catchall parameter conflict",
+                context={
+                    "existing": current.catchall_name,
+                    "new": name,
+                    "segment": segment.pattern,
+                },
+                help_text="Use the same catchall parameter name for routes sharing this branch.",
+            )
+        if current.wildcard is not None:
+            raise StarioError(
+                "Ambiguous route parameter branch",
+                context={
+                    "existing": current.wildcard_name,
+                    "new": name,
+                    "segment": segment.pattern,
+                },
+                help_text=(
+                    "A wildcard and catchall cannot share the same branch because "
+                    "matching is deterministic and does not backtrack."
+                ),
+            )
+        child = Node(host_depth=child_host_depth)
+        current.catchall_name = name
+        current.catchall = child
+        return child
+
+    if _kind_is(kind, KIND_WILDCARD):
+        if current.wildcard is not None:
+            raise StarioError(
+                "Wildcard parameter conflict",
+                context={
+                    "existing": current.wildcard_name,
+                    "new": name,
+                    "segment": segment.pattern,
+                },
+                help_text="Use the same wildcard parameter name for routes sharing this branch.",
+            )
+        if current.catchall is not None:
+            raise StarioError(
+                "Ambiguous route parameter branch",
+                context={
+                    "existing": current.catchall_name,
+                    "new": name,
+                    "segment": segment.pattern,
+                },
+                help_text=(
+                    "A wildcard and catchall cannot share the same branch because "
+                    "matching is deterministic and does not backtrack."
+                ),
+            )
+        child = Node(host_depth=child_host_depth)
+        current.wildcard_name = name
+        current.wildcard = child
+        return child
+
+    child = Node(host_depth=child_host_depth)
+    current.exact[name] = child
+    return child
+
+
+cdef class Router:
+    """Route table: host routes override hostless defaults when they fully match."""
+
+    def __cinit__(self):
+        self._path = Node()
+        self._hosts = Node()
+        self._has_hosts = False
+        self._static = {}
+        self._cache = {}
+        self._cache_n = 0
+
+    @property
+    def host_routing(self):
+        return self._has_hosts
+
+    cdef void _clear_match_cache(self):
+        self._cache = {}
+        self._cache_n = 0
+
+    cdef void _remember_static(self, object pattern, object method, object result):
+        cdef dict by_method
+        cdef PyObject *p
+        if not _pattern_is_static(pattern):
+            return
+        p = PyDict_GetItem(self._static, pattern.text)
+        if p == NULL:
+            by_method = {}
+            PyDict_SetItem(self._static, pattern.text, by_method)
+        else:
+            by_method = <dict>p
+        PyDict_SetItem(by_method, method, result)
+
+    cpdef tuple find_handler(self, object host, object path, object method):
+        cdef dict by_host
+        cdef dict by_path
+        cdef dict by_method
+        cdef tuple result
+        cdef PyObject *p
+
+        # Hostless exact routes: one/two dict lookups, no cache tuple hashing.
+        # Skip when host routing is active AND the request has a Host — a host
+        # tree hit must win over a hostless exact route of the same path.
+        if not self._has_hosts or not host:
+            p = PyDict_GetItem(self._static, path)
+            if p != NULL:
+                p = PyDict_GetItem(<dict>p, method)
+                if p != NULL:
+                    return <tuple>p
+
+        by_host = self._cache
+        p = PyDict_GetItem(by_host, host)
+        by_path = <dict>p if p != NULL else None
+        if by_path is not None:
+            p = PyDict_GetItem(by_path, path)
+            by_method = <dict>p if p != NULL else None
+            if by_method is not None:
+                p = PyDict_GetItem(by_method, method)
+                if p != NULL:
+                    return <tuple>p
+        else:
+            by_method = None
+
+        result = self._match(host, path, method)
+        if self._cache_n >= CACHE_MAX:
+            self._cache = {}
+            self._cache_n = 0
+            by_host = self._cache
+            by_path = None
+            by_method = None
+        if by_path is None:
+            by_path = {}
+            PyDict_SetItem(by_host, host, by_path)
+            by_method = None
+        if by_method is None:
+            by_method = {}
+            PyDict_SetItem(by_path, path, by_method)
+        PyDict_SetItem(by_method, method, result)
+        self._cache_n += 1
+        return result
+
+    cdef tuple _match(self, object host, object path, object method):
+        cdef object host_key
+        cdef object host_handler
+        cdef object host_match
+        cdef int host_status
+        cdef bint host_nf_custom
+        cdef object path_handler
+        cdef object path_match
+        cdef int path_status
+        cdef tuple resolved
+
+        if self._has_hosts and host:
+            host_key = host.lower() if type(host) is str else host
+            resolved = _resolve(self._hosts, host_key, path, method)
+            host_handler = resolved[0]
+            host_match = resolved[1]
+            host_status = resolved[2]
+            host_nf_custom = resolved[3]
+            if host_status == ST_FOUND:
+                return host_handler, host_match
+            resolved = _resolve(self._path, EMPTY_HOST, path, method)
+            path_handler = resolved[0]
+            path_match = resolved[1]
+            path_status = resolved[2]
+            if path_status == ST_FOUND:
+                return path_handler, path_match
+            if host_status == ST_MNA:
+                return host_handler, host_match
+            if path_status == ST_MNA:
+                return path_handler, path_match
+            if host_nf_custom:
+                return host_handler, host_match
+            return path_handler, path_match
+
+        resolved = _resolve(self._path, EMPTY_HOST, path, method)
+        return resolved[0], resolved[1]
+
+    cdef Node _registration_tree(self, object pattern):
+        if pattern.host:
+            self._has_hosts = True
+            return self._hosts
+        return self._path
+
+    cdef Node _leaf_node(self, object pattern):
+        cdef Node tree = self._registration_tree(pattern)
+        return trie_descend(tree, pattern, True, tree is self._hosts)
+
+    cdef Node _policy_node(self, object pattern):
+        cdef object route = _as_pattern(pattern)
+        cdef object segment
+        if any(segment.kind == KIND_CATCHALL for segment in route.host):
+            raise StarioError(
+                "Catchall host policy is not supported",
+                context={"pattern": route.text},
+                help_text=(
+                    "Use an exact host prefix such as "
+                    "UrlPath('/', host='api.example.com') or apply path policy like '/api'."
+                ),
+            )
+        cdef Py_ssize_t npath = len(route.path)
+        if npath and route.path[npath - 1].kind == KIND_CATCHALL:
+            raise StarioError(
+                "Catchall route policy cannot have child routes",
+                context={"pattern": route.text},
+                help_text="Use a non-catchall prefix such as '/api' for route policy.",
+            )
+        return self._leaf_node(route)
+
+    def use(self, pattern, *middleware):
+        cdef Node current = self._policy_node(pattern)
+        if not middleware:
+            return
+        if _branch_has_endpoints(current):
+            raise StarioError(
+                "Middleware must be registered before matching routes",
+                context={"pattern": pattern},
+                help_text=(
+                    "Call app.use(pattern, ...) before app.add(...) or app.get/post on that prefix. "
+                    "Middleware is baked into route handlers at registration time."
+                ),
+            )
+        current.middleware = current.middleware + tuple(middleware)
+        self._clear_match_cache()
+
+    def not_found(self, pattern, handler):
+        self._policy_node(pattern).not_found_handler = handler
+        self._clear_match_cache()
+
+    def method_not_allowed(self, pattern, handler):
+        self._policy_node(pattern).method_not_allowed_handler = handler
+        self._clear_match_cache()
+
+    def handle(self, method, path, handler, *, middleware=()):
+        cdef object route = _as_pattern(path)
+        cdef Node tree
+        cdef Node current
+        cdef list scoped_middleware
+        cdef object wrapped
+        cdef object mw
+        cdef object existing
+        cdef Endpoint endpoint
+        cdef dict endpoints
+        cdef tuple result
+        method = method.upper()
+        tree = self._registration_tree(route)
+        scoped_middleware = _collect_middleware(tree, route, False)
+        if route.host:
+            scoped_middleware.extend(_collect_middleware(self._path, route, True))
+
+        current = trie_descend(tree, route, True, tree is self._hosts)
+
+        wrapped = handler
+        for mw in reversed([*scoped_middleware, *middleware]):
+            wrapped = mw(wrapped)
+
+        endpoints = current.endpoints
+        existing = None if endpoints is None else endpoints.get(method)
+        if existing is not None:
+            raise StarioError(
+                "Route already registered",
+                context={"method": method, "pattern": route.text},
+                help_text="Each HTTP method may be registered only once per route pattern.",
+            )
+
+        endpoint = Endpoint(
+            wrapped,
+            RouteMatch(
+                pattern=route.text,
+                params=EMPTY_ROUTE_MATCH.params,
+            ),
+        )
+        if endpoints is None:
+            current.endpoints = {method: endpoint}
+        else:
+            endpoints[method] = endpoint
+        if method not in current.methods:
+            current.methods = current.methods | frozenset({method})
+        result = (wrapped, endpoint.route_match)
+        self._remember_static(route, method, result)
+        self._clear_match_cache()
+
+    def add(self, route, handler, *, middleware=()):
+        """Register a `Route`. Path + method stay on `handle()`."""
+        if not isinstance(route, Route):
+            raise StarioError(
+                "add() takes a Route",
+                context={"got": type(route).__name__},
+                help_text=(
+                    "Declare the endpoint with Route.get/post/... and pass that object. "
+                    "Use app.handle(method, path, handler) or app.get(path, handler) "
+                    "for a path without a Route."
+                ),
+            )
+        self.handle(route.method, route.path, handler, middleware=middleware)
+
+    def get(self, path, handler, *, middleware=()):
+        self.handle("GET", path, handler, middleware=middleware)
+
+    def query(self, path, handler, *, middleware=()):
+        self.handle("QUERY", path, handler, middleware=middleware)
+
+    def post(self, path, handler, *, middleware=()):
+        self.handle("POST", path, handler, middleware=middleware)
+
+    def put(self, path, handler, *, middleware=()):
+        self.handle("PUT", path, handler, middleware=middleware)
+
+    def delete(self, path, handler, *, middleware=()):
+        self.handle("DELETE", path, handler, middleware=middleware)
+
+    def patch(self, path, handler, *, middleware=()):
+        self.handle("PATCH", path, handler, middleware=middleware)
+
+    def head(self, path, handler, *, middleware=()):
+        self.handle("HEAD", path, handler, middleware=middleware)
+
+    def options(self, path, handler, *, middleware=()):
+        self.handle("OPTIONS", path, handler, middleware=middleware)
+
+
+__all__ = [
+    "Router",
+    "default_not_found",
+    "method_not_allowed_handler",
+]

--- a/src/stario_cython/serve.py
+++ b/src/stario_cython/serve.py
@@ -16,11 +16,15 @@ the exchange — chunks do not ``call_later``. ``RequestPolicy.max_pipelined_req
 (profiling hatch). Under Server the sweep rides the Date-header tick (1s).
 ``STARIO_CYTHON_TIMEOUT_SWEEP`` overrides the fallback sweeper period used
 without Server (default 1s).
+
+``STARIO_CYTHON_PYTHON_APP=1`` keeps the Python ``App`` / ``Router`` on this
+protocol so Cython vs Python dispatch can be compared on the same build.
 """
 
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 
 from stario.cli.imports import load_symbol
@@ -29,6 +33,17 @@ from stario.http.config import RequestPolicy, ServerConfig, server_config_from_e
 from stario.http.server import Server
 from stario.telemetry.noop import NoOpTracer
 from stario_cython.protocol import HttpProtocol
+
+
+def _resolve_app_class():
+    """Cython App unless ``STARIO_CYTHON_PYTHON_APP=1`` (Python App baseline)."""
+    if os.environ.get("STARIO_CYTHON_PYTHON_APP") == "1":
+        from stario.http.app import App
+
+        return App
+    from stario_cython.app import App
+
+    return App
 
 
 def _make_cython_protocol(
@@ -83,6 +98,7 @@ def _server(bootstrap: Bootstrap, config: ServerConfig) -> Server:
         NoOpTracer(),
         config=config,
         make_protocol=_make_cython_protocol,
+        app_factory=_resolve_app_class(),
     )
 
 

--- a/tests/cython/test_router.py
+++ b/tests/cython/test_router.py
@@ -392,3 +392,25 @@ async def test_cython_app_plaintext_and_params_over_protocol() -> None:
         assert b"42" in second
         writer.close()
         await writer.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_sync_handler_skips_create_task_over_protocol() -> None:
+    app = App()
+    tasks_before = []
+
+    def plaintext(_c, w):
+        tasks_before.append(len(app.tasks))
+        responses.text(w, "sync-ok")
+
+    app.get("/plaintext", plaintext)
+
+    async with running_server(app) as port:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(b"GET /plaintext HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+        await writer.drain()
+        body = await read_response(reader)
+        assert b"sync-ok" in body
+        writer.close()
+        await writer.wait_closed()
+    assert tasks_before == [0]

--- a/tests/cython/test_router.py
+++ b/tests/cython/test_router.py
@@ -1,0 +1,394 @@
+"""Parity and behavior tests for the Cython Router and App."""
+
+import asyncio
+
+import pytest
+from stario_cython.app import App
+from stario_cython.router import (
+    Router,
+    default_not_found,
+    method_not_allowed_handler,
+)
+
+import stario.responses as responses
+from stario.exceptions import (
+    ClientDisconnected,
+    HttpException,
+    RedirectException,
+    StarioError,
+    StarioRuntime,
+)
+from stario.http.context import EMPTY_ROUTE_MATCH, Context
+from stario.http.dispatch import (
+    Router as PyRouter,
+    default_not_found as py_default_not_found,
+    method_not_allowed_handler as py_method_not_allowed_handler,
+)
+from stario.http.writer import Writer
+from stario.routing import Route, UrlPath
+from tests.cython.http import read_response, running_server
+from tests.helpers import DummyWriter, make_context
+
+
+async def noop_handler(c: Context, w: Writer) -> None:
+    return None
+
+
+def _register(router: PyRouter | Router) -> None:
+    router.get("/plaintext", noop_handler)
+    router.get("/json", noop_handler)
+    router.get("/user/{user_id}", noop_handler)
+    router.get("/users/{user_id}/posts/{post_id}", noop_handler)
+    router.get("/files/{path...}", noop_handler)
+    router.post("/echo", noop_handler)
+    router.get(UrlPath("/users", host="api.example.com"), noop_handler)
+    router.get(UrlPath("/dashboard", host="{subhost}.example.com"), noop_handler)
+    router.get(UrlPath("/x", host="{tenant...}.cdn.example.com"), noop_handler)
+    router.post("/api", noop_handler)
+    router.get("/health", noop_handler)
+    router.get("/foo/POST", noop_handler)
+
+
+CASES = [
+    ("", "/plaintext", "GET"),
+    ("", "/json", "GET"),
+    ("", "/user/42", "GET"),
+    ("", "/users/42/posts/7", "GET"),
+    ("", "/files/docs/readme.txt", "GET"),
+    ("", "/missing", "GET"),
+    ("", "/plaintext", "POST"),
+    ("", "/echo", "POST"),
+    ("", "/echo", "GET"),
+    ("api.example.com", "/users", "GET"),
+    ("api.example.com", "/users", "POST"),
+    ("www.example.org", "/health", "GET"),
+    ("acme.example.com", "/dashboard", "GET"),
+    ("a.b.cdn.example.com", "/x", "GET"),
+    ("api.example.com", "/api", "POST"),
+    ("", "/", "GET"),
+    ("", "/foo/POST", "GET"),
+    ("", "/foo", "GET"),
+    ("API.Example.Com", "/users", "GET"),
+]
+
+
+def test_find_handler_parity_with_python_router() -> None:
+    py = PyRouter()
+    cy = Router()
+    _register(py)
+    _register(cy)
+
+    for host, path, method in CASES:
+        py_handler, py_match = py.find_handler(host, path, method)
+        cy_handler, cy_match = cy.find_handler(host, path, method)
+        assert py_match.pattern == cy_match.pattern, (host, path, method)
+        assert dict(py_match.params) == dict(cy_match.params), (host, path, method)
+        if py_handler is py_default_not_found:
+            assert cy_handler is default_not_found
+        elif py_match is EMPTY_ROUTE_MATCH and py_handler is not py_default_not_found:
+            assert cy_match is EMPTY_ROUTE_MATCH
+            assert cy_handler is not default_not_found
+        else:
+            assert py_handler is not None
+            assert cy_handler is not None
+
+
+def test_static_exact_and_wildcard_coexist() -> None:
+    router = Router()
+    router.get("/users/me", noop_handler)
+    router.get("/users/{user_id}", noop_handler)
+
+    _, me = router.find_handler("", "/users/me", "GET")
+    _, other = router.find_handler("", "/users/42", "GET")
+
+    assert me.pattern == "/users/me"
+    assert dict(me.params) == {}
+    assert other.pattern == "/users/{user_id}"
+    assert dict(other.params) == {"user_id": "42"}
+
+
+def test_host_route_wins_over_hostless_exact() -> None:
+    async def host_handler(c: Context, w: Writer) -> None:
+        return None
+
+    async def path_handler(c: Context, w: Writer) -> None:
+        return None
+
+    router = Router()
+    router.get("/health", path_handler)
+    router.get(UrlPath("/health", host="api.example.com"), host_handler)
+
+    handler, match = router.find_handler("api.example.com", "/health", "GET")
+    assert handler is host_handler
+    assert match.pattern == "api.example.com/health"
+
+    handler, match = router.find_handler("www.example.org", "/health", "GET")
+    assert handler is path_handler
+    assert match.pattern == "/health"
+
+
+def test_matches_path_params() -> None:
+    router = Router()
+    router.get("/users/{user_id}/posts/{post_id}", noop_handler)
+    _, match = router.find_handler("", "/users/42/posts/7", "GET")
+    assert match.pattern == "/users/{user_id}/posts/{post_id}"
+    assert dict(match.params) == {"user_id": "42", "post_id": "7"}
+
+
+def test_matches_catchall_params() -> None:
+    router = Router()
+    router.get("/files/{path...}", noop_handler)
+    _, match = router.find_handler("", "/files/docs/readme.txt", "GET")
+    assert match.pattern == "/files/{path...}"
+    assert dict(match.params) == {"path": "docs/readme.txt"}
+
+
+def test_method_not_allowed_allow_header_sorted() -> None:
+    router = Router()
+    router.get("/r", noop_handler)
+    router.post("/r", noop_handler)
+    router.patch("/r", noop_handler)
+    handler, _ = router.find_handler("", "/r", "DELETE")
+    assert handler is method_not_allowed_handler(frozenset({"GET", "PATCH", "POST"}))
+
+    async def _run():
+        w = DummyWriter()
+        await handler(make_context(loop=asyncio.get_running_loop()), w)
+        return w
+
+    writer = asyncio.run(_run())
+    assert writer.headers.get("Allow") == "GET, PATCH, POST"
+
+
+def test_hostless_fallback_and_host_params() -> None:
+    router = Router()
+    router.get("/health", noop_handler)
+    router.get(UrlPath("/dashboard", host="{subhost}.example.com"), noop_handler)
+    router.get(UrlPath("/x", host="{tenant...}.cdn.example.com"), noop_handler)
+
+    _, health = router.find_handler("www.example.org", "/health", "GET")
+    assert health.pattern == "/health"
+
+    _, dash = router.find_handler("acme.example.com", "/dashboard", "GET")
+    assert dict(dash.params) == {"subhost": "acme"}
+    assert dash.pattern == "{subhost}.example.com/dashboard"
+
+    _, tenant = router.find_handler("a.b.cdn.example.com", "/x", "GET")
+    assert dict(tenant.params) == {"tenant": "a.b"}
+    assert tenant.pattern == "{tenant...}.cdn.example.com/x"
+
+
+def test_add_registers_route() -> None:
+    router = Router()
+    router.add(Route.post("/rooms/{room_id}/send"), noop_handler)
+    _, match = router.find_handler("", "/rooms/7/send", "POST")
+    assert match.pattern == "/rooms/{room_id}/send"
+    assert dict(match.params) == {"room_id": "7"}
+
+
+def test_rejects_duplicate_route() -> None:
+    router = Router()
+    router.get("/hello", noop_handler)
+    with pytest.raises(StarioError, match="Route already registered"):
+        router.get("/hello", noop_handler)
+
+
+def test_cache_hit_returns_same_route_match() -> None:
+    router = Router()
+    router.get("/user/{user_id}", noop_handler)
+    _, first = router.find_handler("", "/user/42", "GET")
+    _, second = router.find_handler("", "/user/42", "GET")
+    assert first is second
+    assert dict(first.params) == {"user_id": "42"}
+
+
+def test_use_applies_middleware() -> None:
+    calls: list[str] = []
+
+    def scope_middleware(handler):
+        async def wrapped(c, w):
+            calls.append("scope")
+            await handler(c, w)
+
+        return wrapped
+
+    router = Router()
+    router.use("/", scope_middleware)
+    router.get("/users", noop_handler)
+    handler, _ = router.find_handler("", "/users", "GET")
+
+    async def _run() -> None:
+        await handler(make_context(loop=asyncio.get_running_loop()), DummyWriter())
+
+    asyncio.run(_run())
+    assert calls == ["scope"]
+
+
+def test_query_registers_rfc_query_method() -> None:
+    router = Router()
+    router.query("/feed", noop_handler)
+    _, feed = router.find_handler("", "/feed", "QUERY")
+    assert feed.pattern == "/feed"
+
+
+def _run_app(setup, path, method="GET", host="", query=None):
+    async def _run():
+        app = App()
+        setup(app)
+        loop = asyncio.get_running_loop()
+        ctx = make_context(path, method, host, app=app, query=query, loop=loop)
+        w = DummyWriter()
+        await app(ctx, w)
+        return ctx, w
+
+    return asyncio.run(_run())
+
+
+def test_app_trailing_slash_redirect_preserves_query() -> None:
+    _ctx, writer = _run_app(
+        lambda _app: None, "/search/", query={"q": "cats", "page": 2}
+    )
+    assert writer.status == 308
+    assert writer.headers.unsafe_get(b"location") == b"/search?q=cats&page=2"
+
+
+def test_app_params_and_http_exception() -> None:
+    seen: list[str] = []
+
+    async def handler(c, w):
+        seen.append(c.route.params["user_id"])
+        raise HttpException(422, "nope")
+
+    _ctx, writer = _run_app(lambda app: app.get("/user/{user_id}", handler), "/user/42")
+    assert seen == ["42"]
+    assert writer.status == 422
+    assert writer.body == "nope"
+
+
+def test_app_redirect_and_client_disconnected() -> None:
+    async def redirect(_c, _w):
+        raise RedirectException(303, "/next")
+
+    _ctx, writer = _run_app(lambda app: app.get("/go", redirect), "/go")
+    assert writer.status == 303
+    assert writer.headers.get("location") == "/next"
+
+    async def gone(_c, _w):
+        raise ClientDisconnected()
+
+    _ctx, writer = _run_app(lambda app: app.get("/x", gone), "/x")
+    assert writer.status is None
+    assert writer.completed
+
+
+def test_app_create_task_eager_start() -> None:
+    async def _run() -> None:
+        app = App()
+        started = False
+
+        async def worker():
+            nonlocal started
+            started = True
+            return 7
+
+        task = app.create_task(worker(), eager_start=True)
+        assert started
+        assert task.done()
+        assert task.result() == 7
+        assert task not in app.tasks
+
+    asyncio.run(_run())
+
+
+def test_app_handler_must_send_response() -> None:
+    async def missing(_c, _w):
+        return None
+
+    async def runtime_error_handler(_c, w, exc):
+        assert type(exc) is StarioRuntime
+        w.respond(b"missing", b"text/plain", 500)
+
+    def setup(app):
+        app.on_error(StarioRuntime, runtime_error_handler)
+        app.get("/missing", missing)
+
+    _ctx, writer = _run_app(setup, "/missing")
+    assert writer.status == 500
+    assert writer.body == "missing"
+
+
+def test_app_on_error_mro_and_handler_failure() -> None:
+    async def custom(_c, w, _exc):
+        w.respond(b"handled", b"text/plain", 418)
+
+    class MyValueError(ValueError):
+        pass
+
+    async def boom(_c, _w):
+        raise MyValueError("subtype")
+
+    _ctx, writer = _run_app(
+        lambda app: (app.on_error(ValueError, custom), app.get("/x", boom)),
+        "/x",
+    )
+    assert writer.status == 418
+    assert writer.body == "handled"
+
+    async def bad(_c, _w, _exc):
+        raise RuntimeError("handler failed")
+
+    async def orig(_c, _w):
+        raise ValueError("original")
+
+    _ctx, writer = _run_app(
+        lambda app: (app.on_error(ValueError, bad), app.get("/x", orig)),
+        "/x",
+    )
+    assert writer.status == 500
+    assert writer.body == "Internal Server Error"
+
+
+def test_app_requires_running_loop() -> None:
+    with pytest.raises(StarioError, match="requires a running event loop"):
+        App()
+
+
+def test_python_405_identity_not_required_on_cython() -> None:
+    """Cython 405 handlers are equivalent, not the Python lru_cache object."""
+    py = PyRouter()
+    cy = Router()
+    py.get("/r", noop_handler)
+    cy.get("/r", noop_handler)
+    py_handler, _ = py.find_handler("", "/r", "POST")
+    cy_handler, _ = cy.find_handler("", "/r", "POST")
+    assert py_handler is py_method_not_allowed_handler(frozenset({"GET"}))
+    assert cy_handler is method_not_allowed_handler(frozenset({"GET"}))
+    assert py_handler is not cy_handler
+
+
+@pytest.mark.asyncio
+async def test_cython_app_plaintext_and_params_over_protocol() -> None:
+    app = App()
+
+    async def plaintext(_c, w):
+        responses.text(w, "Hello, World!")
+
+    async def get_user(c, w):
+        responses.text(w, c.route.params["user_id"])
+
+    app.get("/plaintext", plaintext)
+    app.get("/user/{user_id}", get_user)
+
+    async with running_server(app) as port:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(b"GET /plaintext HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+        await writer.drain()
+        first = await read_response(reader)
+        assert b"Hello, World!" in first
+
+        writer.write(b"GET /user/42 HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+        await writer.drain()
+        second = await read_response(reader)
+        assert b"42" in second
+        writer.close()
+        await writer.wait_closed()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -109,6 +109,18 @@ class TestAppErrorSurface:
         assert writer.status == 422
         assert writer.body == "nope"
 
+    def test_sync_handler_text_response(self):
+        def handler(_c: Context, w: Writer) -> None:
+            w.respond(b"ok", b"text/plain", 200)
+
+        def setup(app: App) -> None:
+            app.get("/x", handler)
+
+        _context, writer = run_with_app(setup, "/x")
+
+        assert writer.status == 200
+        assert writer.body == "ok"
+
     def test_default_redirect_exception_handler(self):
         async def handler(_c: Context, _w: Writer) -> None:
             raise RedirectException(303, "/next")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Proof of concept: compiled Cython `App`/`Router`, then **sync GET dispatch** so the keep-alive path has no `asyncio.Task`. Profiler said that was the Granian GET gap; wrk now shows Stario **ahead** on plaintext on this host.

## Why

Every request on the Cython protocol used to enter `App.__call__` + `asyncio.Task(eager_start=True)` even when the handler never awaited. py-spy + strace + a uvloop microbench (`baseline-20260829-granian-gap.md`) showed the remaining ~11% Granian lead was that userspace (~740 ns), not I/O (already 1 `read` + 1 `writev`) and not the router (~57 ns).

## What changed

- **Cython Router**: cdef trie; hostless exact routes hit `_static[path][method]`.
- **`App.dispatch` / `dispatch_exchange`**: `def` handlers run inline (no Task, no App/handler coroutine). `async def` returns a continuation the protocol still `create_task`s.
- **`HttpProtocol._start_exchange`**: prefers `dispatch_exchange` on `RequestExchange`.
- Benchmark GET `/plaintext`, `/json`, `/user/{id}` are **sync**. POST stays async. Bodies are still encoded per request (handler policy).
- **`STARIO_CYTHON_PYTHON_APP=1`**: Python App also has `dispatch` for the same protocol.

## wrk vs Granian RSGI (GET)

Official knobs: `RUNS=5 WARMUP=1 DURATION=10s THREADS=2 CONNECTIONS=128`.

| Run | Stario plaintext | Granian | Stario / Granian |
| --- | ---: | ---: | ---: |
| Cython App, async GET (`20260828T210831Z`) | 136,005 | **151,270** | 0.90× |
| Sync `dispatch` (`20260829T061538Z`) | 144,802 | **150,019** | 0.97× |
| + `dispatch_exchange` (`20260829T062337Z`) | **152,836** | 150,095 | **1.02×** |
| GET trio (`20260829T062546Z`) | **163,892** | 146,041 | **1.12×** |

GET trio (`plaintext` / `json` / `params`):

| Endpoint | Stario | Granian | Stario / Granian |
| --- | ---: | ---: | ---: |
| Plaintext | **163,892** | 146,041 | **1.12×** |
| JSON | **152,699** | 151,269 | 1.01× |
| Params | **158,827** | 150,484 | **1.06×** |

Same-host wrk still moves; Stario was 145k–164k across these runs. Direction is stable after dropping Task+coroutines on GET.

Reproduce:

```bash
RUNS=5 WARMUP=1 DURATION=10s THREADS=2 CONNECTIONS=128 \
  ENDPOINTS=plaintext,json,params \
  benchmarks/server/run.sh stario-cython granian-rsgi
```

Earlier App vs Python App vs Granian (async GET) table: [`baseline-20260828-app-router.md`](../blob/cursor/cython-app-router-poc-b193/benchmarks/server/baseline-20260828-app-router.md). Profiler write-up: [`baseline-20260829-granian-gap.md`](../blob/cursor/cython-app-router-poc-b193/benchmarks/server/baseline-20260829-granian-gap.md).

## Tests

`pytest tests`: **773 passed**.

## Further

`responses.text` is still Python; header-template `respond` is optional next. Do not clone `Task.__step` around `coro.send(None)` — that is how we do *not* skip Task for async handlers that suspend.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6d67040-8298-4b50-bafb-c7f9a73bb193?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6d67040-8298-4b50-bafb-c7f9a73bb193&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

