### PR TITLE
Cython HTTP: C complete-message parser vs zttp / httptools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## Unreleased
 
+### Changed
+
+- Cython HTTP/1.1 parse: complete identity-body requests use a C
+  complete-message scanner (`vendor/stario_h1`) that writes the existing
+  llhttp callbacks and `llhttp_t` fields. Chunked / Expect / split reads
+  still use llhttp. `STARIO_CYTHON_PARSER=llhttp` disables the fast path.
+  Parser microbench: `benchmarks/parser_micro.py` (httptools, zttp, Cython
+  llhttp, C h1).
+
 ## 4.1.0 - 2026-08-17
 
 ### Added

--- a/CYTHON.md
+++ b/CYTHON.md
@@ -1,7 +1,21 @@
 # Cython protocol (cython-core)
 
 This worktree is `projects/stario` on branch `cython-core`. uvloop owns the
-socket and llhttp parses in C. The protocol lives in `src/stario_cython`.
+socket. Complete identity-body HTTP/1.1 requests (wrk keep-alive GETs, small
+POSTs) parse in `vendor/stario_h1` — a strict C complete-message scanner that
+fires the same callbacks and fills the same `llhttp_t` fields as llhttp.
+Chunked bodies, Expect: 100-continue, unknown methods, and split reads fall
+back to llhttp. The protocol lives in `src/stario_cython`.
+
+`STARIO_CYTHON_PARSER=llhttp` forces llhttp for every request (A/B hatch).
+
+HTTP/3 cannot ride `asyncio.Protocol`. That API is a TCP/Unix byte stream.
+HTTP/3 is HTTP over QUIC over UDP: you need `asyncio.DatagramProtocol` (or a
+raw UDP socket) and a QUIC stack. zttp's Python API can parse HTTP/3 if you
+feed whole datagrams (`receive_datagram`), but that is a second server path,
+not a drop-in on this protocol. TLS is mandatory and lives inside QUIC, not
+as `ssl.SSLContext` on a stream transport. HTTP/2 *can* share
+`asyncio.Protocol` (TCP + TLS + ALPN).
 
 `projects/stario` stays on `main` and stays a workspace member. Do not
 `uv sync` this folder from the monorepo root. Use an isolated venv:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -8,6 +8,8 @@ Three suites, one per layer we care about:
   servers and ASGI framework stacks under `wrk`.
 - `headers_micro.py` — Cython request-header storage tradeoffs: eager dict,
   current-style lazy dict, direct arena scans, and adaptive promotion.
+- `parser_micro.py` — HTTP/1.1 request parse: httptools, zttp, Cython
+  llhttp callbacks, and the complete-message C scanner.
 
 The goal is repeatable local signal, not lab-grade numbers. Run on a quiet
 machine and compare repeated runs before drawing conclusions.
@@ -37,6 +39,22 @@ HEADERS_BENCH_REPEATS=9 \
 HEADERS_BENCH_JSON=/tmp/headers-micro.json \
 PYTHONPATH=src:. .venv/bin/python benchmarks/headers_micro.py
 ```
+
+## HTTP/1.1 parser (`parser_micro.py`)
+
+Compares the language-boundary cost of one complete request:
+
+- `cython-h1` — `stario_h1_try` (production complete-message path)
+- `cython-llhttp` — `llhttp_execute` with the same C callbacks
+- `httptools` — Python callback API (what the Python Stario protocol uses)
+- `zttp` — Zig core, pull events (optional: `uv pip install zttp`)
+
+```bash
+PYTHONPATH=src:. .venv/bin/python benchmarks/parser_micro.py
+```
+
+`PARSER_BENCH_ITERATIONS`, `PARSER_BENCH_REPEATS`, and `PARSER_BENCH_JSON`
+override defaults. This is not a substitute for `benchmarks/server`.
 
 ## HTML generation (`html/`)
 

--- a/benchmarks/parser_micro.py
+++ b/benchmarks/parser_micro.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Parser microbench: httptools, zttp, Cython llhttp, complete-message C.
+
+Measures one complete request at a time (the wrk keep-alive shape). This is
+not a server bench — it isolates parser + language-boundary cost.
+
+    PYTHONPATH=src:. .venv/bin/python benchmarks/parser_micro.py
+
+Environment:
+
+    PARSER_BENCH_ITERATIONS=200000
+    PARSER_BENCH_REPEATS=7
+    PARSER_BENCH_JSON=/tmp/parser-micro.json
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from stario_cython.parser_bench import (  # noqa: E402
+    bench_h1,
+    bench_llhttp,
+    parse_h1_once,
+)
+
+ITERATIONS = int(os.environ.get("PARSER_BENCH_ITERATIONS", "200000"))
+REPEATS = int(os.environ.get("PARSER_BENCH_REPEATS", "7"))
+JSON_PATH = os.environ.get("PARSER_BENCH_JSON")
+
+GET = (
+    b"GET /plaintext HTTP/1.1\r\n"
+    b"Host: 127.0.0.1\r\n"
+    b"User-Agent: wrk\r\n"
+    b"Accept: */*\r\n"
+    b"\r\n"
+)
+
+POST = (
+    b"POST /echo HTTP/1.1\r\n"
+    b"Host: 127.0.0.1\r\n"
+    b"Content-Type: application/json\r\n"
+    b"Content-Length: 23\r\n"
+    b"\r\n"
+    b'{"name":"Ada","age":42}'
+)
+
+CASES = (("simple GET", GET), ("POST + JSON body", POST))
+
+
+class _HttpToolsSink:
+    __slots__ = ()
+
+    def on_message_begin(self) -> None:
+        return None
+
+    def on_url(self, url: bytes) -> None:
+        return None
+
+    def on_header(self, name: bytes, value: bytes) -> None:
+        return None
+
+    def on_headers_complete(self) -> None:
+        return None
+
+    def on_body(self, body: bytes) -> None:
+        return None
+
+    def on_message_complete(self) -> None:
+        return None
+
+
+def _bench_httptools(payload: bytes, repeats: int) -> None:
+    from httptools import HttpRequestParser
+
+    sink = _HttpToolsSink()
+    parser = HttpRequestParser(sink)
+    for _ in range(repeats):
+        parser.feed_data(payload)
+
+
+def _bench_zttp(payload: bytes, repeats: int) -> None:
+    import zttp
+
+    conn = zttp.Connection(zttp.SERVER)
+    need = zttp.NEED_DATA
+    for _ in range(repeats):
+        event = conn.receive_event(payload)
+        if event is need:
+            raise RuntimeError("zttp.receive_event returned NEED_DATA")
+        while True:
+            nxt = conn.next_event()
+            if nxt is need:
+                break
+        conn.start_next_cycle()
+
+
+def _time(fn, payload: bytes) -> float:
+    start = time.perf_counter()
+    fn(payload, ITERATIONS)
+    return time.perf_counter() - start
+
+
+def _median_rps(samples: list[float]) -> tuple[float, float]:
+    rates = [ITERATIONS / s for s in samples]
+    if len(rates) == 1:
+        return rates[0], 0.0
+    return statistics.median(rates), statistics.stdev(rates)
+
+
+def _try_import(name: str):
+    try:
+        return __import__(name)
+    except ImportError:
+        return None
+
+
+def main() -> int:
+    consumed, method, flags = parse_h1_once(GET)
+    if consumed != len(GET) or method != 1:
+        print(
+            f"stario_h1 sanity failed: consumed={consumed} method={method}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"stario_h1 GET ok consumed={consumed} method={method} flags={flags}")
+
+    engines: list[tuple[str, object]] = [
+        ("cython-h1 (complete C)", bench_h1),
+        ("cython-llhttp (callbacks)", bench_llhttp),
+    ]
+    if _try_import("httptools") is not None:
+        engines.append(("httptools (Python callbacks)", _bench_httptools))
+    if _try_import("zttp") is not None:
+        engines.append(("zttp (Zig / pull events)", _bench_zttp))
+    else:
+        print("zttp not installed; skip that row (uv pip install zttp)")
+
+    rows: list[dict[str, object]] = []
+    print(f"iterations={ITERATIONS} repeats={REPEATS}")
+    print()
+    for case_name, payload in CASES:
+        print(f"## {case_name} ({len(payload)} bytes)")
+        print(f"{'engine':<32} {'req/s':>12} {'stdev':>10}")
+        print("-" * 56)
+        for engine_name, fn in engines:
+            fn(payload, max(200, ITERATIONS // 50))
+            samples = [_time(fn, payload) for _ in range(REPEATS)]
+            median, stdev = _median_rps(samples)
+            print(f"{engine_name:<32} {median:12,.0f} {stdev:10,.0f}")
+            rows.append(
+                {
+                    "case": case_name,
+                    "engine": engine_name,
+                    "bytes": len(payload),
+                    "median_rps": median,
+                    "stdev_rps": stdev,
+                    "iterations": ITERATIONS,
+                    "repeats": REPEATS,
+                }
+            )
+        print()
+
+    if JSON_PATH:
+        Path(JSON_PATH).write_text(json.dumps(rows, indent=2) + "\n")
+        print(f"wrote {JSON_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ Issues = "https://github.com/bobowski/stario/issues"
 
 [project.optional-dependencies]
 uvloop = ["uvloop>=0.21.0,<1"]
+zttp = ["zttp"]
 
 [project.scripts]
 stario = "stario.cli.main:main"

--- a/setup.py
+++ b/setup.py
@@ -69,9 +69,33 @@ extensions = [
             "vendor/llhttp/src/http.c",
             "vendor/llhttp/src/api.c",
             "vendor/llhttp/src/stario_alloc.c",
+            "vendor/stario_h1/stario_h1.c",
         ],
-        include_dirs=["vendor/llhttp/include", "vendor", "src"],
-        extra_compile_args=["-O3", "-fno-strict-aliasing"],
+        include_dirs=[
+            "vendor/llhttp/include",
+            "vendor/stario_h1",
+            "vendor",
+            "src",
+        ],
+        extra_compile_args=["-O3", "-fno-strict-aliasing", "-msse2"],
+    ),
+    Extension(
+        "stario_cython.parser_bench",
+        sources=[
+            "src/stario_cython/parser_bench.pyx",
+            "vendor/llhttp/src/llhttp.c",
+            "vendor/llhttp/src/http.c",
+            "vendor/llhttp/src/api.c",
+            "vendor/llhttp/src/stario_alloc.c",
+            "vendor/stario_h1/stario_h1.c",
+        ],
+        include_dirs=[
+            "vendor/llhttp/include",
+            "vendor/stario_h1",
+            "vendor",
+            "src",
+        ],
+        extra_compile_args=["-O3", "-fno-strict-aliasing", "-msse2"],
     ),
 ]
 

--- a/src/stario/http/server.py
+++ b/src/stario/http/server.py
@@ -3,6 +3,10 @@ Runs `App` behind an asyncio listener: signal handling, bootstrap, graceful drai
 
 Bootstrap startup completes before `start_serving`; exceptions there fail startup loudly. Transport policy
 (TCP vs Unix, backlog, compression defaults) lives here so `Router`/`App` stay free of process-level concerns.
+
+``STARIO_HTTP_PARSER=zttp`` selects the optional Zig pull parser for the
+Python protocol. The Cython server ignores that variable and uses
+``STARIO_CYTHON_PARSER`` instead.
 """
 
 import asyncio
@@ -31,7 +35,21 @@ from .bootstrap import (
 )
 from .compression import CompressionConfig
 from .config import RequestPolicy, ServerConfig
-from .protocol import HttpProtocol
+from .protocol import HttpProtocol as PythonHttpProtocol
+
+
+def _python_http_protocol() -> type[PythonHttpProtocol]:
+    """httptools by default; ``STARIO_HTTP_PARSER=zttp`` selects the Zig parser."""
+    if os.environ.get("STARIO_HTTP_PARSER") != "zttp":
+        return PythonHttpProtocol
+    try:
+        from .zttp_protocol import HttpProtocol as ZttpHttpProtocol
+    except ImportError as exc:
+        raise StarioError(
+            "STARIO_HTTP_PARSER=zttp requires the zttp package",
+            help_text="Install zttp (pip install zttp) or unset STARIO_HTTP_PARSER.",
+        ) from exc
+    return ZttpHttpProtocol
 
 # Connections may be the Python protocol or the Cython HttpProtocol.
 type Connection = Any
@@ -209,7 +227,7 @@ class Server:
                     connections,
                     self.config.requests,
                 )
-            return HttpProtocol(
+            return _python_http_protocol()(
                 loop,
                 app,
                 self.tracer,

--- a/src/stario/http/zttp_protocol.py
+++ b/src/stario/http/zttp_protocol.py
@@ -1,0 +1,121 @@
+"""Python HTTP/1.1 protocol using zttp (Zig pull parser) instead of httptools.
+
+Selected with ``STARIO_HTTP_PARSER=zttp``. The Cython server does not use this:
+complete requests go through ``vendor/stario_h1`` and the rest through llhttp.
+This module exists so the Python path can A/B zttp against httptools.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import zttp
+
+from stario.exceptions import StarioError
+
+from .protocol import HttpProtocol as HttpToolsProtocol
+
+
+class _ParserShim:
+    """Stand-in for ``httptools.HttpRequestParser`` getters."""
+
+    __slots__ = ("_keep_alive", "_method", "_version")
+
+    def __init__(self) -> None:
+        self._method = b"GET"
+        self._version = "1.1"
+        self._keep_alive = True
+
+    def get_method(self) -> bytes:
+        return self._method
+
+    def get_http_version(self) -> str:
+        return self._version
+
+    def should_keep_alive(self) -> bool:
+        return self._keep_alive
+
+
+class HttpProtocol(HttpToolsProtocol):
+    """Same connection/pipeline/timeout behavior; zttp pulls events."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.parser = _ParserShim()
+        self._zttp = zttp.Connection(zttp.SERVER)
+        self._shim = cast(_ParserShim, self.parser)
+
+    def connection_lost(self, exc: Exception | None) -> None:
+        super().connection_lost(exc)
+        self._zttp = None
+
+    def data_received(self, data: bytes) -> None:
+        if self._rejected:
+            return
+        conn = self._zttp
+        if conn is None:
+            return
+        if self._timeout_kind == "idle":
+            self._cancel_timeout()
+        try:
+            event = conn.receive_event(data)
+            self._dispatch_event(event)
+            self._drain_events()
+        except zttp.RemoteProtocolError:
+            self._close_with_error(400, "Invalid HTTP request")
+        except zttp.LocalProtocolError as exc:
+            raise StarioError(
+                "zttp local protocol error",
+                context={"error": str(exc)},
+            ) from exc
+
+    def _drain_events(self) -> None:
+        conn = self._zttp
+        if conn is None or self._rejected:
+            return
+        while True:
+            event = conn.next_event()
+            if event is zttp.NEED_DATA:
+                return
+            self._dispatch_event(event)
+            if self._rejected:
+                return
+
+    def _dispatch_event(self, event: object) -> None:
+        if event is zttp.NEED_DATA:
+            return
+        if isinstance(event, zttp.Request):
+            self._on_zttp_request(event)
+            return
+        if isinstance(event, zttp.Data):
+            self.on_body(event.data)
+            return
+        if isinstance(event, zttp.EndOfMessage):
+            self._finish_zttp_message()
+
+    def _on_zttp_request(self, event: zttp.Request) -> None:
+        conn = self._zttp
+        if conn is None:
+            return
+        self.on_message_begin()
+        self.on_url(event.target)
+        for name, value in event.headers:
+            self.on_header(name, value)
+        self._shim._method = event.method
+        version = event.http_version
+        self._shim._version = (
+            version.decode("ascii") if isinstance(version, bytes) else str(version)
+        )
+        self._shim._keep_alive = not conn.should_close()
+        self.parser = self._shim
+        self.on_headers_complete()
+        if event.end_stream:
+            self._finish_zttp_message()
+
+    def _finish_zttp_message(self) -> None:
+        self.on_message_complete()
+        conn = self._zttp
+        if conn is None or self._rejected:
+            return
+        conn.start_next_cycle()
+        self._drain_events()

--- a/src/stario_cython/__init__.py
+++ b/src/stario_cython/__init__.py
@@ -1,4 +1,4 @@
-"""Cython protocol for Stario: uvloop owns the socket, llhttp parses, App runs."""
+"""Cython protocol for Stario: uvloop owns the socket, C/llhttp parse, App runs."""
 
 from __future__ import annotations
 

--- a/src/stario_cython/llhttp.pxd
+++ b/src/stario_cython/llhttp.pxd
@@ -1,4 +1,4 @@
-from libc.stdint cimport uint8_t, uint16_t, uint64_t
+from libc.stdint cimport int64_t, uint8_t, uint16_t, uint64_t
 
 
 cdef extern from "llhttp.h":
@@ -63,3 +63,14 @@ cdef extern from "stario_alloc.h":
     void* stario_parser_get_data(const llhttp_t* parser)
     uint16_t stario_parser_flags(const llhttp_t* parser)
     uint64_t stario_parser_content_length(const llhttp_t* parser)
+
+cdef extern from "stario_h1.h":
+    int64_t STARIO_H1_ERROR
+    int64_t STARIO_H1_INCOMPLETE
+    int64_t stario_h1_try(
+        llhttp_t* parser,
+        const llhttp_settings_t* settings,
+        const char* data,
+        size_t len,
+        size_t max_message,
+    )

--- a/src/stario_cython/parser_bench.pyx
+++ b/src/stario_cython/parser_bench.pyx
@@ -1,0 +1,93 @@
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+"""Native parser sinks for ``benchmarks/parser_micro.py``."""
+
+from libc.stdint cimport int64_t
+
+from stario_cython.llhttp cimport *
+
+
+cdef int _sink_ok(llhttp_t* parser) noexcept:
+    return 0
+
+
+cdef int _sink_data(llhttp_t* parser, const char* at, size_t length) noexcept:
+    return 0
+
+
+cdef llhttp_settings_t* _SINK = NULL
+
+
+cdef void _bind_sink() noexcept:
+    global _SINK
+    if _SINK != NULL:
+        return
+    _SINK = stario_settings_new()
+    _SINK.on_message_begin = _sink_ok
+    _SINK.on_url = _sink_data
+    _SINK.on_header_field = _sink_data
+    _SINK.on_header_value = _sink_data
+    _SINK.on_header_value_complete = _sink_ok
+    _SINK.on_headers_complete = _sink_ok
+    _SINK.on_body = _sink_data
+    _SINK.on_message_complete = _sink_ok
+
+
+def bench_llhttp(bytes data, int repeats):
+    cdef llhttp_t* parser
+    cdef const char* ptr = data
+    cdef size_t n = <size_t>len(data)
+    cdef int i
+    cdef int err
+    _bind_sink()
+    parser = stario_parser_new()
+    if parser == NULL:
+        raise MemoryError()
+    try:
+        llhttp_init(parser, HTTP_REQUEST, _SINK)
+        for i in range(repeats):
+            err = llhttp_execute(parser, ptr, n)
+            if err != HPE_OK:
+                raise RuntimeError("llhttp_execute failed")
+    finally:
+        stario_parser_del(parser)
+
+
+def bench_h1(bytes data, int repeats):
+    cdef llhttp_t* parser
+    cdef const char* ptr = data
+    cdef size_t n = <size_t>len(data)
+    cdef int i
+    cdef int64_t consumed
+    _bind_sink()
+    parser = stario_parser_new()
+    if parser == NULL:
+        raise MemoryError()
+    try:
+        llhttp_init(parser, HTTP_REQUEST, _SINK)
+        for i in range(repeats):
+            consumed = stario_h1_try(parser, _SINK, ptr, n, n)
+            if consumed != <int64_t>n:
+                raise RuntimeError("stario_h1_try did not consume the request")
+    finally:
+        stario_parser_del(parser)
+
+
+def parse_h1_once(bytes data):
+    cdef llhttp_t* parser
+    cdef int64_t consumed
+    _bind_sink()
+    parser = stario_parser_new()
+    if parser == NULL:
+        raise MemoryError()
+    try:
+        llhttp_init(parser, HTTP_REQUEST, _SINK)
+        consumed = stario_h1_try(
+            parser, _SINK, data, <size_t>len(data), <size_t>len(data)
+        )
+        return (
+            int(consumed),
+            int(llhttp_get_method(parser)),
+            int(stario_parser_flags(parser)),
+        )
+    finally:
+        stario_parser_del(parser)

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -697,7 +697,9 @@ cdef class HttpProtocol:
         n = len(data)
         ptr = <const char*>data
         if PARSER_MODE == PARSER_AUTO and not self.llhttp_in_progress:
-            while offset < n and not self.pause_reasons and not self.rejected:
+            # Keep going after PAUSE_PIPELINE so a single read can fill the
+            # queue and hit the cap, matching one llhttp_execute on the buffer.
+            while offset < n and not self.rejected:
                 consumed = stario_h1_try(
                     self.parser,
                     _SETTINGS,
@@ -715,10 +717,11 @@ cdef class HttpProtocol:
                 return
             if self.rejected:
                 return
-            if offset >= n or self.pause_reasons:
-                if self.pause_reasons and offset < n:
-                    self.held_data = data
-                    self.held_offset = offset
+            if offset >= n:
+                return
+            if self.pause_reasons:
+                self.held_data = data
+                self.held_offset = offset
                 return
         self._pump_llhttp(ptr, data, offset, n)
 

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -1,9 +1,12 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
-"""asyncio Protocol + llhttp: one TCP connection, pipelining, and dispatch.
+"""asyncio Protocol + HTTP/1.1 parse: one TCP connection, pipelining, dispatch.
 
 ``HttpProtocol`` owns parser callbacks, pause/resume, and request dispatch.
-URL bytes and header fragments are written into the current exchange arena.
-Path/query decoding is cached here because it is connection-parse work.
+Complete identity-body requests (wrk keep-alive GETs, small POSTs) go through
+a C complete-message parser that writes the same llhttp callbacks and
+``llhttp_t`` fields. Chunked, Expect, unknown methods, and partial reads fall
+back to llhttp. URL bytes and header fragments land in the current exchange
+arena. Path/query decoding is cached here because it is connection-parse work.
 
 Header, idle, and body-stall timeouts share one cleanup path. Under Server
 that path is the Date-header tick (once a second): one ``loop.time()``, then
@@ -12,9 +15,10 @@ sweeper at the same period. See ``stario_cython.timeouts``.
 """
 
 import asyncio
+import os
 from collections import deque
 
-from libc.stdint cimport uint16_t, uint32_t, uint64_t
+from libc.stdint cimport int64_t, uint16_t, uint32_t, uint64_t
 from libc.stdlib cimport free, malloc
 from libc.string cimport memcmp, memcpy
 from cpython.bytes cimport PyBytes_FromStringAndSize
@@ -187,6 +191,9 @@ cdef int PAUSE_WRITE = 1
 cdef int PAUSE_PIPELINE = 2
 cdef int PAUSE_BODY = 4
 cdef int PARSER_QUANTUM = 512 * 1024
+cdef int PARSER_AUTO = 0
+cdef int PARSER_LLHTTP_ONLY = 1
+cdef int PARSER_MODE = 0
 cdef int TIMEOUT_NONE = 0
 cdef int TIMEOUT_HEADER = 1
 cdef int TIMEOUT_IDLE = 2
@@ -314,7 +321,15 @@ def _bind_timeout_policy():
     TIMEOUT_SWEEP_INTERVAL = <double>_py_sweep_interval()
 
 
+def _bind_parser_policy():
+    """``STARIO_CYTHON_PARSER=llhttp`` disables the complete-message C path."""
+    global PARSER_MODE
+    raw = os.environ.get("STARIO_CYTHON_PARSER", "h1")
+    PARSER_MODE = PARSER_LLHTTP_ONLY if raw == "llhttp" else PARSER_AUTO
+
+
 _bind_timeout_policy()
+_bind_parser_policy()
 
 
 async def _timeout_sweep_loop(loop, connections, key):
@@ -403,6 +418,7 @@ cdef class HttpProtocol:
     cdef object held_data
     cdef Py_ssize_t held_offset
     cdef bint pump_scheduled
+    cdef public bint llhttp_in_progress
     cdef object _create_task
 
     def __cinit__(self):
@@ -422,6 +438,7 @@ cdef class HttpProtocol:
         self.held_data = None
         self.held_offset = 0
         self.pump_scheduled = False
+        self.llhttp_in_progress = False
         self.timeout_kind = TIMEOUT_NONE
         self.timeout_deadline = 0.0
         self.header_timeout_reset = False
@@ -481,6 +498,7 @@ cdef class HttpProtocol:
         self.held_data = None
         self.held_offset = 0
         self.pump_scheduled = False
+        self.llhttp_in_progress = False
         self.rejected = False
         self.timeout_kind = TIMEOUT_NONE
         self.timeout_deadline = 0.0
@@ -632,17 +650,25 @@ cdef class HttpProtocol:
         ):
             self._arm_timeout(TIMEOUT_HEADER, self.header_timeout)
 
-    cdef void _pump_data(self, object data, Py_ssize_t offset) noexcept:
-        cdef const char* ptr
-        cdef Py_ssize_t n
+    cdef void _mark_llhttp_idle(self) noexcept:
+        if self.reading_exchange is None:
+            self.llhttp_in_progress = False
+
+    cdef void _pump_llhttp(
+        self,
+        const char* ptr,
+        object data,
+        Py_ssize_t offset,
+        Py_ssize_t n,
+    ) noexcept:
         cdef Py_ssize_t end
         cdef int err
-        n = len(data)
-        ptr = <const char*>data
-        if n <= PARSER_QUANTUM:
+        if n - offset <= PARSER_QUANTUM:
             err = llhttp_execute(self.parser, ptr + offset, <size_t>(n - offset))
             if err != HPE_OK:
                 self._close_error(400, "Invalid HTTP request")
+                return
+            self._mark_llhttp_idle()
             return
         while offset < n:
             end = offset + PARSER_QUANTUM
@@ -657,11 +683,44 @@ cdef class HttpProtocol:
                 self._close_error(400, "Invalid HTTP request")
                 return
             offset = end
+            self._mark_llhttp_idle()
             if self.pause_reasons:
                 if offset < n:
                     self.held_data = data
                     self.held_offset = offset
                 return
+
+    cdef void _pump_data(self, object data, Py_ssize_t offset) noexcept:
+        cdef const char* ptr
+        cdef Py_ssize_t n
+        cdef int64_t consumed
+        n = len(data)
+        ptr = <const char*>data
+        if PARSER_MODE == PARSER_AUTO and not self.llhttp_in_progress:
+            while offset < n and not self.pause_reasons and not self.rejected:
+                consumed = stario_h1_try(
+                    self.parser,
+                    _SETTINGS,
+                    ptr + offset,
+                    <size_t>(n - offset),
+                    <size_t>PARSER_QUANTUM,
+                )
+                if consumed > 0:
+                    offset += <Py_ssize_t>consumed
+                    continue
+                if consumed == -2:  # STARIO_H1_INCOMPLETE: use llhttp
+                    self.llhttp_in_progress = True
+                    break
+                self._close_error(400, "Invalid HTTP request")
+                return
+            if self.rejected:
+                return
+            if offset >= n or self.pause_reasons:
+                if self.pause_reasons and offset < n:
+                    self.held_data = data
+                    self.held_offset = offset
+                return
+        self._pump_llhttp(ptr, data, offset, n)
 
     cdef void _set_pause_reason(self, int reason, bint paused):
         cdef int previous = self.pause_reasons

--- a/src/stario_cython/serve.py
+++ b/src/stario_cython/serve.py
@@ -15,7 +15,8 @@ the exchange — chunks do not ``call_later``. ``RequestPolicy.max_pipelined_req
 ``STARIO_CYTHON_TIMEOUTS=off`` disables header/idle/body-stall cleanup
 (profiling hatch). Under Server the sweep rides the Date-header tick (1s).
 ``STARIO_CYTHON_TIMEOUT_SWEEP`` overrides the fallback sweeper period used
-without Server (default 1s).
+without Server (default 1s). ``STARIO_CYTHON_PARSER=llhttp`` disables the
+complete-message C parser and uses llhttp for every request.
 """
 
 from __future__ import annotations

--- a/tests/cython/test_h1_parser.py
+++ b/tests/cython/test_h1_parser.py
@@ -1,0 +1,160 @@
+"""Complete-message C parser vs llhttp fallback."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import stario.responses as responses
+from stario import App
+from stario_cython.protocol import HttpProtocol
+from tests.cython.http import (
+    RecordingTransport,
+    make_protocol,
+    response_status,
+)
+
+
+async def _drain(app: App) -> None:
+    await asyncio.sleep(0)
+    await app.drain_tasks()
+
+
+def _attach(app: App | None = None):
+    loop = asyncio.get_running_loop()
+    if app is None:
+        app = App()
+    proto = make_protocol(loop, app)
+    transport = RecordingTransport(proto)
+    proto.connection_made(transport)
+    return proto, app, transport
+
+
+@pytest.mark.asyncio
+async def test_wrk_style_get_uses_complete_message_path() -> None:
+    app = App()
+    hits: list[str] = []
+
+    async def handler(c, w) -> None:
+        hits.append(c.req.method + " " + c.req.path)
+        assert c.req.keep_alive is True
+        assert c.req.protocol_version == "1.1"
+        assert c.req.headers.get("host") == "127.0.0.1"
+        responses.text(w, "ok")
+
+    app.get("/plaintext", handler)
+    proto, app, transport = _attach(app)
+    try:
+        proto.data_received(
+            b"GET /plaintext HTTP/1.1\r\n"
+            b"Host: 127.0.0.1\r\n"
+            b"\r\n"
+        )
+        await _drain(app)
+        assert response_status(transport.writes) == 200
+        assert hits == ["GET /plaintext"]
+        assert proto.llhttp_in_progress is False
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_split_headers_fall_back_to_llhttp() -> None:
+    app = App()
+    hits: list[str] = []
+
+    async def handler(_c, w) -> None:
+        hits.append("ok")
+        responses.text(w, "ok")
+
+    app.get("/", handler)
+    proto, app, transport = _attach(app)
+    try:
+        proto.data_received(b"GET / HTTP/1.1\r\nHost: t\r\n")
+        await asyncio.sleep(0)
+        assert hits == []
+        proto.data_received(b"\r\n")
+        await _drain(app)
+        assert response_status(transport.writes) == 200
+        assert hits == ["ok"]
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_http10_keep_alive_and_close() -> None:
+    app = App()
+
+    async def handler(c, w) -> None:
+        responses.text(w, "ok" if c.req.keep_alive else "close")
+
+    app.get("/", handler)
+    proto, app, transport = _attach(app)
+    try:
+        proto.data_received(
+            b"GET / HTTP/1.0\r\nHost: t\r\nConnection: keep-alive\r\n\r\n"
+        )
+        await _drain(app)
+        assert b"ok" in b"".join(transport.writes)
+        assert not transport.is_closing()
+
+        proto.data_received(b"GET / HTTP/1.0\r\nHost: t\r\n\r\n")
+        await _drain(app)
+        assert b"close" in b"".join(transport.writes)
+        assert transport.is_closing()
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_duplicate_content_length_is_400() -> None:
+    proto, app, transport = _attach()
+    try:
+        proto.data_received(
+            b"POST / HTTP/1.1\r\n"
+            b"Host: t\r\n"
+            b"Content-Length: 1\r\n"
+            b"Content-Length: 2\r\n"
+            b"\r\n"
+            b"ab"
+        )
+        await _drain(app)
+        assert response_status(transport.writes) == 400
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_content_length_and_te_is_400() -> None:
+    proto, app, transport = _attach()
+    try:
+        proto.data_received(
+            b"POST / HTTP/1.1\r\n"
+            b"Host: t\r\n"
+            b"Content-Length: 5\r\n"
+            b"Transfer-Encoding: chunked\r\n"
+            b"\r\n"
+            b"0\r\n\r\n"
+        )
+        await _drain(app)
+        assert response_status(transport.writes) == 400
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_parser_is_httpprotocol() -> None:
+    loop = asyncio.get_running_loop()
+    proto = make_protocol(loop, App())
+    assert isinstance(proto, HttpProtocol)

--- a/tests/test_zttp_protocol.py
+++ b/tests/test_zttp_protocol.py
@@ -1,0 +1,88 @@
+"""Python protocol driven by zttp instead of httptools."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("zttp")
+
+import stario.responses as responses
+from stario import App
+from stario.http.compression import CompressionConfig
+from stario.http.config import RequestPolicy
+from stario.http.zttp_protocol import HttpProtocol
+from stario.telemetry.noop import NoOpTracer
+from tests.test_http_protocol_hardening import _RecordingTransport, _response_status
+
+
+def _attach(app: App | None = None) -> tuple[HttpProtocol, App, _RecordingTransport]:
+    loop = asyncio.get_running_loop()
+    if app is None:
+        app = App()
+    proto = HttpProtocol(
+        loop,
+        app,
+        NoOpTracer(),
+        lambda: b"date: Thu, 01 Jan 1970 00:00:00 GMT\r\n",
+        CompressionConfig(),
+        set(),
+        RequestPolicy(),
+    )
+    transport = _RecordingTransport(proto)
+    proto.connection_made(transport)
+    return proto, app, transport
+
+
+async def _drain(app: App) -> None:
+    await asyncio.sleep(0)
+    await app.drain_tasks()
+
+
+@pytest.mark.asyncio
+async def test_zttp_plaintext_and_keepalive_post() -> None:
+    app = App()
+    seen: list[str] = []
+
+    async def hello(_c, w):
+        seen.append("get")
+        responses.text(w, "hi")
+
+    async def echo(c, w):
+        seen.append((await c.req.body()).decode())
+        responses.text(w, "ok")
+
+    app.get("/", hello)
+    app.post("/echo", echo)
+    proto, app, transport = _attach(app)
+    try:
+        proto.data_received(b"GET / HTTP/1.1\r\nHost: t\r\n\r\n")
+        await _drain(app)
+        assert _response_status(transport) == 200
+        proto.data_received(
+            b"POST /echo HTTP/1.1\r\n"
+            b"Host: t\r\n"
+            b"Content-Length: 3\r\n"
+            b"\r\n"
+            b"abc"
+        )
+        await _drain(app)
+        assert seen == ["get", "abc"]
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_zttp_garbage_is_400() -> None:
+    proto, app, transport = _attach()
+    try:
+        proto.data_received(b"\x00\xff not http \r\n\r\n")
+        await _drain(app)
+        assert _response_status(transport) == 400
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)

--- a/vendor/stario_h1/stario_h1.c
+++ b/vendor/stario_h1/stario_h1.c
@@ -571,5 +571,11 @@ int64_t stario_h1_try(
   if (fire_cb(parser, settings->on_message_complete) != 0) {
     return STARIO_H1_ERROR;
   }
+  /* Same cleanup as llhttp__after_message_complete so a later
+   * llhttp_execute does not inherit Content-Length / Connection flags. */
+  parser->flags = 0;
+  parser->upgrade = 0;
+  parser->content_length = 0;
+  parser->finish = HTTP_FINISH_SAFE;
   return (int64_t)total;
 }

--- a/vendor/stario_h1/stario_h1.c
+++ b/vendor/stario_h1/stario_h1.c
@@ -1,0 +1,575 @@
+#include "stario_h1.h"
+
+#include <string.h>
+
+#ifdef __SSE2__
+#include <emmintrin.h>
+#endif
+
+#ifndef STARIO_H1_MAX_HEADERS
+#define STARIO_H1_MAX_HEADERS 64
+#endif
+
+typedef struct {
+  const char* name;
+  size_t name_len;
+  const char* value;
+  size_t value_len;
+} stario_h1_hdr;
+
+enum {
+  H1_OK = 0,
+  H1_ERR = 1,
+  H1_INC = 2
+};
+
+/* RFC 9110 tchar */
+static const unsigned char H1_TCHAR[256] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 1, 0,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+/* HTAB, SP..tilde except DEL, plus obs-text. */
+static const unsigned char H1_VALUE[256] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+
+static const char* find_crlfcrlf(const char* p, const char* end) {
+#ifdef __SSE2__
+  const __m128i cr = _mm_set1_epi8('\r');
+  while (p + 16 <= end) {
+    __m128i chunk = _mm_loadu_si128((const __m128i*)(const void*)p);
+    int mask = _mm_movemask_epi8(_mm_cmpeq_epi8(chunk, cr));
+    while (mask) {
+      int i = __builtin_ctz(mask);
+      if (p + i + 3 < end && p[i + 1] == '\n' && p[i + 2] == '\r' &&
+          p[i + 3] == '\n') {
+        return p + i;
+      }
+      mask &= mask - 1;
+    }
+    p += 16;
+  }
+#else
+  while (p + 8 <= end) {
+    uint64_t word;
+    memcpy(&word, p, 8);
+    uint64_t x = word ^ 0x0d0d0d0d0d0d0d0dULL;
+    uint64_t has = (x - 0x0101010101010101ULL) & ~x & 0x8080808080808080ULL;
+    if (has) {
+      size_t i;
+      for (i = 0; i < 8; i++) {
+        if (p[i] == '\r' && p + i + 3 < end && p[i + 1] == '\n' &&
+            p[i + 2] == '\r' && p[i + 3] == '\n') {
+          return p + i;
+        }
+      }
+    }
+    p += 7;
+  }
+#endif
+  while (p + 3 < end) {
+    if (p[0] == '\r' && p[1] == '\n' && p[2] == '\r' && p[3] == '\n') {
+      return p;
+    }
+    p++;
+  }
+  return NULL;
+}
+
+static int parse_method(const char* p, size_t n, uint8_t* out) {
+  switch (n) {
+    case 3:
+      if (p[0] == 'G' && p[1] == 'E' && p[2] == 'T') {
+        *out = HTTP_GET;
+        return H1_OK;
+      }
+      if (p[0] == 'P' && p[1] == 'U' && p[2] == 'T') {
+        *out = HTTP_PUT;
+        return H1_OK;
+      }
+      return H1_INC;
+    case 4:
+      if (p[0] == 'P' && p[1] == 'O' && p[2] == 'S' && p[3] == 'T') {
+        *out = HTTP_POST;
+        return H1_OK;
+      }
+      if (p[0] == 'H' && p[1] == 'E' && p[2] == 'A' && p[3] == 'D') {
+        *out = HTTP_HEAD;
+        return H1_OK;
+      }
+      return H1_INC;
+    case 5:
+      if (memcmp(p, "PATCH", 5) == 0) {
+        *out = HTTP_PATCH;
+        return H1_OK;
+      }
+      if (memcmp(p, "TRACE", 5) == 0) {
+        *out = HTTP_TRACE;
+        return H1_OK;
+      }
+      if (memcmp(p, "QUERY", 5) == 0) {
+        *out = HTTP_QUERY;
+        return H1_OK;
+      }
+      return H1_INC;
+    case 6:
+      if (memcmp(p, "DELETE", 6) == 0) {
+        *out = HTTP_DELETE;
+        return H1_OK;
+      }
+      return H1_INC;
+    case 7:
+      if (memcmp(p, "OPTIONS", 7) == 0) {
+        *out = HTTP_OPTIONS;
+        return H1_OK;
+      }
+      if (memcmp(p, "CONNECT", 7) == 0) {
+        *out = HTTP_CONNECT;
+        return H1_OK;
+      }
+      return H1_INC;
+    default:
+      return H1_INC;
+  }
+}
+
+static int name_eq(const char* p, size_t n, const char* lit, size_t lit_n) {
+  size_t i;
+  unsigned char c;
+  if (n != lit_n) {
+    return 0;
+  }
+  for (i = 0; i < n; i++) {
+    c = (unsigned char)p[i];
+    if (c >= 'A' && c <= 'Z') {
+      c = (unsigned char)(c + 32);
+    }
+    if (c != (unsigned char)lit[i]) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+static int valid_url(const char* p, size_t n) {
+  size_t i;
+  unsigned char c;
+  if (n == 0) {
+    return 0;
+  }
+  for (i = 0; i < n; i++) {
+    c = (unsigned char)p[i];
+    if (c <= 0x20 || c == 0x7f) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+static int valid_value(const char* p, size_t n) {
+  size_t i;
+  for (i = 0; i < n; i++) {
+    if (!H1_VALUE[(unsigned char)p[i]]) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+static int parse_content_length(const char* p, size_t n, uint64_t* out) {
+  uint64_t value = 0;
+  size_t i;
+  if (n == 0) {
+    return H1_ERR;
+  }
+  for (i = 0; i < n; i++) {
+    unsigned char c = (unsigned char)p[i];
+    uint64_t next;
+    if (c < '0' || c > '9') {
+      return H1_ERR;
+    }
+    next = value * 10u + (uint64_t)(c - '0');
+    if (next < value) {
+      return H1_ERR;
+    }
+    value = next;
+  }
+  *out = value;
+  return H1_OK;
+}
+
+static void scan_connection(const char* p, size_t n, uint16_t* flags) {
+  size_t i = 0;
+  while (i < n) {
+    size_t start;
+    size_t end;
+    while (i < n && (p[i] == ' ' || p[i] == '\t' || p[i] == ',')) {
+      i++;
+    }
+    start = i;
+    while (i < n && p[i] != ',') {
+      i++;
+    }
+    end = i;
+    while (end > start && (p[end - 1] == ' ' || p[end - 1] == '\t')) {
+      end--;
+    }
+    if (end > start) {
+      size_t tok = end - start;
+      if (name_eq(p + start, tok, "close", 5)) {
+        *flags |= F_CONNECTION_CLOSE;
+      } else if (name_eq(p + start, tok, "keep-alive", 10)) {
+        *flags |= F_CONNECTION_KEEP_ALIVE;
+      } else if (name_eq(p + start, tok, "upgrade", 7)) {
+        *flags |= F_CONNECTION_UPGRADE;
+      }
+    }
+    if (i < n && p[i] == ',') {
+      i++;
+    }
+  }
+}
+
+static int te_is_chunked(const char* p, size_t n) {
+  size_t i = 0;
+  int saw_chunked = 0;
+  while (i < n) {
+    size_t start;
+    size_t end;
+    size_t semi;
+    while (i < n && (p[i] == ' ' || p[i] == '\t' || p[i] == ',')) {
+      i++;
+    }
+    start = i;
+    while (i < n && p[i] != ',') {
+      i++;
+    }
+    end = i;
+    while (end > start && (p[end - 1] == ' ' || p[end - 1] == '\t')) {
+      end--;
+    }
+    semi = start;
+    while (semi < end && p[semi] != ';') {
+      semi++;
+    }
+    while (semi > start && (p[semi - 1] == ' ' || p[semi - 1] == '\t')) {
+      semi--;
+    }
+    if (semi > start) {
+      if (name_eq(p + start, semi - start, "chunked", 7)) {
+        saw_chunked = 1;
+      } else {
+        return 0;
+      }
+    }
+    if (i < n && p[i] == ',') {
+      i++;
+    }
+  }
+  return saw_chunked;
+}
+
+static int is_expect_continue(const char* p, size_t n) {
+  size_t i = 0;
+  while (i < n) {
+    size_t start;
+    size_t end;
+    while (i < n && (p[i] == ' ' || p[i] == '\t' || p[i] == ',')) {
+      i++;
+    }
+    start = i;
+    while (i < n && p[i] != ',') {
+      i++;
+    }
+    end = i;
+    while (end > start && (p[end - 1] == ' ' || p[end - 1] == '\t')) {
+      end--;
+    }
+    if (end > start && name_eq(p + start, end - start, "100-continue", 12)) {
+      return 1;
+    }
+    if (i < n && p[i] == ',') {
+      i++;
+    }
+  }
+  return 0;
+}
+
+static int fire_cb(llhttp_t* parser, llhttp_cb fn) {
+  if (fn == NULL) {
+    return 0;
+  }
+  return fn(parser);
+}
+
+static int fire_data(
+    llhttp_t* parser,
+    llhttp_data_cb fn,
+    const char* at,
+    size_t n
+) {
+  if (fn == NULL || n == 0) {
+    return 0;
+  }
+  return fn(parser, at, n);
+}
+
+int64_t stario_h1_try(
+    llhttp_t* parser,
+    const llhttp_settings_t* settings,
+    const char* data,
+    size_t len,
+    size_t max_message
+) {
+  const char* end;
+  const char* headers_term;
+  const char* line_end;
+  const char* p;
+  const char* method;
+  const char* url;
+  const char* version;
+  size_t method_len;
+  size_t url_len;
+  stario_h1_hdr headers[STARIO_H1_MAX_HEADERS];
+  size_t header_count = 0;
+  uint8_t http_method = 0;
+  uint8_t minor = 1;
+  uint16_t flags = 0;
+  uint64_t content_length = 0;
+  int has_cl = 0;
+  int has_te = 0;
+  int expect_continue = 0;
+  size_t header_bytes;
+  size_t total;
+  size_t i;
+  int rc;
+
+  if (parser == NULL || settings == NULL || data == NULL) {
+    return STARIO_H1_ERROR;
+  }
+  if (len < 16) {
+    return STARIO_H1_INCOMPLETE;
+  }
+  end = data + len;
+  headers_term = find_crlfcrlf(data, end);
+  if (headers_term == NULL) {
+    return STARIO_H1_INCOMPLETE;
+  }
+
+  /* Request line: METHOD SP target SP HTTP/1.x CRLF */
+  line_end = memchr(data, '\n', (size_t)(headers_term + 3 - data));
+  if (line_end == NULL || line_end == data || line_end[-1] != '\r') {
+    return STARIO_H1_ERROR;
+  }
+  line_end--; /* points at CR */
+
+  p = memchr(data, ' ', (size_t)(line_end - data));
+  if (p == NULL || p == data) {
+    return STARIO_H1_ERROR;
+  }
+  method = data;
+  method_len = (size_t)(p - data);
+  p++;
+  url = p;
+  p = memchr(url, ' ', (size_t)(line_end - url));
+  if (p == NULL || p == url) {
+    return STARIO_H1_ERROR;
+  }
+  url_len = (size_t)(p - url);
+  version = p + 1;
+  if ((size_t)(line_end - version) != 8 || memcmp(version, "HTTP/1.", 7) != 0) {
+    return STARIO_H1_INCOMPLETE;
+  }
+  if (version[7] == '1') {
+    minor = 1;
+  } else if (version[7] == '0') {
+    minor = 0;
+  } else {
+    return STARIO_H1_INCOMPLETE;
+  }
+  rc = parse_method(method, method_len, &http_method);
+  if (rc != H1_OK) {
+    return STARIO_H1_INCOMPLETE;
+  }
+  if (!valid_url(url, url_len)) {
+    return STARIO_H1_ERROR;
+  }
+
+  p = line_end + 2;
+  while (p < headers_term) {
+    const char* colon;
+    const char* value;
+    size_t name_len;
+    size_t value_len;
+    const char* row_end = memchr(p, '\n', (size_t)(headers_term + 3 - p));
+    if (row_end == NULL || row_end == p || row_end[-1] != '\r') {
+      return STARIO_H1_ERROR;
+    }
+    row_end--;
+    if (p[0] == ' ' || p[0] == '\t') {
+      return STARIO_H1_ERROR;
+    }
+    colon = memchr(p, ':', (size_t)(row_end - p));
+    if (colon == NULL || colon == p) {
+      return STARIO_H1_ERROR;
+    }
+    name_len = (size_t)(colon - p);
+    for (i = 0; i < name_len; i++) {
+      if (!H1_TCHAR[(unsigned char)p[i]]) {
+        return STARIO_H1_ERROR;
+      }
+    }
+    value = colon + 1;
+    while (value < row_end && (*value == ' ' || *value == '\t')) {
+      value++;
+    }
+    value_len = (size_t)(row_end - value);
+    while (value_len > 0 &&
+           (value[value_len - 1] == ' ' || value[value_len - 1] == '\t')) {
+      value_len--;
+    }
+    if (!valid_value(value, value_len)) {
+      return STARIO_H1_ERROR;
+    }
+    if (header_count >= STARIO_H1_MAX_HEADERS) {
+      return STARIO_H1_INCOMPLETE;
+    }
+    headers[header_count].name = p;
+    headers[header_count].name_len = name_len;
+    headers[header_count].value = value;
+    headers[header_count].value_len = value_len;
+    header_count++;
+
+    if (name_eq(p, name_len, "content-length", 14)) {
+      uint64_t parsed = 0;
+      if (parse_content_length(value, value_len, &parsed) != H1_OK) {
+        return STARIO_H1_ERROR;
+      }
+      if (has_cl && parsed != content_length) {
+        return STARIO_H1_ERROR;
+      }
+      has_cl = 1;
+      content_length = parsed;
+      flags |= F_CONTENT_LENGTH;
+    } else if (name_eq(p, name_len, "transfer-encoding", 17)) {
+      has_te = 1;
+      flags |= F_TRANSFER_ENCODING;
+      if (te_is_chunked(value, value_len)) {
+        flags |= F_CHUNKED;
+      }
+    } else if (name_eq(p, name_len, "connection", 10)) {
+      scan_connection(value, value_len, &flags);
+    } else if (name_eq(p, name_len, "upgrade", 7)) {
+      flags |= F_UPGRADE;
+    } else if (name_eq(p, name_len, "expect", 6)) {
+      if (is_expect_continue(value, value_len)) {
+        expect_continue = 1;
+      }
+    }
+    p = row_end + 2;
+  }
+
+  if (has_te && has_cl) {
+    return STARIO_H1_ERROR;
+  }
+  if (has_te) {
+    return STARIO_H1_INCOMPLETE;
+  }
+  if (http_method == HTTP_CONNECT) {
+    return STARIO_H1_INCOMPLETE;
+  }
+
+  header_bytes = (size_t)(headers_term + 4 - data);
+  if (has_cl) {
+    if (content_length > (uint64_t)(SIZE_MAX - header_bytes)) {
+      return STARIO_H1_ERROR;
+    }
+    total = header_bytes + (size_t)content_length;
+  } else {
+    total = header_bytes;
+  }
+  if (total > max_message) {
+    return STARIO_H1_INCOMPLETE;
+  }
+  if (has_cl && header_bytes + (size_t)content_length > len) {
+    return STARIO_H1_INCOMPLETE;
+  }
+  if (expect_continue && has_cl && content_length > 0 &&
+      header_bytes + (size_t)content_length > len) {
+    return STARIO_H1_INCOMPLETE;
+  }
+
+  parser->method = http_method;
+  parser->http_major = 1;
+  parser->http_minor = minor;
+  parser->flags = flags;
+  parser->content_length = has_cl ? content_length : 0;
+  if ((flags & F_UPGRADE) && (flags & F_CONNECTION_UPGRADE)) {
+    parser->upgrade = 1;
+  } else {
+    parser->upgrade = 0;
+  }
+
+  if (fire_cb(parser, settings->on_message_begin) != 0) {
+    return STARIO_H1_ERROR;
+  }
+  if (fire_data(parser, settings->on_url, url, url_len) != 0) {
+    return STARIO_H1_ERROR;
+  }
+  for (i = 0; i < header_count; i++) {
+    if (fire_data(
+            parser,
+            settings->on_header_field,
+            headers[i].name,
+            headers[i].name_len
+        ) != 0) {
+      return STARIO_H1_ERROR;
+    }
+    if (fire_data(
+            parser,
+            settings->on_header_value,
+            headers[i].value,
+            headers[i].value_len
+        ) != 0) {
+      return STARIO_H1_ERROR;
+    }
+    if (fire_cb(parser, settings->on_header_value_complete) != 0) {
+      return STARIO_H1_ERROR;
+    }
+  }
+  if (fire_cb(parser, settings->on_headers_complete) != 0) {
+    return STARIO_H1_ERROR;
+  }
+  if (has_cl && content_length > 0) {
+    if (fire_data(
+            parser,
+            settings->on_body,
+            data + header_bytes,
+            (size_t)content_length
+        ) != 0) {
+      return STARIO_H1_ERROR;
+    }
+  }
+  if (fire_cb(parser, settings->on_message_complete) != 0) {
+    return STARIO_H1_ERROR;
+  }
+  return (int64_t)total;
+}

--- a/vendor/stario_h1/stario_h1.h
+++ b/vendor/stario_h1/stario_h1.h
@@ -1,0 +1,44 @@
+#ifndef STARIO_H1_H
+#define STARIO_H1_H
+
+#include <stdint.h>
+
+#include "llhttp.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Complete-message HTTP/1.1 request parser. Same callbacks and llhttp_t
+ * fields as llhttp_execute, but only for a request that is already fully
+ * present in the buffer (headers + Content-Length body).
+ *
+ * Returns:
+ *   > 0  bytes consumed (one complete request)
+ *   STARIO_H1_INCOMPLETE (-2)  not a complete identity-body request;
+ *                              caller should feed the same bytes to llhttp
+ *   STARIO_H1_ERROR (-1)       definite protocol error
+ *
+ * Callbacks are not invoked on INCOMPLETE. On ERROR, some callbacks may
+ * already have run (same as a failing llhttp_execute).
+ *
+ * Chunked, Expect: 100-continue without a complete body, unknown methods,
+ * and messages larger than max_message are INCOMPLETE so llhttp stays the
+ * streaming / edge-case engine.
+ */
+#define STARIO_H1_ERROR ((int64_t)-1)
+#define STARIO_H1_INCOMPLETE ((int64_t)-2)
+
+int64_t stario_h1_try(
+    llhttp_t* parser,
+    const llhttp_settings_t* settings,
+    const char* data,
+    size_t len,
+    size_t max_message
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Complete identity-body HTTP/1.1 requests (wrk keep-alive GETs, small POSTs) now parse in `vendor/stario_h1`: a strict C scanner that fires the existing llhttp callbacks and fills the same `llhttp_t` fields. Chunked bodies, Expect: 100-continue, unknown methods, and split reads still go through llhttp.

## Parser microbench (this agent host)

200k iterations × 7 repeats. One complete request per iteration.

| Engine | simple GET | POST + JSON |
| --- | ---: | ---: |
| **cython-h1 (complete C)** | **12.6M req/s** | **12.0M req/s** |
| cython-llhttp (C callbacks) | 8.4M | 7.1M |
| zttp (Zig / Python events) | 2.9M | 2.0M |
| httptools (Python callbacks) | 2.1M | 1.8M |

zttp beats httptools (~1.36× GET), matching its docs. It loses to Cython+C because each event becomes Python objects. Production stays on the C complete-message path.

`STARIO_CYTHON_PARSER=llhttp` forces llhttp for every Cython request. `STARIO_HTTP_PARSER=zttp` selects `stario.http.zttp_protocol` for the Python server.

## HTTP/3

`asyncio.Protocol` is a TCP/Unix byte stream. HTTP/3 is QUIC over UDP — you need `asyncio.DatagramProtocol` (or a raw UDP socket) plus a QUIC stack. zttp can parse H3 if you feed whole datagrams (`receive_datagram`); that is a second server path, not a drop-in on this protocol. TLS is mandatory inside QUIC. HTTP/2 *can* share `asyncio.Protocol` (TCP + TLS + ALPN).

## Tests

758 passed, including Cython protocol/hardening and the optional zttp Python protocol.

Parser microbench: `PYTHONPATH=src:. .venv/bin/python benchmarks/parser_micro.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d3e4a82-06aa-4c5e-9c63-f77df4cbb293?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d3e4a82-06aa-4c5e-9c63-f77df4cbb293&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

