### PR TITLE
Cython HTTP: llhttp H1, nghttp2 H2, TLS, lazy query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - `stario.http.middleware.catch_errors` — wrap handlers so listed exceptions
   become HTTP responses when nothing was sent yet. Presets:
   `catch_request_body_errors()` and `respond_request_body_error`.
+- Cython HTTP/2 via nghttp2 on the same connection class. Switch once per socket (TLS ALPN `h2` or the cleartext connection preface). Responses go out as frames, not HTTP/1.1 text.
+- Direct TLS: `ServerConfig(ssl=…)` or `STARIO_SSL_CERTFILE` / `STARIO_SSL_KEYFILE`. Context is TLS 1.2+ with ALPN `h2`, `http/1.1`.
 
 ### Changed
 
@@ -43,6 +45,8 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Cython uploads: Content-Length bodies ≤ 256 KiB dispatch after the
   message is complete (`body()` is already bytes). `stream()` with a known
   Content-Length yields `min(length, 256 KiB)` instead of a fixed 64 KiB.
+- `ParsedQuery` (Python and Cython) matches `Headers`: first read fills `_keys` / `_values`, then `get` / `getlist` / `items` linear-scan. `as_dict` / `as_lists` group those arrays for forms / Pydantic; headers have no analogue. HTTP/1 stays on [llhttp](https://github.com/nodejs/llhttp): picohttpparser was tried on the same `HttpProtocol` and is ~2.5× in a parser-only microbench, but not noticeably faster end-to-end (GET ~even, small POST behind). llhttp is also the same incremental-callback model as nghttp2.
+- HTTP/1 and HTTP/2 share the core dispatch rule (empty GET / `mark_nobody` at headers; small POST ≤256KiB waits for complete). HTTP/2 receive window is 1MiB per stream / 4MiB per connection. Recv credit is submitted as `WINDOW_UPDATE` when a stream ends and after each `mem_recv` — nghttp2 `consume()` only emits a frame at 50% of the window, which stalls keep-alive small POSTs. Mid-body updates are still batched. Outbound DATA uses nghttp2 `NO_COPY` into `h2_out`; responses queued during `mem_recv` flush once.
 
 ## 4.1.0 - 2026-08-17
 

--- a/CYTHON.md
+++ b/CYTHON.md
@@ -1,7 +1,9 @@
 # Cython protocol (cython-core)
 
 This worktree is `projects/stario` on branch `cython-core`. uvloop owns the
-socket and llhttp parses in C. The protocol lives in `src/stario_cython`.
+socket. HTTP/1 is [llhttp](https://github.com/nodejs/llhttp);
+HTTP/2 is nghttp2. Both live in one `HttpProtocol` and share
+`RequestExchange`. The protocol lives in `src/stario_cython`.
 
 `projects/stario` stays on `main` and stays a workspace member. Do not
 `uv sync` this folder from the monorepo root. Use an isolated venv:
@@ -16,11 +18,22 @@ uv pip install --python .venv/bin/python -e ".[uvloop]" cython setuptools wheel 
 PYTHONPATH=src:. .venv/bin/python -m stario_cython examples.cython.hello:bootstrap
 ```
 
-Linux builds need `pkg-config` and the Brotli development package. Gzip
-links system zlib (`-lz`). The native protocol offers `br` and `gzip`
-only. Python Stario still negotiates zstd.
+Linux builds need `pkg-config`, the Brotli development package, and
+`libnghttp2-dev`. Gzip links system zlib (`-lz`). The native protocol
+offers `br` and `gzip` only. Python Stario still negotiates zstd.
+
+Direct TLS: `STARIO_SSL_CERTFILE` / `STARIO_SSL_KEYFILE` (or
+`ServerConfig(ssl=…)`). ALPN advertises `h2` then `http/1.1`.
 
 `STARIO_HOST` and `STARIO_PORT` set the bind address.
+
+Same-host check (2026-08-31): picohttpparser is ~2.5–3.3× llhttp in a
+parser-only microbench, but end-to-end HTTP/1 is about even on GET
+(0.98–1.07×) and behind on a tiny JSON POST (0.85×). HTTP/1 stays on
+llhttp. HTTP/2 GETs on the same process are ~1.8× HTTP/1 when `h2load`
+uses 100 streams per connection. TLS ALPN selects `h2` or `http/1.1`;
+a self-signed cert serves both. See
+[`benchmarks/server/pico-h2-20260831.md`](benchmarks/server/pico-h2-20260831.md).
 
 `PYTHONPATH=src` is required so `stario_cython` resolves after the inplace
 build.

--- a/benchmarks/server/pico-h2-20260831.md
+++ b/benchmarks/server/pico-h2-20260831.md
@@ -1,0 +1,46 @@
+# pico vs llhttp / nghttp2 / TLS (same host, 2026-08-31)
+
+**Decision:** HTTP/1 stays on llhttp. picohttpparser is faster in a
+parser-only microbench but not noticeably faster end-to-end, and it is a
+complete-message leftover parser. llhttp and nghttp2 are both incremental
+callback parsers.
+
+All server numbers: `h2load -D 4 --warm-up-time=1 -t 2`. HTTP/1 uses `--h1 -c 64` (POST `-c 32`). HTTP/2 uses default `h2c -c 64 -m 100` (POST `-c 32 -m 100`). Cython servers: `apps.stario_app`, compression off, `STARIO_TRACER=noop`.
+
+## Parser only (headers, 2M iterations, `-O3 -msse4.2`)
+
+| Engine | GET | POST+JSON |
+| --- | ---: | ---: |
+| picohttpparser | **24.31 M/s** | **29.83 M/s** |
+| llhttp (vendored 9.2.1) | 9.92 M/s | 9.09 M/s |
+| pico / llhttp | **2.45×** | **3.28×** |
+
+## HTTP/1 server: this branch (pico) vs `cython-core` (llhttp)
+
+| Endpoint | pico H1 req/s | llhttp H1 req/s | pico / llhttp |
+| --- | ---: | ---: | ---: |
+| `/plaintext` | 148,018 | 150,686 | 0.98× |
+| `/json` | 134,173 | 129,414 | **1.04×** |
+| `/user/42` | 135,515 | 126,626 | **1.07×** |
+| POST `/echo/json` | 119,979 | 140,916 | 0.85× |
+
+Parser speed does not show up as a GET win: the Cython path is already App/response bound. Small POST is a bit slower on this leftover+scan path in this run.
+
+## HTTP/2 vs HTTP/1 on this branch (pico + nghttp2)
+
+| Endpoint | H1 req/s | H2 req/s | H2 / H1 |
+| --- | ---: | ---: | ---: |
+| `/plaintext` | 148,018 | 265,600 | **1.79×** |
+| `/json` | 134,173 | 256,850 | **1.91×** |
+| `/user/42` | 135,515 | 245,575 | **1.81×** |
+| POST `/echo/json` | 119,979 | 68,800 | 0.57× |
+
+H2 GETs use 100 concurrent streams per connection. H2 POST pays frame + DATA-provider overhead.
+
+## TLS + certificates
+
+Self-signed RSA-2048, `STARIO_SSL_CERTFILE` / `STARIO_SSL_KEYFILE`.
+
+- `openssl s_client -alpn h2,http/1.1` → `ALPN protocol: h2`, verify code 18 (self-signed, expected).
+- `curl --http1.1 -k https://127.0.0.1:8767/plaintext` → `HTTP/1.1 200` `Hello, World!`
+- `curl --http2 -k` → `HTTP/2 200` `http_version=2` `Hello, World!`

--- a/benchmarks/server/run.sh
+++ b/benchmarks/server/run.sh
@@ -24,7 +24,7 @@ TARGETS=(
 )
 TARGET_LABELS=(
   "stario|Stario (Python httptools)"
-  "stario-cython|Stario (Cython llhttp)"
+  "stario-cython|Stario (Cython llhttp/nghttp2)"
   "socketify|Socketify (uWebSockets/libuv)"
   "robyn|Robyn (Rust/Actix)"
   "granian-rsgi|Granian RSGI (Rust, no framework)"

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ extensions = [
             "vendor/llhttp/src/stario_alloc.c",
         ],
         include_dirs=["vendor/llhttp/include", "vendor", "src"],
+        libraries=["nghttp2"],
         extra_compile_args=["-O3", "-fno-strict-aliasing"],
     ),
 ]

--- a/src/stario/cli/help.py
+++ b/src/stario/cli/help.py
@@ -12,6 +12,8 @@ Listen:
   STARIO_BACKLOG=2048
   STARIO_REUSE_ADDR=1          (TCP only; set 0 to disable SO_REUSEADDR)
   STARIO_GRACEFUL_SHUTDOWN_TIMEOUT=5
+  STARIO_SSL_CERTFILE=         (PEM cert; enables direct TLS + ALPN h2,http/1.1)
+  STARIO_SSL_KEYFILE=          (PEM key; defaults to the cert file if omitted)
 
 Telemetry (STARIO_TRACER plus json/sqlite backend tuning):
   STARIO_TRACER=auto|tty|json|noop|sqlite|module|module:callable

--- a/src/stario/http/config.py
+++ b/src/stario/http/config.py
@@ -5,7 +5,9 @@ alongside `BodyReader`; this module re-exports them for env wiring.
 """
 
 from collections.abc import Callable
+from pathlib import Path
 from typing import Literal
+from ssl import SSLContext
 
 from stario._env import (
     env_bool,
@@ -16,6 +18,7 @@ from stario._env import (
     env_str,
 )
 from stario.exceptions import StarioError
+from stario.http.tls import load_tls_context
 
 from .compression import CompressionConfig, compression_config_from_env
 from .request import (
@@ -151,6 +154,7 @@ class ServerConfig:
         "port",
         "requests",
         "reuse_addr",
+        "ssl",
         "unix_socket",
         "unix_socket_mode",
     )
@@ -168,6 +172,9 @@ class ServerConfig:
         backlog: int = DEFAULT_BACKLOG,
         reuse_addr: bool = DEFAULT_REUSE_ADDR,
         event_loop: EventLoopKind = DEFAULT_EVENT_LOOP,
+        ssl: SSLContext | None = None,
+        ssl_certfile: str | Path | None = None,
+        ssl_keyfile: str | Path | None = None,
     ) -> None:
         if not 1 <= port <= 65535:
             raise StarioError(
@@ -204,6 +211,16 @@ class ServerConfig:
                 "event_loop must be 'asyncio' or 'uvloop'",
                 help_text="Set STARIO_LOOP or pass event_loop to ServerConfig.",
             )
+        if ssl is not None and (ssl_certfile is not None or ssl_keyfile is not None):
+            raise StarioError(
+                "pass either ssl= or ssl_certfile=, not both",
+                help_text="Use a prepared SSLContext or certificate paths.",
+            )
+        if ssl_keyfile is not None and ssl_certfile is None:
+            raise StarioError(
+                "ssl_keyfile requires ssl_certfile",
+                help_text="Set STARIO_SSL_CERTFILE with STARIO_SSL_KEYFILE.",
+            )
 
         self.host = host
         self.port = port
@@ -217,6 +234,15 @@ class ServerConfig:
         self.backlog = backlog
         self.reuse_addr = reuse_addr
         self.event_loop: EventLoopKind = event_loop
+        if ssl is not None:
+            self.ssl = ssl
+        elif ssl_certfile is not None:
+            self.ssl = load_tls_context(
+                certfile=ssl_certfile,
+                keyfile=ssl_keyfile,
+            )
+        else:
+            self.ssl = None
 
 
 def _event_loop_from_env() -> EventLoopKind:
@@ -247,5 +273,7 @@ def server_config_from_env() -> ServerConfig:
             backlog=env_int("STARIO_BACKLOG", DEFAULT_BACKLOG),
             reuse_addr=env_bool("STARIO_REUSE_ADDR", DEFAULT_REUSE_ADDR),
             event_loop=_event_loop_from_env(),
+            ssl_certfile=env_optional_str("STARIO_SSL_CERTFILE"),
+            ssl_keyfile=env_optional_str("STARIO_SSL_KEYFILE"),
         )
     )

--- a/src/stario/http/headers.py
+++ b/src/stario/http/headers.py
@@ -1,8 +1,10 @@
 """HTTP header container used by the parser, writer, and application API.
 
 `Headers` is the Cython pair list: each field is stored as wire-ready
-`name: ` / `value\\r\\n`. `get` / `set` still see clean strings. Repeated
-fields such as `Set-Cookie` stay as adjacent pairs.
+`name: ` / `value\\r\\n`. `get` / `getlist` / `items` scan two arrays.
+Repeated fields such as `Set-Cookie` stay as adjacent pairs. There is no
+`as_dict` — headers are not form data. Query uses the same pair-list lookup
+and adds `as_dict` / `as_lists` only when a mapping is needed.
 
 Request headers on the Cython protocol stay an arena scan (`RequestHeaders`).
 This type is the response map and the Python httptools path.

--- a/src/stario/http/query.py
+++ b/src/stario/http/query.py
@@ -1,61 +1,73 @@
-"""Parsed query strings: repeated keys become lists; `ParsedQuery` exposes first-value and multi-value APIs."""
+"""Query string: same shape as `Headers` — two arrays, linear scan.
+
+On first read the raw `?`-suffix is split and decoded into `_keys` / `_values`.
+`get` / `getlist` / `items` walk those arrays. No hash table.
+
+`as_dict` / `as_lists` are grouping *views* over the same arrays (Pydantic /
+forms). Headers have no equivalent: they are a pair list (`items` / `getlist`),
+not form data.
+"""
 
 from typing import overload
 from urllib.parse import unquote_plus as _unquote_plus
 
 
-def _parse_query(raw: bytes) -> dict[str, list[str]]:
-    """
-    Parse query string bytes into a multi-value dict.
+def _decode_component(raw: bytes, start: int, n: int) -> str:
+    if n <= 0:
+        return ""
+    end = start + n
+    i = start
+    while i < end:
+        c = raw[i]
+        if c == 37 or c == 43:
+            return _unquote_plus(raw[start:end].decode("latin-1"))
+        i += 1
+    return raw[start:end].decode("latin-1")
 
-    Intentionally inline; equivalent to
-    `parse_qsl(qs, keep_blank_values=True, separator="&")`.
-    """
-    data: dict[str, list[str]] = {}
+
+def _parse_query_arrays(raw: bytes) -> tuple[list[str], list[str]]:
+    """One pass: decoded keys and values, same order as the wire."""
     if not raw:
-        return data
-
-    qs = raw.decode("latin-1")
-    needs_unquote = "%" in qs or "+" in qs
-
-    for pair in qs.split("&"):
-        if not pair:
-            continue
-
-        eq = pair.find("=")
-        if eq < 0:
-            k = pair
-            v = ""
-        else:
-            k = pair[:eq]
-            v = pair[eq + 1 :]
-
-        if needs_unquote:
-            if "%" in k or "+" in k:
-                k = _unquote_plus(k)
-            if v and ("%" in v or "+" in v):
-                v = _unquote_plus(v)
-
-        if k in data:
-            data[k].append(v)
-        else:
-            data[k] = [v]
-
-    return data
+        return [], []
+    keys: list[str] = []
+    values: list[str] = []
+    i = 0
+    n = len(raw)
+    while i < n:
+        start = i
+        eq = -1
+        while i < n and raw[i] != 38:
+            if eq < 0 and raw[i] == 61:
+                eq = i
+            i += 1
+        end = i
+        if start < end:
+            if eq < 0:
+                keys.append(_decode_component(raw, start, end - start))
+                values.append("")
+            else:
+                keys.append(_decode_component(raw, start, eq - start))
+                values.append(_decode_component(raw, eq + 1, end - eq - 1))
+        if i < n and raw[i] == 38:
+            i += 1
+    return keys, values
 
 
 class ParsedQuery:
-    """View over parsed query bytes preserving repeated keys.
+    """Query pair list. `get` / `getlist` / `items` match `Headers`."""
 
-    Use `get` for the first value, `getlist` / `as_lists` for every value,
-    and `as_dict` for one string per key (Pydantic-friendly).
-    """
-
-    __slots__ = ("_data",)
+    __slots__ = ("_raw", "_keys", "_values")
 
     def __init__(self, raw: bytes) -> None:
-        """`raw` is query bytes from the URL (no leading `?`), Latin-1 decoded then split on `&`."""
-        self._data = _parse_query(raw)
+        """`raw` is query bytes from the URL (no leading `?`). Split is deferred."""
+        self._raw = raw if raw else b""
+        self._keys: list[str] | None = None
+        self._values: list[str] | None = None
+
+    def _ensure(self) -> None:
+        if self._keys is None:
+            self._keys, self._values = _parse_query_arrays(self._raw)
+            self._raw = b""
 
     @overload
     def get(self, key: str) -> str | None: ...
@@ -65,49 +77,68 @@ class ParsedQuery:
 
     def get[T](self, key: str, default: T | None = None) -> str | T | None:
         """First value for `key`, or `default` when the key is absent."""
-        vals = self._data.get(key)
-        return vals[0] if vals else default
+        self._ensure()
+        for k, v in zip(self._keys, self._values):
+            if k == key:
+                return v
+        return default
 
     def getlist(self, key: str) -> list[str]:
-        """Every value for `key` (empty list if missing), preserving duplicates from the query string."""
-        vals = self._data.get(key)
-        return list(vals) if vals else []
+        """Every value for `key` (empty list if missing), preserving duplicates."""
+        self._ensure()
+        return [v for k, v in zip(self._keys, self._values) if k == key]
 
     def items(self) -> list[tuple[str, str]]:
-        """All key-value pairs, flattened."""
-        return [(k, v) for k, vals in self._data.items() for v in vals]
+        """All key-value pairs, flattened (copy of the pair list)."""
+        self._ensure()
+        return list(zip(self._keys, self._values))
 
     def as_dict(self, *, last: bool = False) -> dict[str, str]:
-        """One string per key, suitable for Pydantic `model_validate` and similar.
+        """Group the pair list: one string per key (Pydantic `model_validate`).
 
         Repeated keys (`?a=1&a=2`) keep the **first** value by default (same as
         `get`). Pass `last=True` to keep the last value. For every value as a
-        list, use `as_lists`.
+        list, use `as_lists`. Headers have no analogue — use `items` / `getlist`.
         """
-        i = -1 if last else 0
-        return {k: vals[i] for k, vals in self._data.items()}
+        self._ensure()
+        out: dict[str, str] = {}
+        for k, v in zip(self._keys, self._values):
+            if last or k not in out:
+                out[k] = v
+        return out
 
     def as_lists(self) -> dict[str, list[str]]:
-        """All keys with every repeated value preserved (copy of each list).
+        """Group the pair list: every repeated value preserved.
 
         Use with schemas whose fields are `list[str]` (or similar) for
         `?tag=a&tag=b`-style parameters.
         """
-        return {k: list(v) for k, v in self._data.items()}
+        self._ensure()
+        out: dict[str, list[str]] = {}
+        for k, v in zip(self._keys, self._values):
+            existing = out.get(k)
+            if existing is None:
+                out[k] = [v]
+            else:
+                existing.append(v)
+        return out
 
     def __contains__(self, key: str) -> bool:
-        return key in self._data
+        self._ensure()
+        return key in self._keys
 
     def __bool__(self) -> bool:
-        return bool(self._data)
+        self._ensure()
+        return bool(self._keys)
 
     def __len__(self) -> int:
-        return len(self._data)
+        self._ensure()
+        return len(set(self._keys))
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, ParsedQuery):
-            return self._data == other._data
+            return self.items() == other.items()
         return NotImplemented
 
     def __repr__(self) -> str:
-        return f"ParsedQuery({self._data!r})"
+        return f"ParsedQuery({self.as_lists()!r})"

--- a/src/stario/http/server.py
+++ b/src/stario/http/server.py
@@ -219,14 +219,18 @@ class Server:
                 self.config.requests,
             )
 
+        ssl_ctx = self.config.ssl
         if listen_sock is not None:
-            return await loop.create_unix_server(protocol_factory, sock=listen_sock)
+            return await loop.create_unix_server(
+                protocol_factory, sock=listen_sock, ssl=ssl_ctx
+            )
         return await loop.create_server(
             protocol_factory,
             self.config.host,
             self.config.port,
             backlog=self.config.backlog,
             reuse_address=self.config.reuse_addr,
+            ssl=ssl_ctx,
         )
 
     async def _drain_listener(
@@ -533,6 +537,7 @@ class Server:
             "server.timeout.request_body": self.config.requests.body_timeout,
             "server.timeout.keep_alive": self.config.requests.keep_alive_timeout,
             "server.event_loop": self.config.event_loop,
+            "server.tls": self.config.ssl is not None,
         }
         if self.config.compression.zstd_window_log is not None:
             attrs["server.compression.zstd_window_log"] = (

--- a/src/stario/http/tls.py
+++ b/src/stario/http/tls.py
@@ -1,0 +1,49 @@
+"""TLS context for hosting Stario directly (not behind a reverse proxy).
+
+ALPN advertises ``h2`` then ``http/1.1`` so one listener can switch once
+per connection. HTTP/2 still needs the Cython protocol; the Python
+httptools path stays HTTP/1.1 even when the socket is TLS.
+"""
+
+from __future__ import annotations
+
+import ssl
+from pathlib import Path
+
+from stario.exceptions import StarioError
+
+
+def load_tls_context(
+    *,
+    certfile: str | Path,
+    keyfile: str | Path | None = None,
+    password: str | None = None,
+) -> ssl.SSLContext:
+    """Server TLS context: TLS 1.2+, ALPN ``h2`` / ``http/1.1``."""
+    cert = Path(certfile)
+    key = Path(keyfile) if keyfile is not None else None
+    if not cert.is_file():
+        raise StarioError(
+            f"TLS certificate not found: {cert}",
+            help_text="Set STARIO_SSL_CERTFILE to an existing PEM certificate.",
+        )
+    if key is not None and not key.is_file():
+        raise StarioError(
+            f"TLS private key not found: {key}",
+            help_text="Set STARIO_SSL_KEYFILE to the matching PEM private key.",
+        )
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+    try:
+        ctx.load_cert_chain(
+            str(cert),
+            str(key) if key is not None else None,
+            password=password,
+        )
+    except ssl.SSLError as exc:
+        raise StarioError(
+            f"Failed to load TLS certificate chain: {exc}",
+            help_text="Check STARIO_SSL_CERTFILE / STARIO_SSL_KEYFILE PEM files.",
+        ) from exc
+    ctx.set_alpn_protocols(["h2", "http/1.1"])
+    return ctx

--- a/src/stario_cython/__init__.py
+++ b/src/stario_cython/__init__.py
@@ -1,4 +1,4 @@
-"""Cython protocol for Stario: uvloop owns the socket, llhttp parses, App runs."""
+"""Cython protocol for Stario: uvloop owns the socket; llhttp + nghttp2 parse."""
 
 from __future__ import annotations
 

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -1,5 +1,5 @@
 from libc.stddef cimport size_t
-from libc.stdint cimport uint32_t, uint64_t
+from libc.stdint cimport int32_t, uint32_t, uint64_t
 
 from stario_cython.compression_buf cimport StarioBrotli, StarioGzip
 from stario_cython.headers cimport Headers
@@ -18,7 +18,10 @@ cdef class Request:
     cdef public object headers
     cdef public object protocol_version
     cdef public bint keep_alive
-    cdef public object query_bytes
+    cdef object _query_bytes
+    cdef object _q_owner
+    cdef Py_ssize_t _q_off
+    cdef Py_ssize_t _q_len
     cdef public object _body
     cdef object _query
     cdef object _cookies
@@ -34,6 +37,8 @@ cdef class Request:
         object headers,
         object body,
     )
+    cdef object _materialize_query(self)
+    cdef void bind_query_span(self, object owner, Py_ssize_t off, Py_ssize_t n) noexcept
 
 cdef class RequestExchange:
     cdef object _transport
@@ -42,6 +47,7 @@ cdef class RequestExchange:
     cdef int _req_encoding
     cdef bint _req_expect_continue
     cdef bint _req_connection_close
+    cdef Py_ssize_t _req_content_length
     cdef char* _req_arena
     cdef Py_ssize_t _req_arena_len
     cdef Py_ssize_t _req_arena_cap
@@ -107,6 +113,17 @@ cdef class RequestExchange:
     cdef int _abort_reason
     cdef bint _body_active
     cdef bint _body_complete
+    cdef bint _http2
+    cdef int32_t _h2_stream_id
+    cdef object _h2_pending
+    cdef Py_ssize_t _h2_pending_off
+    cdef bint _h2_body_done
+    cdef object _h2_method
+    cdef bint _h2_dispatched
+    cdef bint _h2_headers_done
+    cdef bint _h2_headers_sent
+    cdef object _h2_date_line
+    cdef object _h2_date_bare
     cdef bint _expect_continue
     cdef bint _waiting
     cdef bint _discard_body
@@ -126,6 +143,9 @@ cdef class RequestExchange:
         int max_body_size,
         double body_timeout,
     ) noexcept
+    cdef void bind_http2(self, int32_t stream_id) noexcept
+    cdef object _h2_date_value(self)
+    cdef void _h2_respond(self, object body, object content_type, int status, Py_ssize_t nbytes)
     cdef void start_response(self)
     cdef void handler_finished(self)
     cdef void cancel_before_start(self)
@@ -139,7 +159,15 @@ cdef class RequestExchange:
     cdef int append_request_url(self, const char* data, size_t length) noexcept
     cdef int append_request_header_name(self, const char* data, size_t length) noexcept
     cdef int append_request_header_value(self, const char* data, size_t length) noexcept
+    cdef int append_request_header(
+        self,
+        const char* name,
+        size_t name_length,
+        const char* value,
+        size_t value_length,
+    ) noexcept
     cdef int finish_request_header(self) noexcept
+    cdef int _commit_request_header(self) noexcept
     cdef void _scan_request_accept_encoding(
         self,
         const char* value,

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -11,7 +11,7 @@ import asyncio
 from types import MappingProxyType
 
 from libc.stddef cimport size_t
-from libc.stdint cimport uint32_t
+from libc.stdint cimport int32_t, uint32_t, uint64_t
 from libc.stdlib cimport free, realloc
 from libc.stdio cimport sprintf
 from libc.string cimport memcmp, memcpy
@@ -25,6 +25,7 @@ from cpython.bytes cimport (
     PyBytes_FromStringAndSize,
     PyBytes_GET_SIZE,
 )
+from cpython.list cimport PyList_GET_ITEM, PyList_GET_SIZE
 from cpython.exc cimport PyErr_Clear, PyErr_Occurred
 from cpython.mem cimport PyMem_Free, PyMem_Malloc
 from cpython.unicode cimport PyUnicode_DecodeLatin1, PyUnicode_DecodeUTF8
@@ -167,6 +168,22 @@ cdef inline bint _token_equals(
         if ch != <unsigned char>token[i]:
             return False
     return True
+
+
+cdef Py_ssize_t _parse_content_length(const char* s, size_t n) noexcept:
+    cdef uint64_t value = 0
+    cdef size_t i
+    cdef unsigned int digit
+    if n == 0:
+        return -1
+    for i in range(n):
+        digit = <unsigned int>(<unsigned char>s[i] - 48)
+        if digit > 9:
+            return -1
+        if value > (<uint64_t>9223372036854775807 - digit) / 10:
+            return -1
+        value = value * 10 + digit
+    return <Py_ssize_t>value
 
 
 cdef bint _contains_token(
@@ -447,35 +464,33 @@ cdef object _unquote_plus_component(const char* s, Py_ssize_t n):
         PyMem_Free(buf)
 
 
-cdef object _decode_query_component(const char* s, Py_ssize_t n):
+cdef inline bint _span_needs_unquote(const char* s, Py_ssize_t n) noexcept:
     cdef Py_ssize_t i
-    cdef bint has_pct = False
-    cdef bint has_plus = False
+    for i in range(n):
+        if s[i] == 37 or s[i] == 43:
+            return True
+    return False
+
+
+cdef object _decode_query_component(const char* s, Py_ssize_t n):
     if n <= 0:
         return ""
-    for i in range(n):
-        if s[i] == 37:
-            has_pct = True
-        elif s[i] == 43:
-            has_plus = True
-    if has_pct:
+    if _span_needs_unquote(s, n):
         return _unquote_plus_component(s, n)
-    if has_plus:
-        return _decode_latin1(s, n).replace("+", " ")
     return _decode_latin1(s, n)
 
 
-cdef dict _parse_query_bytes(const char* s, Py_ssize_t n):
-    cdef dict data = {}
+cdef int _fill_query_arrays(
+    const char* s,
+    Py_ssize_t n,
+    list keys,
+    list values,
+) except -1:
+    """One pass: decoded keys and values, same order as the wire."""
     cdef Py_ssize_t i = 0
     cdef Py_ssize_t start
     cdef Py_ssize_t eq
     cdef Py_ssize_t end
-    cdef object key
-    cdef object val
-    cdef list existing
-    if n <= 0:
-        return data
     while i < n:
         start = i
         eq = -1
@@ -486,82 +501,197 @@ cdef dict _parse_query_bytes(const char* s, Py_ssize_t n):
         end = i
         if start < end:
             if eq < 0:
-                key = _decode_query_component(s + start, end - start)
-                val = ""
+                keys.append(_decode_query_component(s + start, end - start))
+                values.append("")
             else:
-                key = _decode_query_component(s + start, eq - start)
-                val = _decode_query_component(s + eq + 1, end - eq - 1)
-            existing = data.get(key)
-            if existing is None:
-                data[key] = [val]
-            else:
-                existing.append(val)
+                keys.append(_decode_query_component(s + start, eq - start))
+                values.append(_decode_query_component(s + eq + 1, end - eq - 1))
         if i < n and s[i] == 38:
             i += 1
-    return data
+    return 0
 
 
 cdef class ParsedQuery:
-    """Cython view over query bytes. Same API as ``stario.http.query.ParsedQuery``."""
+    """Two arrays after first read. Same API as ``stario.http.query.ParsedQuery``."""
 
-    cdef dict _data
+    cdef bytes _raw
+    cdef object _owner
+    cdef Py_ssize_t _off
+    cdef Py_ssize_t _len
+    cdef list _keys
+    cdef list _values
+
+    def __cinit__(self):
+        self._raw = None
+        self._owner = None
+        self._off = 0
+        self._len = 0
+        self._keys = None
+        self._values = None
 
     def __init__(self, raw=b""):
-        cdef bytes b
-        if not raw:
-            self._data = {}
+        self._raw = raw if raw else b""
+        self._owner = None
+        self._off = 0
+        self._len = PyBytes_GET_SIZE(self._raw) if self._raw else 0
+        self._keys = None
+        self._values = None
+
+    cdef void bind_span(self, object owner, Py_ssize_t off, Py_ssize_t n) noexcept:
+        """Point at request-arena query bytes until the first read fills arrays."""
+        self._raw = None
+        self._owner = owner
+        self._off = off
+        self._len = n
+        self._keys = None
+        self._values = None
+
+    cdef void _ensure(self) except *:
+        cdef const char* s = NULL
+        cdef Py_ssize_t n
+        cdef list keys
+        cdef list values
+        cdef RequestExchange owner
+        if self._keys is not None:
             return
-        b = raw
-        self._data = _parse_query_bytes(
-            PyBytes_AS_STRING(b),
-            PyBytes_GET_SIZE(b),
-        )
+        keys = []
+        values = []
+        n = self._len
+        if n > 0:
+            if self._raw is not None:
+                s = PyBytes_AS_STRING(self._raw)
+            elif self._owner is not None:
+                owner = <RequestExchange>self._owner
+                if owner._req_arena != NULL:
+                    s = owner._req_arena + self._off
+            if s != NULL:
+                _fill_query_arrays(s, n, keys, values)
+        self._keys = keys
+        self._values = values
+        self._raw = None
+        self._owner = None
+        self._off = 0
+        self._len = 0
 
     def get(self, key, default=None):
-        cdef list vals = self._data.get(key)
-        if not vals:
-            return default
-        return vals[0]
+        cdef Py_ssize_t i
+        cdef Py_ssize_t n
+        cdef list keys
+        cdef list values
+        self._ensure()
+        keys = self._keys
+        values = self._values
+        n = PyList_GET_SIZE(keys)
+        for i in range(n):
+            if <object>PyList_GET_ITEM(keys, i) == key:
+                return <object>PyList_GET_ITEM(values, i)
+        return default
 
     def getlist(self, key):
-        cdef list vals = self._data.get(key)
-        if not vals:
-            return []
-        return list(vals)
+        cdef Py_ssize_t i
+        cdef Py_ssize_t n
+        cdef list keys
+        cdef list values
+        cdef list out = []
+        self._ensure()
+        keys = self._keys
+        values = self._values
+        n = PyList_GET_SIZE(keys)
+        for i in range(n):
+            if <object>PyList_GET_ITEM(keys, i) == key:
+                out.append(<object>PyList_GET_ITEM(values, i))
+        return out
 
     def items(self):
-        return [(k, v) for k, vals in self._data.items() for v in vals]
+        cdef Py_ssize_t i
+        cdef Py_ssize_t n
+        cdef list keys
+        cdef list values
+        cdef list out = []
+        self._ensure()
+        keys = self._keys
+        values = self._values
+        n = PyList_GET_SIZE(keys)
+        for i in range(n):
+            out.append((
+                <object>PyList_GET_ITEM(keys, i),
+                <object>PyList_GET_ITEM(values, i),
+            ))
+        return out
 
     def as_dict(self, *, last=False):
         cdef dict out = {}
-        cdef list vals
-        cdef Py_ssize_t idx
-        for k, vals in self._data.items():
-            if not vals:
-                continue
-            idx = len(vals) - 1 if last else 0
-            out[k] = vals[idx]
+        cdef Py_ssize_t i
+        cdef Py_ssize_t n
+        cdef object key
+        cdef list keys
+        cdef list values
+        self._ensure()
+        keys = self._keys
+        values = self._values
+        n = PyList_GET_SIZE(keys)
+        for i in range(n):
+            key = <object>PyList_GET_ITEM(keys, i)
+            if last or key not in out:
+                out[key] = <object>PyList_GET_ITEM(values, i)
         return out
 
     def as_lists(self):
-        return {k: list(v) for k, v in self._data.items()}
+        cdef dict out = {}
+        cdef Py_ssize_t i
+        cdef Py_ssize_t n
+        cdef object key
+        cdef list existing
+        cdef list keys
+        cdef list values
+        self._ensure()
+        keys = self._keys
+        values = self._values
+        n = PyList_GET_SIZE(keys)
+        for i in range(n):
+            key = <object>PyList_GET_ITEM(keys, i)
+            existing = out.get(key)
+            if existing is None:
+                out[key] = [<object>PyList_GET_ITEM(values, i)]
+            else:
+                existing.append(<object>PyList_GET_ITEM(values, i))
+        return out
 
     def __contains__(self, key):
-        return key in self._data
+        cdef Py_ssize_t i
+        cdef Py_ssize_t n
+        cdef list keys
+        self._ensure()
+        keys = self._keys
+        n = PyList_GET_SIZE(keys)
+        for i in range(n):
+            if <object>PyList_GET_ITEM(keys, i) == key:
+                return True
+        return False
 
     def __bool__(self):
-        return bool(self._data)
+        self._ensure()
+        return PyList_GET_SIZE(self._keys) != 0
 
     def __len__(self):
-        return len(self._data)
+        cdef set seen = set()
+        cdef Py_ssize_t i
+        cdef Py_ssize_t n
+        cdef list keys
+        self._ensure()
+        keys = self._keys
+        n = PyList_GET_SIZE(keys)
+        for i in range(n):
+            seen.add(<object>PyList_GET_ITEM(keys, i))
+        return len(seen)
 
     def __eq__(self, other):
         if isinstance(other, ParsedQuery):
-            return self._data == other._data
+            return self.items() == other.items()
         return NotImplemented
 
     def __repr__(self):
-        return f"ParsedQuery({self._data!r})"
+        return f"ParsedQuery({self.as_lists()!r})"
 
 
 cdef inline bint _is_ows(char c) noexcept:
@@ -773,11 +903,38 @@ cdef class Request:
         self.headers = headers
         self.protocol_version = protocol_version
         self.keep_alive = keep_alive
-        self.query_bytes = query_bytes
+        self._query_bytes = query_bytes
+        self._q_owner = None
+        self._q_off = 0
+        self._q_len = 0
         self._body = body
         self._query = None
         self._cookies = None
         self._host = None
+
+    cdef void bind_query_span(self, object owner, Py_ssize_t off, Py_ssize_t n) noexcept:
+        self._q_owner = owner
+        self._q_off = off
+        self._q_len = n
+        self._query_bytes = None
+
+    cdef object _materialize_query(self):
+        cdef RequestExchange owner
+        if self._query_bytes is not None:
+            return self._query_bytes
+        if self._q_len <= 0 or self._q_owner is None:
+            self._query_bytes = b""
+            return self._query_bytes
+        owner = <RequestExchange>self._q_owner
+        self._query_bytes = PyBytes_FromStringAndSize(
+            owner._req_arena + self._q_off,
+            self._q_len,
+        )
+        return self._query_bytes
+
+    @property
+    def query_bytes(self):
+        return self._materialize_query()
 
     @property
     def host(self):
@@ -802,10 +959,16 @@ cdef class Request:
 
     @property
     def query(self):
-        cdef bytes raw
+        cdef ParsedQuery parsed
         if self._query is None:
-            raw = self.query_bytes
-            self._query = ParsedQuery(raw if raw else b"")
+            if self._query_bytes is not None:
+                self._query = ParsedQuery(self._query_bytes)
+            elif self._q_len > 0 and self._q_owner is not None:
+                parsed = ParsedQuery.__new__(ParsedQuery)
+                parsed.bind_span(self._q_owner, self._q_off, self._q_len)
+                self._query = parsed
+            else:
+                self._query = ParsedQuery(b"")
         return self._query
 
     @property
@@ -866,6 +1029,18 @@ cdef class RequestExchange:
         self._tail_used = 0
         self._tail_cap = 0
         self._expected_size = -1
+        self._http2 = False
+        self._h2_stream_id = 0
+        self._h2_pending = b""
+        self._h2_pending_off = 0
+        self._h2_body_done = False
+        self._h2_method = None
+        self._h2_dispatched = False
+        self._h2_headers_done = False
+        self._h2_headers_sent = False
+        self._h2_date_line = None
+        self._h2_date_bare = None
+        self._req_content_length = -1
 
     def __init__(self):
         self.headers = Headers()
@@ -1044,6 +1219,92 @@ cdef class RequestExchange:
             i = sprintf(tmp, "%zu", n)
         return self._buf_add(tmp, i)
 
+    cdef object _h2_date_value(self):
+        cdef object line = self._date_box[0]
+        cdef bytes raw
+        cdef Py_ssize_t n
+        if line is self._h2_date_line and self._h2_date_bare is not None:
+            return self._h2_date_bare
+        raw = <bytes>line
+        n = PyBytes_GET_SIZE(raw)
+        if n > 8 and raw[0] == 100 and raw[n - 2] == 13:
+            self._h2_date_bare = raw[6 : n - 2]
+        else:
+            self._h2_date_bare = raw
+        self._h2_date_line = line
+        return self._h2_date_bare
+
+    cdef void _h2_respond(
+        self,
+        object body,
+        object content_type,
+        int status,
+        Py_ssize_t nbytes,
+    ):
+        cdef Headers h = self.headers
+        cdef object encoding
+        cdef object flat
+        cdef object scanned
+        cdef object existing_ce = None
+        cdef object existing_cl = None
+        cdef const unsigned char* native_out = NULL
+        cdef size_t native_len = 0
+        cdef list nva
+        cdef object payload = body
+        if not h.c_empty():
+            scanned = h.c_scan_respond(content_type)
+            existing_ce = scanned[0]
+            existing_cl = scanned[1]
+        if not _may_have_body(status):
+            payload = b""
+            nbytes = 0
+        elif existing_ce is None and self._may_compress(body, content_type, False, nbytes):
+            encoding = b"br" if self._req_encoding == ENCODING_BR else b"gzip"
+            flat = self._body_as_bytes(body)
+            try:
+                self._frame(flat, encoding, &native_out, &native_len)
+                nbytes = <Py_ssize_t>native_len
+                if existing_cl is not None:
+                    h.c_require_respond_length(existing_cl, _dec(native_len))
+                payload = PyBytes_FromStringAndSize(<char*>native_out, <Py_ssize_t>native_len)
+                nva = [
+                    (b":status", _dec(<size_t>status)),
+                    (b"date", self._h2_date_value()),
+                    (b"content-type", content_type),
+                    (b"content-length", _dec(native_len)),
+                    (b"content-encoding", encoding),
+                ]
+                if not h.c_vary_contains(b"accept-encoding"):
+                    nva.append((b"vary", b"accept-encoding"))
+                self._connection.h2_respond(self, nva, payload, True, True, True)
+            finally:
+                self._free_compressors()
+            self._status_code = status
+            self._declared_length = nbytes
+            self._bytes_written = nbytes
+            self._completed = True
+            self._done()
+            return
+        if existing_cl is not None:
+            h.c_require_respond_length(existing_cl, _dec(<size_t>nbytes))
+        nva = [
+            (b":status", _dec(<size_t>status)),
+            (b"date", self._h2_date_value()),
+        ]
+        if _may_have_body(status):
+            nva.append((b"content-type", content_type))
+            nva.append((b"content-length", _dec(<size_t>nbytes)))
+        if isinstance(payload, (list, tuple)):
+            payload = b"".join(payload) if payload else b""
+        self._connection.h2_respond(
+            self, nva, payload if payload is not None else b"", False, True, True
+        )
+        self._status_code = status
+        self._declared_length = nbytes
+        self._bytes_written = nbytes if nbytes > 0 else 0
+        self._completed = True
+        self._done()
+
     cdef void _flush(self):
         cdef object view
         cdef object done
@@ -1056,6 +1317,9 @@ cdef class RequestExchange:
             self._out_buf = bytearray(256)
         view = memoryview(done)[:self._out_len]
         self._out_len = 0
+        if self._http2:
+            self._connection.h2_write_data(self, view, False)
+            return
         self._transport.write(view)
 
     @property
@@ -1247,18 +1511,48 @@ cdef class RequestExchange:
         self._req_pending_value_length += <Py_ssize_t>length
         return 0
 
+    cdef int append_request_header(
+        self,
+        const char* name,
+        size_t name_length,
+        const char* value,
+        size_t value_length,
+    ) noexcept:
+        """Complete header in one pass (H2 delivers name and value together)."""
+        if name_length == 0 or name_length >= <size_t>REQUEST_NAME_MAX:
+            return -1
+        if self._req_pending_header and self.finish_request_header() != 0:
+            return -1
+        if self._reserve_request_arena(<Py_ssize_t>(name_length + value_length)) != 0:
+            return -1
+        self._req_pending_name_offset = self._req_arena_len
+        _lower_copy(self._req_arena + self._req_arena_len, name, name_length)
+        self._req_arena_len += <Py_ssize_t>name_length
+        self._req_pending_name_length = <Py_ssize_t>name_length
+        self._req_pending_value_offset = self._req_arena_len
+        if value_length:
+            memcpy(self._req_arena + self._req_arena_len, value, value_length)
+        self._req_arena_len += <Py_ssize_t>value_length
+        self._req_pending_value_length = <Py_ssize_t>value_length
+        self._req_pending_header = True
+        return self._commit_request_header()
+
     cdef int finish_request_header(self) noexcept:
-        cdef RawHeader* header
-        cdef const char* name
-        cdef const char* value
-        cdef size_t name_length
-        cdef size_t value_length
         if not self._req_pending_header:
             return 0
         if self._req_pending_name_length == 0:
             return -1
         if self._req_pending_value_offset < 0:
             self._req_pending_value_offset = self._req_arena_len
+        return self._commit_request_header()
+
+    cdef int _commit_request_header(self) noexcept:
+        cdef RawHeader* header
+        cdef const char* name
+        cdef const char* value
+        cdef size_t name_length
+        cdef size_t value_length
+        cdef Py_ssize_t parsed
         name = self._req_arena + self._req_pending_name_offset
         value = self._req_arena + self._req_pending_value_offset
         name_length = <size_t>self._req_pending_name_length
@@ -1286,6 +1580,13 @@ cdef class RequestExchange:
         elif name_length == 13 and memcmp(name, "authorization", 13) == 0:
             if self._req_authorization_index < 0:
                 self._req_authorization_index = self._req_raw_count
+        elif name_length == 14 and memcmp(name, "content-length", 14) == 0:
+            parsed = _parse_content_length(value, value_length)
+            if parsed < 0:
+                return -1
+            if self._req_content_length >= 0 and self._req_content_length != parsed:
+                return -1
+            self._req_content_length = parsed
         elif name_length == 15 and memcmp(name, "accept-encoding", 15) == 0:
             self._scan_request_accept_encoding(value, value_length)
         self._req_raw_count += 1
@@ -1429,11 +1730,31 @@ cdef class RequestExchange:
         self._clear_request_headers()
         self.handler_done = False
         self.handler_started = False
+        self._http2 = False
+        self._h2_stream_id = 0
+        self._h2_pending = b""
+        self._h2_pending_off = 0
+        self._h2_body_done = False
+        self._h2_method = None
+        self._h2_dispatched = False
+        self._h2_headers_done = False
+        self._h2_headers_sent = False
+
+    cdef void bind_http2(self, int32_t stream_id) noexcept:
+        self._http2 = True
+        self._h2_stream_id = stream_id
+        self._h2_pending = b""
+        self._h2_pending_off = 0
+        self._h2_body_done = False
+        self._h2_dispatched = False
+        self._h2_headers_done = False
+        self._h2_headers_sent = False
 
     cdef void _clear_hot_request_headers(self) noexcept:
         self._req_encoding = ENCODING_NONE
         self._req_expect_continue = False
         self._req_connection_close = False
+        self._req_content_length = -1
         self._req_accept_present = False
         self._req_br_q = -1
         self._req_gzip_q = -1
@@ -1580,6 +1901,9 @@ cdef class RequestExchange:
             nbytes = self._body_nbytes(body)
         self._declared_length = nbytes
         self._bytes_written = 0
+        if self._http2:
+            self._h2_respond(body, content_type, status, nbytes)
+            return
         # Empty headers + no compression: writelines of interned pieces
         # (status, Date, type, length, body). No join, no cross-request cache.
         if h.c_empty() and (
@@ -1701,7 +2025,10 @@ cdef class RequestExchange:
         self._free_compressors()
         self._completed = True
         self.headers.c_set(b"connection", b"close")
-        self._transport.close()
+        if self._http2:
+            self._connection.h2_abort(self)
+        else:
+            self._transport.close()
         self._done()
 
     def write_headers(self, int status_code):
@@ -1709,6 +2036,7 @@ cdef class RequestExchange:
         cdef object raw_length
         cdef object parsed_length
         cdef object encoding
+        cdef list nva
         if self._transport.is_closing():
             return self
         if self._status_code >= 0:
@@ -1739,7 +2067,7 @@ cdef class RequestExchange:
                     context={"content-length": raw_length},
                     help_text="Set Content-Length to a non-negative integer before write_headers().",
                 ) from exc
-        else:
+        elif not self._http2:
             headers.c_set(b"transfer-encoding", b"chunked")
             if headers.c_get(b"content-encoding") is None:
                 encoding = None
@@ -1756,6 +2084,14 @@ cdef class RequestExchange:
                         self._ensure_gzip()
                     headers.c_set(b"content-encoding", encoding)
                     headers.c_merge_vary(b"accept-encoding")
+        if self._http2:
+            nva = [
+                (b":status", _dec(<size_t>status_code)),
+                (b"date", self._h2_date_value()),
+            ]
+            self._connection.h2_write_headers(self, nva, False, False, False)
+            self._status_code = status_code
+            return self
         self._buf_bytes(_status_line(status_code))
         self._buf_bytes(self._date_box[0])
         if self._out_buf is None:
@@ -1798,6 +2134,15 @@ cdef class RequestExchange:
             )
         n = self._body_nbytes(data)
         if n == 0:
+            return self
+        if self._http2:
+            self._bytes_written += n
+            if isinstance(data, (list, tuple)):
+                for part in data:
+                    if part:
+                        self._connection.h2_write_data(self, part, False)
+            else:
+                self._connection.h2_write_data(self, data, False)
             return self
         if self._declared_length >= 0:
             self._bytes_written += n
@@ -1842,6 +2187,11 @@ cdef class RequestExchange:
             self.write_headers(200 if data is not None else 204)
         if data:
             self.write(data)
+        if self._http2:
+            self._connection.h2_end(self)
+            self._completed = True
+            self._done()
+            return
         if self._declared_length >= 0 and self._bytes_written != self._declared_length:
             raise StarioRuntime(
                 "Response body length mismatch: wrote "
@@ -2113,8 +2463,12 @@ cdef class RequestExchange:
     cdef void _maybe_continue(self):
         if self._expect_continue:
             self._expect_continue = False
-            if self._transport is not None and not self._transport.is_closing():
-                self._transport.write(b"HTTP/1.1 100 Continue\r\n\r\n")
+            if self._transport is None or self._transport.is_closing():
+                return
+            if self._http2:
+                self._connection.h2_write_headers(self, [(b":status", b"100")], True, True, True, True)
+                return
+            self._transport.write(b"HTTP/1.1 100 Continue\r\n\r\n")
 
     cdef void _maybe_pause(self):
         if self._consumed_as == CONSUMED_STREAM:

--- a/src/stario_cython/nghttp2.pxd
+++ b/src/stario_cython/nghttp2.pxd
@@ -1,0 +1,273 @@
+from libc.stddef cimport size_t
+from libc.stdint cimport int32_t, uint8_t, uint32_t
+
+cdef extern from *:
+    ctypedef long ssize_t
+
+cdef extern from "nghttp2/nghttp2.h":
+    cdef enum:
+        NGHTTP2_PROTO_VERSION_ID_LEN
+        NGHTTP2_FLAG_NONE
+        NGHTTP2_FLAG_END_STREAM
+        NGHTTP2_FLAG_END_HEADERS
+        NGHTTP2_DATA
+        NGHTTP2_HEADERS
+        NGHTTP2_SETTINGS
+        NGHTTP2_WINDOW_UPDATE
+        NGHTTP2_GOAWAY
+        NGHTTP2_RST_STREAM
+        NGHTTP2_NO_ERROR
+        NGHTTP2_PROTOCOL_ERROR
+        NGHTTP2_INTERNAL_ERROR
+        NGHTTP2_ERR_CALLBACK_FAILURE
+        NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE
+        NGHTTP2_ERR_DEFERRED
+        NGHTTP2_ERR_PAUSE
+        NGHTTP2_DATA_FLAG_NONE
+        NGHTTP2_DATA_FLAG_EOF
+        NGHTTP2_DATA_FLAG_NO_COPY
+        NGHTTP2_NV_FLAG_NONE
+        NGHTTP2_NV_FLAG_NO_INDEX
+        NGHTTP2_NV_FLAG_NO_COPY_NAME
+        NGHTTP2_NV_FLAG_NO_COPY_VALUE
+        NGHTTP2_SETTINGS_ENABLE_PUSH
+        NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS
+        NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE
+        NGHTTP2_HCAT_REQUEST
+
+    ctypedef struct nghttp2_option:
+        pass
+
+    ctypedef struct nghttp2_settings_entry:
+        int32_t settings_id
+        uint32_t value
+
+    ctypedef struct nghttp2_session:
+        pass
+
+    ctypedef struct nghttp2_session_callbacks:
+        pass
+
+    ctypedef struct nghttp2_nv:
+        uint8_t* name
+        uint8_t* value
+        size_t namelen
+        size_t valuelen
+        uint8_t flags
+
+    ctypedef struct nghttp2_frame_hd:
+        size_t length
+        int32_t stream_id
+        uint8_t type
+        uint8_t flags
+        uint8_t reserved
+
+    ctypedef struct nghttp2_headers:
+        nghttp2_frame_hd hd
+        int cat
+
+    ctypedef struct nghttp2_data:
+        nghttp2_frame_hd hd
+        size_t padlen
+
+    ctypedef union nghttp2_frame:
+        nghttp2_frame_hd hd
+        nghttp2_headers headers
+        nghttp2_data data
+
+    ctypedef union nghttp2_data_source:
+        int fd
+        void* ptr
+
+    ctypedef ssize_t (*nghttp2_data_source_read_callback)(
+        nghttp2_session* session,
+        int32_t stream_id,
+        uint8_t* buf,
+        size_t length,
+        uint32_t* data_flags,
+        nghttp2_data_source* source,
+        void* user_data,
+    )
+
+    ctypedef struct nghttp2_data_provider:
+        nghttp2_data_source source
+        nghttp2_data_source_read_callback read_callback
+
+    ctypedef int (*nghttp2_on_begin_headers_callback)(
+        nghttp2_session* session,
+        const nghttp2_frame* frame,
+        void* user_data,
+    )
+    ctypedef int (*nghttp2_on_header_callback)(
+        nghttp2_session* session,
+        const nghttp2_frame* frame,
+        const uint8_t* name,
+        size_t namelen,
+        const uint8_t* value,
+        size_t valuelen,
+        uint8_t flags,
+        void* user_data,
+    )
+    ctypedef int (*nghttp2_on_frame_recv_callback)(
+        nghttp2_session* session,
+        const nghttp2_frame* frame,
+        void* user_data,
+    )
+    ctypedef int (*nghttp2_on_data_chunk_recv_callback)(
+        nghttp2_session* session,
+        uint8_t flags,
+        int32_t stream_id,
+        const uint8_t* data,
+        size_t len,
+        void* user_data,
+    )
+    ctypedef int (*nghttp2_on_stream_close_callback)(
+        nghttp2_session* session,
+        int32_t stream_id,
+        uint32_t error_code,
+        void* user_data,
+    )
+    ctypedef int (*nghttp2_send_data_callback)(
+        nghttp2_session* session,
+        nghttp2_frame* frame,
+        const uint8_t* framehd,
+        size_t length,
+        nghttp2_data_source* source,
+        void* user_data,
+    )
+
+    int nghttp2_session_callbacks_new(nghttp2_session_callbacks** callbacks_ptr)
+    void nghttp2_session_callbacks_del(nghttp2_session_callbacks* callbacks)
+    void nghttp2_session_callbacks_set_on_begin_headers_callback(
+        nghttp2_session_callbacks* cbs,
+        nghttp2_on_begin_headers_callback on_begin_headers_callback,
+    )
+    void nghttp2_session_callbacks_set_on_header_callback(
+        nghttp2_session_callbacks* cbs,
+        nghttp2_on_header_callback on_header_callback,
+    )
+    void nghttp2_session_callbacks_set_on_frame_recv_callback(
+        nghttp2_session_callbacks* cbs,
+        nghttp2_on_frame_recv_callback on_frame_recv_callback,
+    )
+    void nghttp2_session_callbacks_set_on_data_chunk_recv_callback(
+        nghttp2_session_callbacks* cbs,
+        nghttp2_on_data_chunk_recv_callback on_data_chunk_recv_callback,
+    )
+    void nghttp2_session_callbacks_set_on_stream_close_callback(
+        nghttp2_session_callbacks* cbs,
+        nghttp2_on_stream_close_callback on_stream_close_callback,
+    )
+    void nghttp2_session_callbacks_set_send_data_callback(
+        nghttp2_session_callbacks* cbs,
+        nghttp2_send_data_callback send_data_callback,
+    )
+
+    int nghttp2_option_new(nghttp2_option** option_ptr)
+    void nghttp2_option_del(nghttp2_option* option)
+    void nghttp2_option_set_no_auto_window_update(nghttp2_option* option, int val)
+
+    int nghttp2_session_server_new(
+        nghttp2_session** session_ptr,
+        const nghttp2_session_callbacks* callbacks,
+        void* user_data,
+    )
+    int nghttp2_session_server_new2(
+        nghttp2_session** session_ptr,
+        const nghttp2_session_callbacks* callbacks,
+        void* user_data,
+        const nghttp2_option* option,
+    )
+    int nghttp2_session_set_local_window_size(
+        nghttp2_session* session,
+        uint8_t flags,
+        int32_t stream_id,
+        int32_t window_size,
+    )
+    int32_t nghttp2_session_get_effective_recv_data_length(
+        nghttp2_session* session,
+    )
+    int32_t nghttp2_session_get_local_window_size(nghttp2_session* session)
+    int32_t nghttp2_session_get_stream_effective_recv_data_length(
+        nghttp2_session* session,
+        int32_t stream_id,
+    )
+    int32_t nghttp2_session_get_stream_local_window_size(
+        nghttp2_session* session,
+        int32_t stream_id,
+    )
+    int nghttp2_session_consume(
+        nghttp2_session* session,
+        int32_t stream_id,
+        size_t size,
+    )
+    int nghttp2_session_consume_connection(
+        nghttp2_session* session,
+        size_t size,
+    )
+    void nghttp2_session_del(nghttp2_session* session)
+    ssize_t nghttp2_session_mem_recv(
+        nghttp2_session* session,
+        const uint8_t* data,
+        size_t datalen,
+    )
+    ssize_t nghttp2_session_mem_send(nghttp2_session* session, const uint8_t** data_ptr)
+    int nghttp2_session_resume_data(nghttp2_session* session, int32_t stream_id)
+    void* nghttp2_session_get_stream_user_data(
+        nghttp2_session* session,
+        int32_t stream_id,
+    )
+    int nghttp2_session_set_stream_user_data(
+        nghttp2_session* session,
+        int32_t stream_id,
+        void* stream_user_data,
+    )
+    int nghttp2_submit_response(
+        nghttp2_session* session,
+        int32_t stream_id,
+        const nghttp2_nv* nva,
+        size_t nvlen,
+        const nghttp2_data_provider* data_prd,
+    )
+    int nghttp2_submit_headers(
+        nghttp2_session* session,
+        uint8_t flags,
+        int32_t stream_id,
+        const void* pri_spec,
+        const nghttp2_nv* nva,
+        size_t nvlen,
+        void* stream_user_data,
+    )
+    int nghttp2_submit_data(
+        nghttp2_session* session,
+        uint8_t flags,
+        int32_t stream_id,
+        const nghttp2_data_provider* data_prd,
+    )
+    int nghttp2_submit_rst_stream(
+        nghttp2_session* session,
+        uint8_t flags,
+        int32_t stream_id,
+        uint32_t error_code,
+    )
+    int nghttp2_submit_goaway(
+        nghttp2_session* session,
+        uint8_t flags,
+        int32_t last_stream_id,
+        uint32_t error_code,
+        const uint8_t* opaque_data,
+        size_t opaque_data_len,
+    )
+    int nghttp2_submit_settings(
+        nghttp2_session* session,
+        uint8_t flags,
+        const nghttp2_settings_entry* iv,
+        size_t niv,
+    )
+    int nghttp2_submit_window_update(
+        nghttp2_session* session,
+        uint8_t flags,
+        int32_t stream_id,
+        int32_t window_size_increment,
+    )
+    const char* nghttp2_strerror(int lib_error_code)

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -1,9 +1,10 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
-"""asyncio Protocol + llhttp: one TCP connection, pipelining, and dispatch.
+"""asyncio Protocol: llhttp for HTTP/1, nghttp2 for HTTP/2.
 
 ``HttpProtocol`` owns parser callbacks, pause/resume, and request dispatch.
-URL bytes and header fragments are written into the current exchange arena.
-Path/query decoding is cached here because it is connection-parse work.
+H1 vs H2 is chosen once (TLS ALPN or the cleartext H2 preface). URL bytes
+and header fragments go into the current exchange arena. Path/query
+decoding is cached here because it is connection-parse work.
 
 Header, idle, and body-stall timeouts share one cleanup path. Under Server
 that path is the Date-header tick (once a second): one ``loop.time()``, then
@@ -14,11 +15,24 @@ sweeper at the same period. See ``stario_cython.timeouts``.
 import asyncio
 from collections import deque
 
-from libc.stdint cimport uint16_t, uint32_t, uint64_t
+from libc.stddef cimport size_t
+from libc.stdint cimport int32_t, uint8_t, uint16_t, uint32_t, uint64_t
 from libc.stdlib cimport free, malloc
-from libc.string cimport memcmp, memcpy
-from cpython.bytes cimport PyBytes_FromStringAndSize
-from cpython.unicode cimport PyUnicode_DecodeASCII
+from libc.string cimport memcmp, memcpy, memmove
+from cpython.bytearray cimport (
+    PyByteArray_AS_STRING,
+    PyByteArray_Check,
+    PyByteArray_GET_SIZE,
+    PyByteArray_Resize,
+)
+from cpython.bytes cimport (
+    PyBytes_AS_STRING,
+    PyBytes_Check,
+    PyBytes_FromStringAndSize,
+    PyBytes_GET_SIZE,
+)
+from cpython.exc cimport PyErr_Clear
+from cpython.unicode cimport PyUnicode_DecodeASCII, PyUnicode_DecodeLatin1
 
 from stario.http.config import (
     DEFAULT_HEADER_TIMEOUT,
@@ -31,7 +45,63 @@ from stario.http.wire import decode_path
 from stario.telemetry.noop import NoOpTracer
 
 from stario_cython.exchange cimport Request, RequestExchange, acquire_exchange, _status_line
+from stario_cython.headers cimport Headers
 from stario_cython.llhttp cimport *
+from stario_cython.nghttp2 cimport (
+    ssize_t,
+    NGHTTP2_DATA,
+    NGHTTP2_DATA_FLAG_EOF,
+    NGHTTP2_DATA_FLAG_NO_COPY,
+    NGHTTP2_ERR_CALLBACK_FAILURE,
+    NGHTTP2_ERR_DEFERRED,
+    NGHTTP2_FLAG_END_STREAM,
+    NGHTTP2_FLAG_NONE,
+    NGHTTP2_HEADERS,
+    NGHTTP2_INTERNAL_ERROR,
+    NGHTTP2_PROTOCOL_ERROR,
+    NGHTTP2_NV_FLAG_NONE,
+    NGHTTP2_NV_FLAG_NO_COPY_NAME,
+    NGHTTP2_NV_FLAG_NO_COPY_VALUE,
+    NGHTTP2_SETTINGS_ENABLE_PUSH,
+    NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE,
+    NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS,
+    nghttp2_data_provider,
+    nghttp2_data_source,
+    nghttp2_frame,
+    nghttp2_nv,
+    nghttp2_option,
+    nghttp2_option_del,
+    nghttp2_option_new,
+    nghttp2_option_set_no_auto_window_update,
+    nghttp2_session,
+    nghttp2_session_callbacks,
+    nghttp2_session_callbacks_del,
+    nghttp2_session_callbacks_new,
+    nghttp2_session_callbacks_set_on_begin_headers_callback,
+    nghttp2_session_callbacks_set_on_data_chunk_recv_callback,
+    nghttp2_session_callbacks_set_on_frame_recv_callback,
+    nghttp2_session_callbacks_set_on_header_callback,
+    nghttp2_session_callbacks_set_on_stream_close_callback,
+    nghttp2_session_callbacks_set_send_data_callback,
+    nghttp2_session_del,
+    nghttp2_session_get_effective_recv_data_length,
+    nghttp2_session_get_local_window_size,
+    nghttp2_session_get_stream_effective_recv_data_length,
+    nghttp2_session_get_stream_local_window_size,
+    nghttp2_session_get_stream_user_data,
+    nghttp2_session_mem_recv,
+    nghttp2_session_mem_send,
+    nghttp2_session_resume_data,
+    nghttp2_session_server_new2,
+    nghttp2_session_set_local_window_size,
+    nghttp2_session_set_stream_user_data,
+    nghttp2_settings_entry,
+    nghttp2_submit_headers,
+    nghttp2_submit_response,
+    nghttp2_submit_rst_stream,
+    nghttp2_submit_settings,
+    nghttp2_submit_window_update,
+)
 from stario_cython.timeouts import (
     DATE_TICK_SWEEP_ATTR as _PY_DATE_TICK_SWEEP_ATTR,
     TIMEOUT_MODE as _PY_TIMEOUT_MODE,
@@ -45,14 +115,30 @@ cdef enum:
     # body() is then already bytes when the handler starts. File uploads
     # (MiB) still dispatch at headers-complete so stream() can start early.
     SMALL_BODY_COMPLETE_DISPATCH = 256 * 1024
+    PARSE_NONE = 0
+    PARSE_H1 = 1
+    PARSE_H2 = 2
+    H2_PREFACE_LEN = 24
+    # Receive windows: default 64KiB stalls a multiplexed POST and
+    # auto-WINDOW_UPDATE emits a frame per DATA. 1MiB/4MiB plus batched
+    # consume keeps credit up without a frame per request.
+    H2_STREAM_WINDOW = 1024 * 1024
+    H2_CONN_WINDOW = 4 * 1024 * 1024
+    H2_STREAM_UPDATE_THRESH = 256 * 1024
+    H2_CONN_UPDATE_THRESH = 512 * 1024
+    H2_MAX_CONCURRENT = 256
 
 cdef char* _UC_KEY[256]
 cdef Py_ssize_t _UC_LEN[256]
 cdef uint32_t _UC_HASH[256]
+cdef Py_ssize_t _UC_QOFF[256]
+cdef Py_ssize_t _UC_QLEN[256]
 cdef list _UC_PATH = None
-cdef list _UC_QUERY = None
-cdef object Q_EMPTY = b""
 cdef object PATH_EMPTY = ""
+cdef bytes H2_PREFACE = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+cdef uint8_t H2_NV_NOCOPY = (
+    NGHTTP2_NV_FLAG_NO_COPY_NAME | NGHTTP2_NV_FLAG_NO_COPY_VALUE
+)
 
 
 cdef uint32_t _url_hash(const char* s, Py_ssize_t n) noexcept:
@@ -64,16 +150,17 @@ cdef uint32_t _url_hash(const char* s, Py_ssize_t n) noexcept:
 
 
 cdef void _url_cache_init():
-    global _UC_PATH, _UC_QUERY
+    global _UC_PATH
     cdef int i
     if _UC_PATH is not None:
         return
     _UC_PATH = [None] * URL_CACHE_CAP
-    _UC_QUERY = [None] * URL_CACHE_CAP
     for i in range(URL_CACHE_CAP):
         _UC_KEY[i] = NULL
         _UC_LEN[i] = 0
         _UC_HASH[i] = 0
+        _UC_QOFF[i] = 0
+        _UC_QLEN[i] = 0
 
 
 cdef void _url_cache_clear():
@@ -84,8 +171,9 @@ cdef void _url_cache_clear():
             _UC_KEY[i] = NULL
         _UC_LEN[i] = 0
         _UC_HASH[i] = 0
+        _UC_QOFF[i] = 0
+        _UC_QLEN[i] = 0
         _UC_PATH[i] = None
-        _UC_QUERY[i] = None
 
 
 cdef int _url_find(const char* url, Py_ssize_t n, uint32_t h) noexcept:
@@ -109,7 +197,8 @@ cdef void _url_store(
     Py_ssize_t n,
     uint32_t h,
     object path,
-    object query,
+    Py_ssize_t qoff,
+    Py_ssize_t qlen,
 ):
     cdef int slot
     cdef int i
@@ -126,7 +215,8 @@ cdef void _url_store(
             _UC_LEN[slot] = n
             _UC_HASH[slot] = h
             _UC_PATH[slot] = path
-            _UC_QUERY[slot] = query
+            _UC_QOFF[slot] = qoff
+            _UC_QLEN[slot] = qlen
             return
         slot = (slot + 1) & (URL_CACHE_CAP - 1)
     _url_cache_clear()
@@ -140,7 +230,8 @@ cdef void _url_store(
     _UC_LEN[slot] = n
     _UC_HASH[slot] = h
     _UC_PATH[slot] = path
-    _UC_QUERY[slot] = query
+    _UC_QOFF[slot] = qoff
+    _UC_QLEN[slot] = qlen
 
 
 cdef object _decode_path_n(const char* s, Py_ssize_t n):
@@ -155,39 +246,71 @@ cdef object _decode_path_n(const char* s, Py_ssize_t n):
     return PyUnicode_DecodeASCII(s, n, NULL)
 
 
-cdef tuple _split_request_target_n(const char* url, Py_ssize_t n):
+cdef object _path_for_url(
+    const char* url,
+    Py_ssize_t n,
+    Py_ssize_t* qoff,
+    Py_ssize_t* qlen,
+):
+    """Decoded path; query is a span inside the current URL (no copy)."""
     cdef Py_ssize_t question = -1
     cdef Py_ssize_t i
     cdef uint32_t h = 0
     cdef int slot
     cdef object path
-    cdef object query
+    qoff[0] = 0
+    qlen[0] = 0
     if n <= 0:
-        return (PATH_EMPTY, Q_EMPTY)
+        return PATH_EMPTY
     if n <= URL_CACHE_MAX_KEY:
         h = _url_hash(url, n)
         slot = _url_find(url, n, h)
         if slot >= 0:
-            return (_UC_PATH[slot], _UC_QUERY[slot])
+            qoff[0] = _UC_QOFF[slot]
+            qlen[0] = _UC_QLEN[slot]
+            return _UC_PATH[slot]
     for i in range(n):
         if url[i] == 63:
             question = i
             break
     if question < 0:
         path = _decode_path_n(url, n)
-        query = Q_EMPTY
     else:
         path = _decode_path_n(url, question)
         if question + 1 < n:
-            query = PyBytes_FromStringAndSize(url + question + 1, n - question - 1)
-        else:
-            query = Q_EMPTY
+            qoff[0] = question + 1
+            qlen[0] = n - question - 1
     if n <= URL_CACHE_MAX_KEY:
-        _url_store(url, n, h, path, query)
-    return (path, query)
+        _url_store(url, n, h, path, qoff[0], qlen[0])
+    return path
+
+cdef inline bint _as_buf(object data, const char** ptr, Py_ssize_t* n) noexcept:
+    if PyBytes_Check(data):
+        ptr[0] = PyBytes_AS_STRING(data)
+        n[0] = PyBytes_GET_SIZE(data)
+        return True
+    if PyByteArray_Check(data):
+        ptr[0] = PyByteArray_AS_STRING(data)
+        n[0] = PyByteArray_GET_SIZE(data)
+        return True
+    return False
+
+
+cdef int _preface_append(object hold, const char* p, Py_ssize_t n) noexcept:
+    cdef Py_ssize_t old
+    if n <= 0:
+        return 0
+    old = PyByteArray_GET_SIZE(hold)
+    if PyByteArray_Resize(hold, old + n) < 0:
+        PyErr_Clear()
+        return -1
+    memcpy(PyByteArray_AS_STRING(hold) + old, p, <size_t>n)
+    return 0
+
 
 cdef int F_CHUNKED = 0x8
 cdef int F_CONTENT_LENGTH = 0x20
+cdef int F_TRANSFER_ENCODING = 0x200
 cdef int PAUSE_WRITE = 1
 cdef int PAUSE_PIPELINE = 2
 cdef int PAUSE_BODY = 4
@@ -200,8 +323,8 @@ cdef int CLEANUP_SWEEP = 1
 cdef int TIMEOUT_MODE = 1
 cdef double TIMEOUT_SWEEP_INTERVAL = 1.0
 cdef object _SWEEPS_ATTR = "_stario_timeout_sweeps"
-# GET and large/chunked bodies dispatch at headers-complete. Small
-# Content-Length bodies dispatch at message-complete so body() is cached.
+# Empty / small bodies finish before the handler runs so body() is cached.
+# Large, chunked, and 100-continue still dispatch at headers.
 
 cdef object METH_DELETE = "DELETE"
 cdef object METH_GET = "GET"
@@ -212,8 +335,10 @@ cdef object METH_CONNECT = "CONNECT"
 cdef object METH_OPTIONS = "OPTIONS"
 cdef object METH_TRACE = "TRACE"
 cdef object METH_PATCH = "PATCH"
+cdef object METH_QUERY = "QUERY"
 cdef object VER_10 = "1.0"
 cdef object VER_11 = "1.1"
+cdef object VER_20 = "2"
 
 cdef llhttp_settings_t* _SETTINGS = NULL
 
@@ -241,11 +366,54 @@ cdef object _method_str(int method):
 
 
 cdef object _version_str(int major, int minor):
+    if major == 2:
+        return VER_20
     if major == 1 and minor == 1:
         return VER_11
     if major == 1 and minor == 0:
         return VER_10
     return "%d.%d" % (major, minor)
+
+
+cdef inline bint _header_name_ok(const char* p, size_t n) noexcept nogil:
+    cdef size_t i
+    cdef unsigned char c
+    if n == 0:
+        return False
+    for i in range(n):
+        c = <unsigned char>p[i]
+        if c <= 32 or c >= 127:
+            return False
+    return True
+
+
+cdef object _method_from_bytes(const char* p, size_t n) noexcept:
+    if n == 3:
+        if memcmp(p, "GET", 3) == 0:
+            return METH_GET
+        if memcmp(p, "PUT", 3) == 0:
+            return METH_PUT
+    elif n == 4:
+        if memcmp(p, "POST", 4) == 0:
+            return METH_POST
+        if memcmp(p, "HEAD", 4) == 0:
+            return METH_HEAD
+    elif n == 5:
+        if memcmp(p, "PATCH", 5) == 0:
+            return METH_PATCH
+        if memcmp(p, "TRACE", 5) == 0:
+            return METH_TRACE
+        if memcmp(p, "QUERY", 5) == 0:
+            return METH_QUERY
+    elif n == 6:
+        if memcmp(p, "DELETE", 6) == 0:
+            return METH_DELETE
+    elif n == 7:
+        if memcmp(p, "OPTIONS", 7) == 0:
+            return METH_OPTIONS
+        if memcmp(p, "CONNECT", 7) == 0:
+            return METH_CONNECT
+    return PyUnicode_DecodeLatin1(p, <Py_ssize_t>n, NULL)
 
 
 
@@ -311,6 +479,115 @@ cdef int _cb_message_complete(llhttp_t* parser) noexcept:
     cdef HttpProtocol proto = <HttpProtocol>stario_parser_get_data(parser)
     proto._on_message_complete()
     return -1 if proto.rejected else 0
+
+
+cdef int _h2_on_begin_headers(
+    nghttp2_session* session,
+    const nghttp2_frame* frame,
+    void* user_data,
+) noexcept:
+    cdef HttpProtocol proto
+    try:
+        if frame.hd.type != NGHTTP2_HEADERS:
+            return 0
+        proto = <HttpProtocol>user_data
+        proto._h2_begin_stream(frame.hd.stream_id)
+        return 0
+    except Exception:
+        return NGHTTP2_ERR_CALLBACK_FAILURE
+
+
+cdef int _h2_on_header(
+    nghttp2_session* session,
+    const nghttp2_frame* frame,
+    const uint8_t* name,
+    size_t namelen,
+    const uint8_t* value,
+    size_t valuelen,
+    uint8_t flags,
+    void* user_data,
+) noexcept:
+    cdef HttpProtocol proto = <HttpProtocol>user_data
+    proto._h2_on_header(frame.hd.stream_id, name, namelen, value, valuelen)
+    return 0
+
+
+cdef int _h2_on_data(
+    nghttp2_session* session,
+    uint8_t flags,
+    int32_t stream_id,
+    const uint8_t* data,
+    size_t length,
+    void* user_data,
+) noexcept:
+    cdef HttpProtocol proto = <HttpProtocol>user_data
+    proto._h2_on_data(stream_id, data, length)
+    return 0
+
+
+cdef int _h2_on_frame_recv(
+    nghttp2_session* session,
+    const nghttp2_frame* frame,
+    void* user_data,
+) noexcept:
+    cdef HttpProtocol proto
+    cdef uint8_t ftype
+    try:
+        proto = <HttpProtocol>user_data
+        ftype = frame.hd.type
+        if ftype == NGHTTP2_HEADERS:
+            proto._h2_headers_frame(
+                frame.hd.stream_id, (frame.hd.flags & NGHTTP2_FLAG_END_STREAM) != 0
+            )
+        elif ftype == NGHTTP2_DATA and (frame.hd.flags & NGHTTP2_FLAG_END_STREAM):
+            proto._h2_end_stream(frame.hd.stream_id)
+        return 0
+    except Exception:
+        return NGHTTP2_ERR_CALLBACK_FAILURE
+
+
+cdef int _h2_on_stream_close(
+    nghttp2_session* session,
+    int32_t stream_id,
+    uint32_t error_code,
+    void* user_data,
+) noexcept:
+    cdef HttpProtocol proto
+    try:
+        proto = <HttpProtocol>user_data
+        proto._h2_stream_closed(stream_id)
+        return 0
+    except Exception:
+        return NGHTTP2_ERR_CALLBACK_FAILURE
+
+
+cdef ssize_t _h2_data_source_read(
+    nghttp2_session* session,
+    int32_t stream_id,
+    uint8_t* buf,
+    size_t length,
+    uint32_t* data_flags,
+    nghttp2_data_source* source,
+    void* user_data,
+) noexcept:
+    cdef HttpProtocol proto = <HttpProtocol>user_data
+    cdef RequestExchange ex
+    if source != NULL and source.ptr != NULL:
+        ex = <RequestExchange>source.ptr
+        return proto._h2_read_data(ex, buf, length, data_flags)
+    return NGHTTP2_ERR_CALLBACK_FAILURE
+
+
+cdef int _h2_send_data(
+    nghttp2_session* session,
+    nghttp2_frame* frame,
+    const uint8_t* framehd,
+    size_t length,
+    nghttp2_data_source* source,
+    void* user_data,
+) noexcept:
+    cdef HttpProtocol proto = <HttpProtocol>user_data
+    return proto._h2_send_data_frame(frame, framehd, length, source)
 
 
 def _bind_timeout_policy():
@@ -410,6 +687,13 @@ cdef class HttpProtocol:
     cdef bint pump_scheduled
     cdef object _create_task
     cdef object _find_handler
+    cdef public int parse_mode
+    cdef bytearray preface_hold
+    cdef nghttp2_session* h2
+    cdef dict h2_streams
+    cdef object h2_out
+    cdef Py_ssize_t h2_out_used
+    cdef bint h2_in_recv
 
     def __cinit__(self):
         _bind_settings()
@@ -431,11 +715,21 @@ cdef class HttpProtocol:
         self.timeout_kind = TIMEOUT_NONE
         self.timeout_deadline = 0.0
         self.header_timeout_reset = False
+        self.parse_mode = PARSE_NONE
+        self.preface_hold = bytearray()
+        self.h2 = NULL
+        self.h2_streams = {}
+        self.h2_out = bytearray()
+        self.h2_out_used = 0
+        self.h2_in_recv = False
 
     def __dealloc__(self):
         if self.parser != NULL:
             stario_parser_del(self.parser)
             self.parser = NULL
+        if self.h2 != NULL:
+            nghttp2_session_del(self.h2)
+            self.h2 = NULL
 
     def __init__(
         self,
@@ -480,6 +774,8 @@ cdef class HttpProtocol:
         self.header_timeout_reset = False
 
     def connection_made(self, transport):
+        cdef object ssl_object
+        cdef object selected
         self.transport = transport
         self.closed = False
         self.disconnect = None
@@ -491,7 +787,14 @@ cdef class HttpProtocol:
         self.rejected = False
         self.timeout_kind = TIMEOUT_NONE
         self.timeout_deadline = 0.0
+        self.parse_mode = PARSE_NONE
+        self.preface_hold.clear()
         self.connections.add(self)
+        ssl_object = transport.get_extra_info("ssl_object")
+        if ssl_object is not None:
+            selected = ssl_object.selected_alpn_protocol()
+            if selected == "h2":
+                self._start_h2()
         # First request: header deadline only. Keep-alive stores a
         # deadline; the sweeper compares it. No TimerHandle per request.
         self._arm_timeout(TIMEOUT_HEADER, self.header_timeout)
@@ -510,6 +813,14 @@ cdef class HttpProtocol:
         self._cancel_timeout()
         self.connections.discard(self)
         _stop_timeout_sweeper(self.loop, self.connections)
+        if self.h2 != NULL:
+            nghttp2_session_del(self.h2)
+            self.h2 = NULL
+        for exchange in list(self.h2_streams.values()):
+            exchange.c_abort()
+            if not exchange.handler_started:
+                exchange.cancel_before_start()
+        self.h2_streams.clear()
         if self.idle_exchange is not None:
             self.idle_exchange.release_global()
             self.idle_exchange = None
@@ -545,7 +856,9 @@ cdef class HttpProtocol:
         return False
 
     def data_received(self, data):
-        if self.rejected or self.parser == NULL or not data:
+        if self.rejected or not data:
+            return
+        if self.parse_mode != PARSE_H2 and self.parser == NULL:
             return
         if self.timeout_kind == TIMEOUT_IDLE:
             # Keep-alive traffic: drop the idle deadline. The sweeper
@@ -553,8 +866,7 @@ cdef class HttpProtocol:
             self.timeout_kind = TIMEOUT_NONE
             self.timeout_deadline = 0.0
         if self.held_data is not None:
-            self.held_data = self.held_data[self.held_offset :] + data
-            self.held_offset = 0
+            self._held_append(data)
             return
         if self.pause_reasons:
             self.held_data = data
@@ -562,6 +874,60 @@ cdef class HttpProtocol:
             return
         self._pump_data(data, 0)
         self._after_pump()
+
+    cdef void _held_append(self, object data) noexcept:
+        """Append ``data`` onto paused input without ``held[off:] + data``."""
+        cdef object held = self.held_data
+        cdef Py_ssize_t off = self.held_offset
+        cdef Py_ssize_t keep
+        cdef Py_ssize_t add_n
+        cdef Py_ssize_t new_n
+        cdef const char* src = NULL
+        cdef const char* oldp = NULL
+        cdef char* dst
+        cdef object ba
+        if not _as_buf(data, &src, &add_n):
+            self.held_data = held[off:] + data
+            self.held_offset = 0
+            return
+        if PyBytes_Check(held):
+            oldp = PyBytes_AS_STRING(held)
+            keep = PyBytes_GET_SIZE(held) - off
+            if keep < 0:
+                keep = 0
+            new_n = keep + add_n
+            ba = bytearray()
+            if PyByteArray_Resize(ba, new_n) < 0:
+                PyErr_Clear()
+                self.held_data = held[off:] + data
+                self.held_offset = 0
+                return
+            dst = PyByteArray_AS_STRING(ba)
+            if keep:
+                memcpy(dst, oldp + off, <size_t>keep)
+            if add_n:
+                memcpy(dst + keep, src, <size_t>add_n)
+            self.held_data = ba
+            self.held_offset = 0
+            return
+        if PyByteArray_Check(held):
+            oldp = PyByteArray_AS_STRING(held)
+            keep = PyByteArray_GET_SIZE(held) - off
+            if keep < 0:
+                keep = 0
+            if off:
+                if keep:
+                    memmove(<char*>oldp, oldp + off, <size_t>keep)
+                self.held_offset = 0
+            new_n = keep + add_n
+            if PyByteArray_Resize(held, new_n) < 0:
+                PyErr_Clear()
+                return
+            if add_n:
+                memcpy(PyByteArray_AS_STRING(held) + keep, src, <size_t>add_n)
+            return
+        self.held_data = held[off:] + data
+        self.held_offset = 0
 
     cdef void _arm_timeout(self, int kind, double seconds):
         """Store a header or idle deadline on the connection.
@@ -598,6 +964,7 @@ cdef class HttpProtocol:
         """Compare stored deadlines against ``now`` (one value per sweep)."""
         cdef RequestExchange reading
         cdef RequestExchange active
+        cdef RequestExchange exchange
         cdef object transport
         cdef double seconds
         if self.rejected:
@@ -625,6 +992,10 @@ cdef class HttpProtocol:
         self._check_body_stall(reading, now)
         if active is not None and active is not reading:
             self._check_body_stall(active, now)
+        if self.parse_mode == PARSE_H2:
+            for exchange in self.h2_streams.values():
+                if exchange is not reading and exchange is not active:
+                    self._check_body_stall(exchange, now)
 
     cdef void _after_pump(self):
         """Arm a header deadline only if this read left headers (or a deferred
@@ -642,12 +1013,78 @@ cdef class HttpProtocol:
             self._arm_timeout(TIMEOUT_HEADER, self.header_timeout)
 
     cdef void _pump_data(self, object data, Py_ssize_t offset) noexcept:
-        cdef const char* ptr
+        cdef const char* ptr = NULL
+        cdef Py_ssize_t n
+        if not _as_buf(data, &ptr, &n):
+            n = len(data)
+            ptr = <const char*>data
+        if offset >= n:
+            return
+        if self.parse_mode == PARSE_H2:
+            self._h2_recv(ptr + offset, <size_t>(n - offset))
+            return
+        if self.parse_mode == PARSE_NONE:
+            if not self._maybe_start_h2(ptr + offset, n - offset):
+                return
+            if self.parse_mode == PARSE_H2:
+                self._h2_recv(ptr + offset, <size_t>(n - offset))
+                return
+            if self.preface_hold:
+                self._h1_execute_held()
+                return
+        self._h1_execute(data, offset)
+
+    cdef bint _maybe_start_h2(self, const char* p, Py_ssize_t n) noexcept:
+        """Detect the H2 preface before llhttp sees the first bytes.
+
+        Incomplete preface prefixes are held. Anything else is HTTP/1.
+        When the hold already contains this chunk, H1 fallback executes
+        the hold only (do not append ``data`` again).
+        """
+        cdef const char* pref = PyBytes_AS_STRING(H2_PREFACE)
+        cdef bint from_hold = False
+        if self.preface_hold:
+            if _preface_append(self.preface_hold, p, n) != 0:
+                self._close_error(500, "Internal Server Error")
+                return False
+            p = PyByteArray_AS_STRING(self.preface_hold)
+            n = PyByteArray_GET_SIZE(self.preface_hold)
+            from_hold = True
+        elif n > 0 and n < H2_PREFACE_LEN and memcmp(p, pref, <size_t>n) == 0:
+            if _preface_append(self.preface_hold, p, n) != 0:
+                self._close_error(500, "Internal Server Error")
+            return False
+        if n >= H2_PREFACE_LEN and memcmp(p, pref, <size_t>H2_PREFACE_LEN) == 0:
+            if from_hold:
+                self._start_h2()
+                self._h2_recv(p, <size_t>n)
+                self.preface_hold.clear()
+                return False
+            self._start_h2()
+            return True
+        if n < H2_PREFACE_LEN and n > 0 and memcmp(p, pref, <size_t>n) == 0:
+            if not from_hold:
+                if _preface_append(self.preface_hold, p, n) != 0:
+                    self._close_error(500, "Internal Server Error")
+            return False
+        self.parse_mode = PARSE_H1
+        return True
+
+    cdef void _h1_execute_held(self) noexcept:
+        cdef object held = self.preface_hold
+        self.preface_hold = bytearray()
+        self._h1_execute(held, 0)
+
+    cdef void _h1_execute(self, object data, Py_ssize_t offset) noexcept:
+        cdef const char* ptr = NULL
         cdef Py_ssize_t n
         cdef Py_ssize_t end
         cdef int err
-        n = len(data)
-        ptr = <const char*>data
+        if self.parser == NULL:
+            return
+        if not _as_buf(data, &ptr, &n):
+            n = len(data)
+            ptr = <const char*>data
         if n <= PARSER_QUANTUM:
             err = llhttp_execute(self.parser, ptr + offset, <size_t>(n - offset))
             if err != HPE_OK:
@@ -734,6 +1171,7 @@ cdef class HttpProtocol:
             or self.pending_exchanges
             or self.held_data is not None
             or self.rejected
+            or self.h2_streams
         ):
             return False
         transport = self.transport
@@ -837,6 +1275,12 @@ cdef class HttpProtocol:
             self._close_error(400, "Upgrade not supported")
             return
         flags = stario_parser_flags(self.parser)
+        # RFC 7230 3.3.3: TE without chunked as the final coding — body
+        # length is undefined. Reject before dispatch (llhttp errors after
+        # on_headers_complete, which would otherwise 404 then 400).
+        if (flags & F_TRANSFER_ENCODING) and not (flags & F_CHUNKED):
+            self._close_error(400, "Invalid HTTP request")
+            return
         content_length = stario_parser_content_length(self.parser)
         if flags & F_CONTENT_LENGTH and content_length > <uint64_t>self.max_body_bytes:
             self._close_error(413, "Request body too large")
@@ -918,29 +1362,43 @@ cdef class HttpProtocol:
     cdef Request _build_request(self, RequestExchange exchange, object body):
         cdef object method
         cdef object version
-        cdef tuple split
+        cdef object path
+        cdef Py_ssize_t qoff = 0
+        cdef Py_ssize_t qlen = 0
         cdef Request request = exchange.req
         if exchange._req_url_length > 0:
-            split = _split_request_target_n(
+            path = _path_for_url(
                 exchange._req_arena + exchange._req_url_offset,
                 exchange._req_url_length,
+                &qoff,
+                &qlen,
             )
         else:
-            split = (PATH_EMPTY, Q_EMPTY)
-        method = _method_str(<int>llhttp_get_method(self.parser))
-        version = _version_str(
-            <int>llhttp_get_http_major(self.parser),
-            <int>llhttp_get_http_minor(self.parser),
-        )
+            path = PATH_EMPTY
+        if exchange._http2:
+            method = exchange._h2_method or METH_GET
+            version = VER_20
+        else:
+            method = _method_str(<int>llhttp_get_method(self.parser))
+            version = _version_str(
+                <int>llhttp_get_http_major(self.parser),
+                <int>llhttp_get_http_minor(self.parser),
+            )
         request.reset(
             method,
-            split[0],
-            split[1],
+            path,
+            None,
             version,
-            self.request_keep_alive,
+            True if exchange._http2 else self.request_keep_alive,
             exchange.request_headers,
             body,
         )
+        if qlen > 0:
+            request.bind_query_span(
+                exchange,
+                exchange._req_url_offset + qoff,
+                qlen,
+            )
         return request
 
     cdef void _dispatch(self, RequestExchange exchange, Request request):
@@ -954,6 +1412,9 @@ cdef class HttpProtocol:
         else:
             span = self.tracer.create("request") if self.tracer is not None else None
         exchange.span = span
+        if exchange._http2:
+            self._start_exchange(exchange, True)
+            return
         if self.active_exchange is None:
             self._start_exchange(exchange, True)
         else:
@@ -972,13 +1433,15 @@ cdef class HttpProtocol:
         cdef object span
         cdef object host
         cdef object method
+        cdef object loc
         cdef const char* url
         cdef Py_ssize_t n
         cdef Py_ssize_t i
         cdef Py_ssize_t path_end
         cdef Py_ssize_t start
         cdef Py_ssize_t end
-        self.active_exchange = exchange
+        if not exchange._http2:
+            self.active_exchange = exchange
         n = exchange._req_url_length
         if n > 1:
             url = exchange._req_arena + exchange._req_url_offset
@@ -994,6 +1457,29 @@ cdef class HttpProtocol:
                     start += 1
                 while end > start and url[end - 1] == 47:
                     end -= 1
+                if exchange._http2:
+                    loc = b"/"
+                    if end > start:
+                        loc = loc + PyBytes_FromStringAndSize(
+                            url + start, end - start
+                        )
+                    if path_end + 1 < n:
+                        loc = loc + b"?" + PyBytes_FromStringAndSize(
+                            url + path_end + 1, n - path_end - 1
+                        )
+                    exchange.start_response()
+                    exchange.headers.set("location", loc.decode("latin-1"))
+                    if self.noop_span is None:
+                        req = exchange.req
+                        finish_request_span(
+                            exchange.span,
+                            status=308,
+                            method=req.method,
+                            path=req.path,
+                        )
+                    exchange.respond(b"", b"text/plain; charset=utf-8", 308)
+                    exchange.handler_finished()
+                    return
                 exchange.start_response()
                 exchange._buf_bytes(_status_line(308))
                 exchange._buf_bytes(exchange._date_box[0])
@@ -1079,6 +1565,18 @@ cdef class HttpProtocol:
         cdef object transport = self.transport
         cdef object conn
         cdef RequestExchange next_exchange
+        if exchange._http2:
+            self.h2_streams.pop(exchange._h2_stream_id, None)
+            if (
+                transport is not None
+                and not transport.is_closing()
+                and not self.h2_streams
+                and self.reading_exchange is None
+                and not self.pending_exchanges
+                and not self.app.shutdown.done()
+            ):
+                self._arm_timeout(TIMEOUT_IDLE, self.keep_alive_timeout)
+            return
         if self.active_exchange is not exchange:
             return
         self.active_exchange = None
@@ -1129,7 +1627,8 @@ cdef class HttpProtocol:
         cdef object span
         cdef object method
         cdef object path
-        cdef tuple split
+        cdef Py_ssize_t qoff
+        cdef Py_ssize_t qlen
         cdef RequestExchange exchange
         if self.rejected:
             return
@@ -1140,16 +1639,21 @@ cdef class HttpProtocol:
         span = None
         method = None
         path = None
+        qoff = 0
+        qlen = 0
         if exchange is not None:
             span = exchange.span
             try:
                 if exchange._req_url_length > 0:
-                    split = _split_request_target_n(
+                    path = _path_for_url(
                         exchange._req_arena + exchange._req_url_offset,
                         exchange._req_url_length,
+                        &qoff,
+                        &qlen,
                     )
-                    path = split[0]
-                    if self.parser != NULL:
+                    if exchange._http2:
+                        method = exchange._h2_method or METH_GET
+                    elif self.parser != NULL:
                         method = _method_str(<int>llhttp_get_method(self.parser))
                 elif self.request_dispatched and exchange.req is not None:
                     method = exchange.req.method
@@ -1165,6 +1669,10 @@ cdef class HttpProtocol:
                 if not exchange.handler_started:
                     exchange.cancel_before_start()
             self._drop_pending()
+            if self.parse_mode == PARSE_H2:
+                self._finish_protocol_span(status, span, method, path)
+                transport.close()
+                return
             body = message.encode("utf-8")
             date = self.date_box[0]
             transport.write(
@@ -1186,3 +1694,642 @@ cdef class HttpProtocol:
                     transport.close()
             except Exception:
                 pass
+
+    # --- HTTP/2 ---
+
+    cdef void _start_h2(self) noexcept:
+        cdef nghttp2_session_callbacks* cbs = NULL
+        cdef nghttp2_option* opt = NULL
+        cdef nghttp2_settings_entry iv[3]
+        cdef int rv
+        if self.h2 != NULL:
+            self.parse_mode = PARSE_H2
+            return
+        self.parse_mode = PARSE_H2
+        rv = nghttp2_session_callbacks_new(&cbs)
+        if rv != 0:
+            self._close_error(500, "Internal Server Error")
+            return
+        nghttp2_session_callbacks_set_on_begin_headers_callback(cbs, _h2_on_begin_headers)
+        nghttp2_session_callbacks_set_on_header_callback(cbs, _h2_on_header)
+        nghttp2_session_callbacks_set_on_data_chunk_recv_callback(cbs, _h2_on_data)
+        nghttp2_session_callbacks_set_on_frame_recv_callback(cbs, _h2_on_frame_recv)
+        nghttp2_session_callbacks_set_on_stream_close_callback(cbs, _h2_on_stream_close)
+        nghttp2_session_callbacks_set_send_data_callback(cbs, _h2_send_data)
+        rv = nghttp2_option_new(&opt)
+        if rv != 0:
+            nghttp2_session_callbacks_del(cbs)
+            self._close_error(500, "Internal Server Error")
+            return
+        nghttp2_option_set_no_auto_window_update(opt, 1)
+        rv = nghttp2_session_server_new2(&self.h2, cbs, <void*>self, opt)
+        nghttp2_option_del(opt)
+        nghttp2_session_callbacks_del(cbs)
+        if rv != 0:
+            self.h2 = NULL
+            self._close_error(500, "Internal Server Error")
+            return
+        iv[0].settings_id = NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE
+        iv[0].value = <uint32_t>H2_STREAM_WINDOW
+        iv[1].settings_id = NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS
+        iv[1].value = <uint32_t>H2_MAX_CONCURRENT
+        iv[2].settings_id = NGHTTP2_SETTINGS_ENABLE_PUSH
+        iv[2].value = 0
+        nghttp2_submit_settings(self.h2, NGHTTP2_FLAG_NONE, iv, 3)
+        nghttp2_session_set_local_window_size(
+            self.h2, NGHTTP2_FLAG_NONE, 0, <int32_t>H2_CONN_WINDOW
+        )
+        self._h2_send()
+
+    cdef void _h2_recv(self, const char* data, size_t n) noexcept:
+        cdef ssize_t rv
+        if self.h2 == NULL:
+            return
+        # Queue WINDOW_UPDATE / responses during this recv; one mem_send after
+        # so multiplexed streams share a write instead of one flush each.
+        self.h2_in_recv = True
+        rv = nghttp2_session_mem_recv(self.h2, <const uint8_t*>data, n)
+        self.h2_in_recv = False
+        if rv < 0:
+            self._close_error(400, "Invalid HTTP request")
+            return
+        self._h2_release_connection_window(True)
+        self._h2_send()
+
+    cdef void _h2_consume_stream(self, int32_t stream_id, bint force=False) noexcept:
+        cdef int32_t unacked
+        cdef int32_t local
+        if self.h2 == NULL:
+            return
+        unacked = nghttp2_session_get_stream_effective_recv_data_length(
+            self.h2, stream_id
+        )
+        if unacked <= 0:
+            return
+        if not force:
+            local = nghttp2_session_get_stream_local_window_size(self.h2, stream_id)
+            if unacked < H2_STREAM_UPDATE_THRESH and local >= H2_STREAM_UPDATE_THRESH:
+                return
+        # consume() only emits WINDOW_UPDATE at 50% of the local window.
+        # Force-ack with submit so small keep-alive POSTs cannot stall.
+        nghttp2_submit_window_update(
+            self.h2, NGHTTP2_FLAG_NONE, stream_id, unacked
+        )
+
+    cdef void _h2_release_connection_window(self, bint force=False) noexcept:
+        cdef int32_t unacked
+        cdef int32_t local
+        if self.h2 == NULL:
+            return
+        unacked = nghttp2_session_get_effective_recv_data_length(self.h2)
+        if unacked <= 0:
+            return
+        if not force:
+            local = nghttp2_session_get_local_window_size(self.h2)
+            if unacked < H2_CONN_UPDATE_THRESH and local >= H2_CONN_UPDATE_THRESH:
+                return
+        nghttp2_submit_window_update(self.h2, NGHTTP2_FLAG_NONE, 0, unacked)
+
+    cdef int _h2_out_append(self, const char* src, Py_ssize_t n) noexcept:
+        cdef object buf
+        cdef Py_ssize_t used
+        cdef Py_ssize_t cap
+        if n <= 0:
+            return 0
+        buf = self.h2_out
+        if buf is None:
+            buf = bytearray()
+            self.h2_out = buf
+        used = self.h2_out_used
+        cap = PyByteArray_GET_SIZE(buf)
+        if used + n > cap:
+            cap = used + n
+            if cap < 256:
+                cap = 256
+            if PyByteArray_Resize(buf, cap) < 0:
+                PyErr_Clear()
+                return -1
+        memcpy(PyByteArray_AS_STRING(buf) + used, src, <size_t>n)
+        self.h2_out_used = used + n
+        return 0
+
+    cdef void _h2_flush_out(self) noexcept:
+        cdef object buf
+        cdef Py_ssize_t used
+        used = self.h2_out_used
+        if used <= 0 or self.transport is None:
+            self.h2_out_used = 0
+            return
+        buf = self.h2_out
+        self.h2_out_used = 0
+        self.transport.write(
+            PyBytes_FromStringAndSize(PyByteArray_AS_STRING(buf), used)
+        )
+
+    cdef void _h2_send(self) noexcept:
+        cdef const uint8_t* data = NULL
+        cdef ssize_t n
+        if self.h2_in_recv:
+            return
+        if self.h2 == NULL or self.transport is None:
+            return
+        while True:
+            n = nghttp2_session_mem_send(self.h2, &data)
+            if n == 0:
+                break
+            if n < 0:
+                self._close_error(400, "Invalid HTTP request")
+                return
+            if self._h2_out_append(<const char*>data, n) != 0:
+                self._close_error(500, "Internal Server Error")
+                return
+        self._h2_flush_out()
+
+    cdef RequestExchange _h2_stream_ex(self, int32_t stream_id):
+        cdef void* ptr
+        if self.h2 != NULL:
+            ptr = nghttp2_session_get_stream_user_data(self.h2, stream_id)
+            if ptr != NULL:
+                return <RequestExchange>ptr
+        return self.h2_streams.get(stream_id)
+
+    cdef void _h2_dispatch_stream(self, RequestExchange ex) noexcept:
+        if ex is None or ex._h2_dispatched or self.rejected:
+            return
+        if self.transport is None or self.transport.is_closing():
+            return
+        try:
+            self._dispatch(ex, self._build_request(ex, ex))
+            ex._h2_dispatched = True
+        except Exception:
+            self._close_error(400, "Invalid HTTP request")
+
+    cdef void _h2_begin_stream(self, int32_t stream_id):
+        cdef RequestExchange ex
+        if stream_id in self.h2_streams:
+            return
+        if self.idle_exchange is not None:
+            ex = self.idle_exchange
+            self.idle_exchange = None
+            ex.reset(
+                self,
+                self.app,
+                self.transport,
+                self.date_box,
+                self.compression,
+                self.max_body_bytes,
+                self.body_timeout,
+            )
+        else:
+            ex = acquire_exchange(
+                self,
+                self.app,
+                self.transport,
+                self.date_box,
+                self.compression,
+                self.max_body_bytes,
+                self.body_timeout,
+            )
+        ex.bind_http2(stream_id)
+        self.h2_streams[stream_id] = ex
+        if self.h2 != NULL:
+            nghttp2_session_set_stream_user_data(self.h2, stream_id, <void*>ex)
+
+    cdef void _h2_on_header(
+        self,
+        int32_t stream_id,
+        const uint8_t* name,
+        size_t namelen,
+        const uint8_t* value,
+        size_t valuelen,
+    ) noexcept:
+        cdef RequestExchange ex = self._h2_stream_ex(stream_id)
+        cdef const char* hn = <const char*>name
+        if ex is None or ex._h2_dispatched or ex._h2_headers_done:
+            return
+        if namelen > 0 and name[0] == 58:
+            if namelen == 7 and memcmp(hn, ":method", 7) == 0:
+                if valuelen == 7 and memcmp(<const char*>value, "CONNECT", 7) == 0:
+                    self._h2_reject_stream(stream_id, NGHTTP2_PROTOCOL_ERROR)
+                    return
+                ex._h2_method = _method_from_bytes(<const char*>value, valuelen)
+                return
+            if namelen == 5 and memcmp(hn, ":path", 5) == 0:
+                if ex.append_request_url(<const char*>value, valuelen) != 0:
+                    self._close_error(431, "Request header fields too large")
+                return
+            if namelen == 10 and memcmp(hn, ":authority", 10) == 0:
+                if ex.append_request_header("host", 4, <const char*>value, valuelen) != 0:
+                    self._close_error(400, "Invalid HTTP request")
+                return
+            if namelen == 9 and memcmp(hn, ":protocol", 9) == 0:
+                # Extended CONNECT / WebSocket — not supported.
+                self._h2_reject_stream(stream_id, NGHTTP2_PROTOCOL_ERROR)
+                return
+            return
+        if not _header_name_ok(hn, namelen):
+            self._h2_reject_stream(stream_id, NGHTTP2_PROTOCOL_ERROR)
+            return
+        if ex.append_request_header(hn, namelen, <const char*>value, valuelen) != 0:
+            self._close_error(400, "Invalid HTTP request")
+
+    cdef void _h2_on_data(self, int32_t stream_id, const uint8_t* data, size_t length) noexcept:
+        cdef RequestExchange ex = self._h2_stream_ex(stream_id)
+        if ex is None or length == 0:
+            return
+        if not ex._body_active:
+            ex.reset_body(False, -1)
+        if ex.c_feed(<const char*>data, length) != 0:
+            nghttp2_submit_rst_stream(
+                self.h2, NGHTTP2_FLAG_NONE, stream_id, NGHTTP2_INTERNAL_ERROR
+            )
+            return
+        self._h2_consume_stream(stream_id)
+        if (
+            not ex._h2_dispatched
+            and not self.rejected
+            and ex._total_read > SMALL_BODY_COMPLETE_DISPATCH
+        ):
+            self._h2_dispatch_stream(ex)
+
+    cdef void _h2_headers_frame(self, int32_t stream_id, bint end_stream):
+        cdef RequestExchange ex = self._h2_stream_ex(stream_id)
+        cdef Py_ssize_t content_length
+        if ex is None or self.rejected:
+            return
+        if ex._h2_dispatched or ex._h2_headers_done:
+            # Trailers (or a later HEADERS) with END_STREAM finish the body.
+            if end_stream:
+                self._h2_end_stream(stream_id)
+            return
+        ex.finish_request_header()
+        ex.cache_hot_request_headers()
+        content_length = ex._req_content_length
+        if content_length > self.max_body_bytes:
+            self._h2_reject_stream(stream_id, NGHTTP2_PROTOCOL_ERROR)
+            return
+        try:
+            if ex._req_expect_continue or content_length > 0:
+                ex.reset_body(ex._req_expect_continue, content_length)
+                ex._h2_headers_done = True
+                if end_stream and ex._body_active:
+                    ex.c_complete()
+                if (
+                    not ex._req_expect_continue
+                    and content_length > 0
+                    and content_length <= SMALL_BODY_COMPLETE_DISPATCH
+                    and not end_stream
+                ):
+                    return
+            else:
+                ex.mark_nobody()
+                ex._h2_headers_done = True
+            if not ex._h2_dispatched and not self.rejected:
+                self._h2_dispatch_stream(ex)
+        except Exception:
+            self._close_error(400, "Invalid HTTP request")
+
+    cdef void _h2_end_stream(self, int32_t stream_id):
+        cdef RequestExchange ex = self._h2_stream_ex(stream_id)
+        # Return recv credit for this stream (and the connection share).
+        # Batching alone never fires for small POSTs; without this, keep-alive
+        # stalls once the connection window is exhausted.
+        self._h2_consume_stream(stream_id, True)
+        if ex is None:
+            return
+        if ex._body_active and not ex._body_complete:
+            ex.c_complete()
+        if not ex._h2_dispatched and not self.rejected:
+            if not ex._h2_headers_done:
+                self._h2_headers_frame(stream_id, True)
+                return
+            self._h2_dispatch_stream(ex)
+
+    cdef void _h2_stream_closed(self, int32_t stream_id):
+        cdef RequestExchange ex
+        if self.h2 != NULL:
+            nghttp2_session_set_stream_user_data(self.h2, stream_id, NULL)
+        ex = self.h2_streams.pop(stream_id, None)
+        if ex is None:
+            return
+        # Client RST or GOAWAY: stop the handler; recycle if it never started.
+        if not ex._completed:
+            ex.c_abort()
+            if not ex.handler_started:
+                ex.cancel_before_start()
+
+    cdef void _h2_reject_stream(self, int32_t stream_id, uint32_t error_code) noexcept:
+        cdef RequestExchange ex = self.h2_streams.get(stream_id)
+        if ex is not None:
+            ex._h2_dispatched = True
+        if self.h2 != NULL:
+            nghttp2_submit_rst_stream(self.h2, NGHTTP2_FLAG_NONE, stream_id, error_code)
+
+    cdef ssize_t _h2_read_data(
+        self,
+        RequestExchange ex,
+        uint8_t* buf,
+        size_t length,
+        uint32_t* data_flags,
+    ) noexcept:
+        cdef Py_ssize_t avail
+        cdef Py_ssize_t take
+        cdef object pending
+        if ex is None:
+            data_flags[0] |= NGHTTP2_DATA_FLAG_EOF
+            return 0
+        pending = ex._h2_pending
+        if pending is None or pending == b"":
+            avail = 0
+        elif PyByteArray_Check(pending):
+            avail = PyByteArray_GET_SIZE(pending) - ex._h2_pending_off
+        elif PyBytes_Check(pending):
+            avail = PyBytes_GET_SIZE(pending) - ex._h2_pending_off
+        else:
+            avail = 0
+        if avail <= 0:
+            if ex._h2_body_done:
+                data_flags[0] |= NGHTTP2_DATA_FLAG_EOF
+                return 0
+            return NGHTTP2_ERR_DEFERRED
+        take = avail if avail < <Py_ssize_t>length else <Py_ssize_t>length
+        # Payload stays in _h2_pending; send_data appends it into h2_out.
+        data_flags[0] |= NGHTTP2_DATA_FLAG_NO_COPY
+        if take == avail and ex._h2_body_done:
+            data_flags[0] |= NGHTTP2_DATA_FLAG_EOF
+        return <ssize_t>take
+
+    cdef int _h2_send_data_frame(
+        self,
+        nghttp2_frame* frame,
+        const uint8_t* framehd,
+        size_t length,
+        nghttp2_data_source* source,
+    ) noexcept:
+        cdef RequestExchange ex
+        cdef object pending
+        cdef Py_ssize_t off
+        cdef Py_ssize_t n
+        cdef const char* src
+        if source == NULL or source.ptr == NULL:
+            return NGHTTP2_ERR_CALLBACK_FAILURE
+        # We never ask nghttp2 to pad DATA; a padlen would need extra writes.
+        if frame != NULL and frame.data.padlen > 0:
+            return NGHTTP2_ERR_CALLBACK_FAILURE
+        ex = <RequestExchange>source.ptr
+        if self._h2_out_append(<const char*>framehd, 9) != 0:
+            return NGHTTP2_ERR_CALLBACK_FAILURE
+        if length == 0:
+            return 0
+        pending = ex._h2_pending
+        off = ex._h2_pending_off
+        if PyBytes_Check(pending):
+            n = PyBytes_GET_SIZE(pending)
+            src = PyBytes_AS_STRING(pending) + off
+        elif PyByteArray_Check(pending):
+            n = PyByteArray_GET_SIZE(pending)
+            src = PyByteArray_AS_STRING(pending) + off
+        else:
+            return NGHTTP2_ERR_CALLBACK_FAILURE
+        if off < 0 or off + <Py_ssize_t>length > n:
+            return NGHTTP2_ERR_CALLBACK_FAILURE
+        if self._h2_out_append(src, <Py_ssize_t>length) != 0:
+            return NGHTTP2_ERR_CALLBACK_FAILURE
+        ex._h2_pending_off = off + <Py_ssize_t>length
+        if ex._h2_pending_off >= n:
+            ex._h2_pending = b""
+            ex._h2_pending_off = 0
+        return 0
+
+    cdef int _h2_fill_nva(self, object pairs, nghttp2_nv* nvs, size_t maxn) except -1:
+        cdef Py_ssize_t i, n, nn, vn
+        cdef bytes name, value
+        cdef bint trim
+        n = len(pairs)
+        if n > <Py_ssize_t>maxn:
+            n = <Py_ssize_t>maxn
+        for i in range(n):
+            name = pairs[i][0]
+            value = pairs[i][1]
+            trim = len(pairs[i]) > 2 and pairs[i][2]
+            nn = PyBytes_GET_SIZE(name)
+            vn = PyBytes_GET_SIZE(value)
+            if trim:
+                if nn >= 2:
+                    nn -= 2
+                if vn >= 2:
+                    vn -= 2
+            nvs[i].name = <uint8_t*>PyBytes_AS_STRING(name)
+            nvs[i].namelen = <size_t>nn
+            nvs[i].value = <uint8_t*>PyBytes_AS_STRING(value)
+            nvs[i].valuelen = <size_t>vn
+            nvs[i].flags = H2_NV_NOCOPY
+        return <int>n
+
+    cdef int _h2_fill_user_nvs(
+        self,
+        Headers h,
+        nghttp2_nv* nvs,
+        int cap,
+        bint skip_ce,
+        bint skip_cl,
+        bint skip_ct,
+    ) except -1:
+        cdef Py_ssize_t i
+        cdef Py_ssize_t n
+        cdef object nb
+        cdef object vb
+        cdef char* np
+        cdef char* vp
+        cdef Py_ssize_t nl
+        cdef Py_ssize_t vl
+        cdef int filled = 0
+        if h is None or cap <= 0:
+            return 0
+        n = h._n
+        for i in range(n):
+            nb = h._names[i]
+            vb = h._values[i]
+            np = PyBytes_AS_STRING(nb)
+            nl = PyBytes_GET_SIZE(nb)
+            vp = PyBytes_AS_STRING(vb)
+            vl = PyBytes_GET_SIZE(vb)
+            if skip_ct and nl == 14 and memcmp(np, "content-type: ", 14) == 0:
+                continue
+            if skip_cl and nl == 16 and memcmp(np, "content-length: ", 16) == 0:
+                continue
+            if skip_ce and nl == 18 and memcmp(np, "content-encoding: ", 18) == 0:
+                continue
+            if nl == 6 and memcmp(np, "date: ", 6) == 0:
+                continue
+            if nl == 19 and memcmp(np, "transfer-encoding: ", 19) == 0:
+                continue
+            if nl >= 2:
+                nl -= 2
+            if vl >= 2:
+                vl -= 2
+            if filled >= cap:
+                break
+            nvs[filled].name = <uint8_t*>np
+            nvs[filled].namelen = <size_t>nl
+            nvs[filled].value = <uint8_t*>vp
+            nvs[filled].valuelen = <size_t>vl
+            nvs[filled].flags = H2_NV_NOCOPY
+            filled += 1
+        return filled
+
+    def h2_respond(
+        self,
+        RequestExchange ex,
+        object nva,
+        object body,
+        bint skip_ce=False,
+        bint skip_cl=True,
+        bint skip_ct=True,
+    ):
+        cdef nghttp2_nv nvs[64]
+        cdef int nvlen
+        cdef nghttp2_data_provider prd
+        cdef object payload
+        cdef int rv
+        if self.h2 == NULL or ex is None:
+            return
+        nvlen = self._h2_fill_nva(nva, nvs, 64)
+        nvlen += self._h2_fill_user_nvs(
+            ex.headers, nvs + nvlen, 64 - nvlen, skip_ce, skip_cl, skip_ct
+        )
+        if body is None:
+            payload = b""
+        elif PyBytes_Check(body) or PyByteArray_Check(body):
+            payload = body
+        else:
+            payload = bytes(body)
+        if payload:
+            ex._h2_pending = payload
+            ex._h2_pending_off = 0
+            ex._h2_body_done = True
+            prd.source.ptr = <void*>ex
+            prd.read_callback = _h2_data_source_read
+            rv = nghttp2_submit_response(
+                self.h2, ex._h2_stream_id, nvs, <size_t>nvlen, &prd
+            )
+        else:
+            ex._h2_body_done = True
+            rv = nghttp2_submit_response(
+                self.h2, ex._h2_stream_id, nvs, <size_t>nvlen, NULL
+            )
+        if rv != 0:
+            self._close_error(400, "Invalid HTTP request")
+            return
+        self._h2_send()
+
+    def h2_write_headers(
+        self,
+        RequestExchange ex,
+        object nva,
+        bint skip_ce=False,
+        bint skip_cl=False,
+        bint skip_ct=False,
+        bint skip_user=False,
+    ):
+        cdef nghttp2_nv nvs[64]
+        cdef int nvlen
+        cdef nghttp2_data_provider prd
+        cdef int rv
+        if self.h2 == NULL or ex is None:
+            return
+        nvlen = self._h2_fill_nva(nva, nvs, 64)
+        if not skip_user:
+            nvlen += self._h2_fill_user_nvs(
+                ex.headers, nvs + nvlen, 64 - nvlen, skip_ce, skip_cl, skip_ct
+            )
+        if nva and nva[0][0] == b":status" and nva[0][1] == b"100":
+            nghttp2_submit_headers(
+                self.h2, NGHTTP2_FLAG_NONE, ex._h2_stream_id, NULL, nvs, <size_t>nvlen, NULL
+            )
+            self._h2_send()
+            return
+        if ex._h2_headers_sent:
+            return
+        ex._h2_headers_sent = True
+        prd.source.ptr = <void*>ex
+        prd.read_callback = _h2_data_source_read
+        rv = nghttp2_submit_response(self.h2, ex._h2_stream_id, nvs, <size_t>nvlen, &prd)
+        if rv != 0:
+            self._close_error(400, "Invalid HTTP request")
+            return
+        self._h2_send()
+
+    cdef void _h2_pending_extend(self, RequestExchange ex, object data) noexcept:
+        cdef object pending = ex._h2_pending
+        cdef Py_ssize_t off
+        cdef Py_ssize_t keep
+        cdef Py_ssize_t n
+        cdef char* dst
+        cdef const char* src
+        if pending == b"" or pending is None:
+            if PyBytes_Check(data) or PyByteArray_Check(data):
+                ex._h2_pending = data
+            else:
+                pending = bytearray()
+                pending.extend(data)
+                ex._h2_pending = pending
+            ex._h2_pending_off = 0
+            return
+        off = ex._h2_pending_off
+        if not PyByteArray_Check(pending):
+            n = PyBytes_GET_SIZE(pending) if PyBytes_Check(pending) else 0
+            keep = n - off if n > off else 0
+            pending = bytearray()
+            if keep:
+                if PyByteArray_Resize(pending, keep) < 0:
+                    PyErr_Clear()
+                    return
+                memcpy(
+                    PyByteArray_AS_STRING(pending),
+                    PyBytes_AS_STRING(ex._h2_pending) + off,
+                    <size_t>keep,
+                )
+            ex._h2_pending = pending
+            ex._h2_pending_off = 0
+            pending.extend(data)
+            return
+        if off:
+            n = PyByteArray_GET_SIZE(pending)
+            keep = n - off if n > off else 0
+            if keep:
+                memmove(
+                    PyByteArray_AS_STRING(pending),
+                    PyByteArray_AS_STRING(pending) + off,
+                    <size_t>keep,
+                )
+            if PyByteArray_Resize(pending, keep) < 0:
+                PyErr_Clear()
+                return
+            ex._h2_pending_off = 0
+        pending.extend(data)
+
+    def h2_write_data(self, RequestExchange ex, object data, bint end):
+        if self.h2 == NULL or ex is None:
+            return
+        if data:
+            self._h2_pending_extend(ex, data)
+        if end:
+            ex._h2_body_done = True
+        nghttp2_session_resume_data(self.h2, ex._h2_stream_id)
+        self._h2_send()
+
+    def h2_end(self, RequestExchange ex):
+        if self.h2 == NULL or ex is None:
+            return
+        ex._h2_body_done = True
+        nghttp2_session_resume_data(self.h2, ex._h2_stream_id)
+        self._h2_send()
+
+    def h2_abort(self, RequestExchange ex):
+        if self.h2 == NULL or ex is None:
+            return
+        nghttp2_submit_rst_stream(
+            self.h2, NGHTTP2_FLAG_NONE, ex._h2_stream_id, NGHTTP2_INTERNAL_ERROR
+        )
+        self._h2_send()

--- a/src/stario_cython/serve.py
+++ b/src/stario_cython/serve.py
@@ -72,6 +72,7 @@ def _uvloop_config(
         "backlog": cfg.backlog,
         "reuse_addr": cfg.reuse_addr,
         "event_loop": "uvloop",
+        "ssl": cfg.ssl,
     }
     values.update(overrides)
     return ServerConfig(**values)

--- a/tests/cython/test_h2.py
+++ b/tests/cython/test_h2.py
@@ -1,0 +1,403 @@
+"""HTTP/2 on the Cython protocol: cleartext prior knowledge and TLS ALPN."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import stario.responses as responses
+from stario import App
+from stario.http.tls import load_tls_context
+from stario_cython.protocol import HttpProtocol
+from tests.cython.http import RecordingTransport, free_port, make_protocol
+
+
+async def _curl(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run curl without blocking the event loop (the server lives on it)."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        None,
+        lambda: subprocess.run(
+            ["curl", "-sS", "--max-time", "5", *args],
+            check=False,
+            capture_output=True,
+            text=True,
+        ),
+    )
+
+
+def _make_self_signed(dir_path: Path) -> tuple[Path, Path]:
+    cert = dir_path / "cert.pem"
+    key = dir_path / "key.pem"
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            str(key),
+            "-out",
+            str(cert),
+            "-days",
+            "1",
+            "-nodes",
+            "-subj",
+            "/CN=localhost",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return cert, key
+
+
+@pytest.mark.asyncio
+async def test_h2_prior_knowledge_plaintext() -> None:
+    app = App()
+
+    async def hello(c, w) -> None:
+        assert c.req.protocol_version == "2"
+        assert c.req.query.get("q") == "1"
+        responses.text(w, f"h2:{c.req.path}")
+
+    app.get("/hi", hello)
+    loop = asyncio.get_running_loop()
+    connections: set[HttpProtocol] = set()
+    port = free_port()
+    server = await loop.create_server(
+        lambda: make_protocol(loop, app, connections=connections),
+        "127.0.0.1",
+        port,
+    )
+    try:
+        result = await _curl(
+            "--http2-prior-knowledge",
+            f"http://127.0.0.1:{port}/hi?q=1",
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout == "h2:/hi"
+    finally:
+        server.close()
+        await server.wait_closed()
+        await app.drain_tasks()
+
+
+@pytest.mark.asyncio
+async def test_h2_trailing_slash_redirects() -> None:
+    """H2 trailing-slash 308 is frames, not HTTP/1.1 text (same rule as H1)."""
+    app = App()
+
+    async def search(c, w) -> None:
+        responses.text(w, "nope")
+
+    app.get("/search", search)
+    loop = asyncio.get_running_loop()
+    port = free_port()
+    server = await loop.create_server(
+        lambda: make_protocol(loop, app),
+        "127.0.0.1",
+        port,
+    )
+    try:
+        result = await _curl(
+            "--http2-prior-knowledge",
+            "-D",
+            "-",
+            "-o",
+            "/dev/null",
+            f"http://127.0.0.1:{port}/search/?q=1",
+        )
+        assert result.returncode == 0, result.stderr
+        assert "HTTP/2 308" in result.stdout
+        assert "location: /search?q=1" in result.stdout.lower()
+        assert "nope" not in result.stdout
+    finally:
+        server.close()
+        await server.wait_closed()
+        await app.drain_tasks()
+
+
+@pytest.mark.asyncio
+async def test_h2_post_empty_body() -> None:
+    app = App()
+
+    async def echo(c, w) -> None:
+        body = await c.req.body()
+        w.respond(body, b"text/plain; charset=utf-8", 200)
+
+    app.post("/echo", echo)
+    loop = asyncio.get_running_loop()
+    port = free_port()
+    server = await loop.create_server(
+        lambda: make_protocol(loop, app),
+        "127.0.0.1",
+        port,
+    )
+    try:
+        result = await _curl(
+            "--http2-prior-knowledge",
+            "-X",
+            "POST",
+            "-H",
+            "Content-Length: 0",
+            f"http://127.0.0.1:{port}/echo",
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout == ""
+    finally:
+        server.close()
+        await server.wait_closed()
+        await app.drain_tasks()
+
+
+@pytest.mark.asyncio
+async def test_h2_post_large_body() -> None:
+    """Bodies larger than 256KiB still dispatch at headers; body() waits on DATA."""
+    payload = b"x" * (257 * 1024)
+    app = App()
+
+    async def echo(c, w) -> None:
+        body = await c.req.body()
+        w.respond(body, b"text/plain; charset=utf-8", 200)
+
+    app.post("/echo", echo)
+    loop = asyncio.get_running_loop()
+    port = free_port()
+    server = await loop.create_server(
+        lambda: make_protocol(loop, app),
+        "127.0.0.1",
+        port,
+    )
+    try:
+        with tempfile.NamedTemporaryFile() as tmp:
+            tmp.write(payload)
+            tmp.flush()
+            result = await _curl(
+                "--http2-prior-knowledge",
+                "-X",
+                "POST",
+                "--data-binary",
+                f"@{tmp.name}",
+                f"http://127.0.0.1:{port}/echo",
+            )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.encode("latin-1") == payload
+    finally:
+        server.close()
+        await server.wait_closed()
+        await app.drain_tasks()
+
+
+def _iter_h2_frames(blob: bytes):
+    """Yield (type, flags, stream_id, payload) from a wire dump."""
+    i = 0
+    while i + 9 <= len(blob):
+        length = int.from_bytes(blob[i : i + 3], "big")
+        end = i + 9 + length
+        if end > len(blob):
+            break
+        yield (
+            blob[i + 3],
+            blob[i + 4],
+            int.from_bytes(blob[i + 5 : i + 9], "big") & 0x7FFFFFFF,
+            blob[i + 9 : end],
+        )
+        i = end
+
+
+@pytest.mark.asyncio
+async def test_h2_keep_alive_returns_window_credit() -> None:
+    """Small POSTs on one connection must return recv credit when streams end.
+
+    nghttp2 consume() only emits WINDOW_UPDATE at 50% of the local window
+    (2MiB for a 4MiB connection). A client that only has ~1MiB of send
+    credit then deadlocks. Credit must be submitted, not merely consumed.
+    """
+    if shutil.which("h2load") is None:
+        pytest.skip("h2load not installed")
+    payload = b"x" * 256
+    app = App()
+
+    async def echo(c, w) -> None:
+        body = await c.req.body()
+        w.respond(body, b"text/plain; charset=utf-8", 200)
+
+    app.post("/echo", echo)
+    loop = asyncio.get_running_loop()
+    port = free_port()
+    server = await loop.create_server(
+        lambda: make_protocol(loop, app),
+        "127.0.0.1",
+        port,
+    )
+    nreq = 20_000
+    try:
+        with tempfile.NamedTemporaryFile() as tmp:
+            tmp.write(payload)
+            tmp.flush()
+            result = await loop.run_in_executor(
+                None,
+                lambda: subprocess.run(
+                    [
+                        "h2load",
+                        "-n",
+                        str(nreq),
+                        "-c",
+                        "1",
+                        "-m",
+                        "1",
+                        "-d",
+                        tmp.name,
+                        f"http://127.0.0.1:{port}/echo",
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                ),
+            )
+        assert result.returncode == 0, result.stderr
+        assert f"{nreq} succeeded" in result.stdout, result.stdout
+        assert " 0 failed" in result.stdout and " 0 errored" in result.stdout
+    finally:
+        server.close()
+        await server.wait_closed()
+        await app.drain_tasks()
+
+
+@pytest.mark.asyncio
+async def test_h2_post_body() -> None:
+    app = App()
+
+    async def echo(c, w) -> None:
+        body = await c.req.body()
+        w.respond(body, b"text/plain; charset=utf-8", 200)
+
+    app.post("/echo", echo)
+    loop = asyncio.get_running_loop()
+    port = free_port()
+    server = await loop.create_server(
+        lambda: make_protocol(loop, app),
+        "127.0.0.1",
+        port,
+    )
+    try:
+        result = await _curl(
+            "--http2-prior-knowledge",
+            "-X",
+            "POST",
+            "--data-binary",
+            "abcde",
+            f"http://127.0.0.1:{port}/echo",
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout == "abcde"
+    finally:
+        server.close()
+        await server.wait_closed()
+        await app.drain_tasks()
+
+
+@pytest.mark.asyncio
+async def test_tls_http11_and_h2_alpn() -> None:
+    app = App()
+
+    async def hello(c, w) -> None:
+        responses.text(w, f"v={c.req.protocol_version}")
+
+    app.get("/tls", hello)
+    loop = asyncio.get_running_loop()
+    with tempfile.TemporaryDirectory() as tmp:
+        cert, key = _make_self_signed(Path(tmp))
+        ctx = load_tls_context(certfile=cert, keyfile=key)
+        port = free_port()
+        server = await loop.create_server(
+            lambda: make_protocol(loop, app),
+            "127.0.0.1",
+            port,
+            ssl=ctx,
+        )
+        try:
+            h1 = await _curl(
+                "--http1.1",
+                "-k",
+                f"https://127.0.0.1:{port}/tls",
+            )
+            assert h1.returncode == 0, h1.stderr
+            assert h1.stdout == "v=1.1"
+
+            h2 = await _curl(
+                "--http2",
+                "-k",
+                f"https://127.0.0.1:{port}/tls",
+            )
+            assert h2.returncode == 0, h2.stderr
+            assert h2.stdout == "v=2"
+        finally:
+            server.close()
+            await server.wait_closed()
+            await app.drain_tasks()
+
+
+@pytest.mark.asyncio
+async def test_h2_connect_is_rejected() -> None:
+    """No tunnels or WebSockets: CONNECT must not dispatch a handler."""
+    app = App()
+    seen: list[str] = []
+
+    async def boom(c, w) -> None:
+        seen.append(c.req.method)
+        responses.text(w, "nope")
+
+    app.get("/", boom)
+    loop = asyncio.get_running_loop()
+    port = free_port()
+    server = await loop.create_server(
+        lambda: make_protocol(loop, app),
+        "127.0.0.1",
+        port,
+    )
+    try:
+        result = await _curl(
+            "--http2-prior-knowledge",
+            "-X",
+            "CONNECT",
+            f"http://127.0.0.1:{port}/",
+        )
+        assert seen == []
+        assert "nope" not in result.stdout
+    finally:
+        server.close()
+        await server.wait_closed()
+        await app.drain_tasks()
+
+
+@pytest.mark.asyncio
+async def test_h2_preface_on_recording_transport_does_not_raise() -> None:
+    loop = asyncio.get_running_loop()
+    app = App()
+    proto = make_protocol(loop, app)
+    transport = RecordingTransport(proto)
+    proto.connection_made(transport)
+    try:
+        proto.data_received(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+        assert proto.parse_mode == 2
+        assert transport.writes  # server SETTINGS
+        wire = b"".join(transport.writes)
+        conn_updates = [
+            int.from_bytes(payload, "big") & 0x7FFFFFFF
+            for ftype, _flags, stream_id, payload in _iter_h2_frames(wire)
+            if ftype == 0x8 and stream_id == 0 and len(payload) == 4
+        ]
+        # Connection window starts at 65535; we enlarge it to 4MiB.
+        assert conn_updates
+        assert sum(conn_updates) >= (4 * 1024 * 1024) - 65535
+    finally:
+        proto.connection_lost(None)
+        await app.drain_tasks()

--- a/tests/cython/test_hardening.py
+++ b/tests/cython/test_hardening.py
@@ -118,6 +118,53 @@ async def test_invalid_incoming_header_names_return_400() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"GET / HTTP/1.1\r\nHost: t\r\nContent-Length: 0\r\nContent-Length: 0\r\n\r\n",
+        b"POST / HTTP/1.1\r\nHost: t\r\nTransfer-Encoding: gzip\r\n\r\n",
+        b"POST / HTTP/1.1\r\nHost: t\r\nContent-Length: 5\r\nTransfer-Encoding: chunked\r\n\r\n",
+    ],
+    ids=["duplicate_content_length", "unsupported_te", "cl_plus_te"],
+)
+async def test_invalid_content_length_or_transfer_encoding_returns_400(
+    payload: bytes,
+) -> None:
+    proto, app, transport = _attach()
+    try:
+        proto.data_received(payload)
+        await _drain(app)
+        assert response_status(transport.writes) == 400
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_split_headers_then_body() -> None:
+    app = App()
+    bodies: list[bytes] = []
+
+    async def echo(c, w) -> None:
+        bodies.append(await c.req.body())
+        responses.text(w, "ok")
+
+    app.post("/", echo)
+    proto, app, transport = _attach(app=app)
+    try:
+        proto.data_received(b"POST / HTTP/1.1\r\nHost: t\r\nContent-Length: 5\r\n")
+        proto.data_received(b"\r\nhello")
+        await _drain(app)
+        assert response_status(transport.writes) == 200
+        assert bodies == [b"hello"]
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
 async def test_invalid_incoming_header_values_return_400() -> None:
     proto, app, transport = _attach()
     try:

--- a/tests/test_cli_env.py
+++ b/tests/test_cli_env.py
@@ -21,6 +21,7 @@ def test_server_config_from_env_reads_overrides(monkeypatch) -> None:
     assert config.unix_socket == "/tmp/stario.sock"
     assert config.graceful_shutdown_timeout == 12.5
     assert config.reuse_addr is False
+    assert config.ssl is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,3 +19,20 @@ def test_server_config_rejects_blank_unix_socket() -> None:
 def test_server_config_rejects_blank_tcp_host() -> None:
     with pytest.raises(StarioError, match="host must be non-empty"):
         ServerConfig(host="   ")
+
+
+def test_server_config_ssl_and_certfile_are_exclusive() -> None:
+    import ssl
+
+    with pytest.raises(StarioError, match="either ssl= or ssl_certfile"):
+        ServerConfig(ssl=ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER), ssl_certfile="x.pem")
+
+
+def test_server_config_ssl_keyfile_requires_certfile() -> None:
+    with pytest.raises(StarioError, match="ssl_keyfile requires ssl_certfile"):
+        ServerConfig(ssl_keyfile="k.pem")
+
+
+def test_server_config_missing_certfile_raises() -> None:
+    with pytest.raises(StarioError, match="TLS certificate not found"):
+        ServerConfig(ssl_certfile="/no/such/cert.pem")

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -26,3 +26,24 @@ def test_blank_and_bare_keys() -> None:
 
 def test_plus_decoding() -> None:
     assert ParsedQuery(b"a+b=c").get("a b") == "c"
+
+
+def test_items_preserve_wire_order_and_duplicates() -> None:
+    qp = ParsedQuery(b"b=2&a=1&b=3")
+    assert qp.items() == [("b", "2"), ("a", "1"), ("b", "3")]
+    assert qp.get("b") == "2"
+    assert qp.getlist("b") == ["2", "3"]
+    assert len(qp) == 2
+    assert qp.as_dict() == {"b": "2", "a": "1"}
+    assert qp.as_lists() == {"b": ["2", "3"], "a": ["1"]}
+
+
+def test_first_read_fills_key_value_arrays() -> None:
+    qp = ParsedQuery(b"a=1&a=2")
+    assert qp._keys is None
+    assert qp._values is None
+    assert qp.get("a") == "1"
+    assert qp._keys == ["a", "a"]
+    assert qp._values == ["1", "2"]
+    assert qp.as_dict() == {"a": "1"}
+    assert qp.as_lists() == {"a": ["1", "2"]}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add HTTP/2 on the same Cython HttpProtocol via nghttp2. The connection switches once (TLS ALPN h2, or the cleartext preface). HTTP/1 stays on llhttp. picohttpparser was tried and reverted: faster in a parser-only microbench, not faster end-to-end.

Serve TLS 1.2+ from ServerConfig(ssl=…) or STARIO_SSL_CERTFILE / STARIO_SSL_KEYFILE, with ALPN h2 and http/1.1. Reject Transfer-Encoding that is not chunked. RST H2 CONNECT and :protocol. HTTP/1 Upgrade stays 400.

Parse query like headers: first read fills two arrays, then get / getlist / items linear-scan. Dispatch keeps an arena span until that read. as_dict / as_lists are grouping views for forms and Pydantic.

Match core dispatch: mark_nobody for GET and empty bodies, wait for complete on Content-Length ≤256KiB, start large, chunked, and 100-continue at headers. Trailing-slash 308 is inline (H2 frames, not HTTP/1.1 text).

H2 receive windows are 1MiB per stream and 4MiB per connection. Credit is submitted as WINDOW_UPDATE after each mem_recv and when a stream ends — nghttp2 consume() only emits a frame at 50% of the window and stalled keep-alive small POSTs. Outbound DATA is NO_COPY into one coalesced write.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d3e4a82-06aa-4c5e-9c63-f77df4cbb293?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d3e4a82-06aa-4c5e-9c63-f77df4cbb293&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

