### PR TITLE
HTTP/1 and HTTP/2 security audit: protocol, recycle, and injection hardening

### DIFF
--- a/src/stario/cookies.py
+++ b/src/stario/cookies.py
@@ -65,44 +65,60 @@ def set_cookie(
 
     For relative expiry, prefer `max_age` (seconds from now).
     """
+    if path and (";" in path or "," in path):
+        raise StarioError(
+            "Invalid cookie path",
+            context={"path": path},
+            help_text="Cookie Path must not contain ';' or ','.",
+        )
+    if domain and (";" in domain or "," in domain):
+        raise StarioError(
+            "Invalid cookie domain",
+            context={"domain": domain},
+            help_text="Cookie Domain must not contain ';' or ','.",
+        )
+    if isinstance(expires, str) and (";" in expires or "," in expires):
+        raise StarioError(
+            "Invalid cookie expires",
+            context={"expires": expires},
+            help_text="Cookie Expires must not contain ';' or ','.",
+        )
+
     cookie: http.cookies.BaseCookie[str] = http.cookies.SimpleCookie()
     try:
         cookie[name] = value
+        if max_age is not None:
+            cookie[name]["max-age"] = str(max_age)
+        if expires is not None:
+            if isinstance(expires, datetime):
+                cookie[name]["expires"] = format_datetime(expires, usegmt=True)
+            elif isinstance(expires, int):
+                cookie[name]["expires"] = format_datetime(
+                    datetime.fromtimestamp(expires, tz=UTC),
+                    usegmt=True,
+                )
+            else:
+                cookie[name]["expires"] = expires
+        if path:
+            cookie[name]["path"] = path
+        if domain:
+            cookie[name]["domain"] = domain
+        if httponly:
+            cookie[name]["httponly"] = True
+        if samesite:
+            cookie[name]["samesite"] = samesite
+        if secure or samesite == "none":
+            cookie[name]["secure"] = True
+        w.headers.unsafe_add(
+            b"set-cookie",
+            cookie.output(header="").strip().encode("latin-1"),
+        )
     except http.cookies.CookieError as exc:
         raise StarioError(
-            "Invalid cookie name or value",
+            "Invalid cookie name, value, or attribute",
             context={"name": name},
-            help_text="Cookie names and values must follow RFC 6265 rules.",
+            help_text="Cookie names, values, and attributes must follow RFC 6265 rules.",
         ) from exc
-
-    if max_age is not None:
-        cookie[name]["max-age"] = str(max_age)
-    if expires is not None:
-        if isinstance(expires, datetime):
-            cookie[name]["expires"] = format_datetime(expires, usegmt=True)
-        elif isinstance(expires, int):
-            cookie[name]["expires"] = format_datetime(
-                datetime.fromtimestamp(expires, tz=UTC),
-                usegmt=True,
-            )
-        else:
-            cookie[name]["expires"] = expires
-    if path:
-        cookie[name]["path"] = path
-    if domain:
-        cookie[name]["domain"] = domain
-    if httponly:
-        cookie[name]["httponly"] = True
-    if samesite:
-        cookie[name]["samesite"] = samesite
-    # Browsers require Secure when SameSite=None; apply to the cookie, not only a local flag.
-    if secure or samesite == "none":
-        cookie[name]["secure"] = True
-
-    w.headers.unsafe_add(
-        b"set-cookie",
-        cookie.output(header="").strip().encode("latin-1"),
-    )
     return w
 
 

--- a/src/stario/datastar/attributes.py
+++ b/src/stario/datastar/attributes.py
@@ -29,6 +29,7 @@ from typing import Literal
 from stario.exceptions import StarioError
 from stario.markup.escape import escape_attribute_value as escape_attr
 from stario.markup.escape import escape_sq_attribute_value
+from stario.markup.escape import validate_attribute_key
 from stario.markup.types import Attrs
 
 from ._jsevents import JSEvent
@@ -81,6 +82,7 @@ class DatastarAttributes:
         # Attrs(' data-attr:title="$item.label"')
         ```
         """
+        validate_attribute_key(key)
         return Attrs(f' {self.prefix}attr:{key}="{escape_attr(expression)}"')
 
     def attrs(self, mapping: dict[str, str]) -> Attrs:
@@ -111,6 +113,10 @@ class DatastarAttributes:
         ```
         """
         validate_signal_path(signal_name)
+        if prop is not None:
+            validate_attribute_key(prop)
+        if event is not None:
+            validate_attribute_key(event)
         if prop is None and event is None:
             return Attrs(f' {self.prefix}bind="{escape_attr(signal_name)}"')
 
@@ -138,6 +144,7 @@ class DatastarAttributes:
         # Attrs(' data-class:hidden="!$expanded"')
         ```
         """
+        validate_attribute_key(name)
         return Attrs(f' {self.prefix}class:{name}="{escape_attr(expression)}"')
 
     def classes(self, mapping: dict[str, str]) -> Attrs:
@@ -316,6 +323,8 @@ class DatastarAttributes:
                     "`prevent` calls it. Pass only one."
                 ),
             )
+
+        validate_attribute_key(event)
 
         if (
             not once
@@ -586,6 +595,7 @@ class DatastarAttributes:
         # Attrs(' data-style:width="$pct + '%'"')
         ```
         """
+        validate_attribute_key(prop)
         return Attrs(f' {self.prefix}style:{prop}="{escape_attr(expression)}"')
 
     def styles(self, mapping: dict[str, str]) -> Attrs:
@@ -705,6 +715,8 @@ class DatastarAttributes:
         """
         filters = filter_js(include, exclude)
         value: str | bool = filters if filters is not None else True
+        if storage_key is not None:
+            validate_attribute_key(storage_key)
         if storage_key is None:
             key = self.prefix + "persist"
         elif session:

--- a/src/stario/datastar/sse.py
+++ b/src/stario/datastar/sse.py
@@ -52,6 +52,11 @@ def _sse_field_value(name: str, value: str) -> bytes:
     return value.encode()
 
 
+def _sse_payload_lines(data: bytes) -> list[bytes]:
+    """Split an SSE payload on CR, LF, or CRLF (HTML event-stream line endings)."""
+    return data.replace(b"\r\n", b"\n").replace(b"\r", b"\n").split(b"\n")
+
+
 class SSE:
     """Datastar SSE response bound to one `Writer`.
 
@@ -119,7 +124,9 @@ class SSE:
             html_bytes = render(content).encode("utf-8")
 
         # SSE represents multiline payloads as repeated `data:` lines.
-        for line in html_bytes.split(b"\n"):
+        # Split on CR, LF, and CRLF: a bare CR is a line terminator in the
+        # event-stream parser and must not remain inside a `data:` field.
+        for line in _sse_payload_lines(html_bytes):
             lines.append(b"data: elements " + line)
 
         self._prepare_headers()
@@ -141,7 +148,7 @@ class SSE:
         lines = [_EVENT_PATCH_SIGNALS]
         if only_if_missing:
             lines.append(b"data: onlyIfMissing true")
-        for line in json_bytes.split(b"\n"):
+        for line in _sse_payload_lines(json_bytes):
             lines.append(b"data: signals " + line)
         self._prepare_headers()
         self.w.write(b"\n".join(lines) + b"\n\n")

--- a/src/stario/http/config.py
+++ b/src/stario/http/config.py
@@ -68,10 +68,20 @@ class RequestPolicy:
                 "max_header_bytes must be at least 256",
                 help_text="Increase the limit or use the default Server settings.",
             )
+        if max_header_bytes > 2_147_483_647:
+            raise StarioError(
+                "max_header_bytes must be at most 2^31-1",
+                help_text="The Cython protocol stores this cap as a 32-bit int.",
+            )
         if max_body_bytes < 1:
             raise StarioError(
                 "max_body_bytes must be at least 1",
                 help_text="Use a positive byte limit for request bodies.",
+            )
+        if max_body_bytes > 2_147_483_647:
+            raise StarioError(
+                "max_body_bytes must be at most 2^31-1",
+                help_text="The Cython protocol stores this cap as a 32-bit int.",
             )
         for field, value in (
             ("header_timeout", header_timeout),

--- a/src/stario/http/invoke.py
+++ b/src/stario/http/invoke.py
@@ -25,6 +25,7 @@ def _finish_incomplete(w: Writer) -> None:
     if w.started:
         w.abort()
         return
+    w.headers.remove("transfer-encoding")
     w.headers.set("connection", "close")
     w.respond(_INTERNAL_ERROR, _PLAIN, 500)
 

--- a/src/stario/markup/attributes.py
+++ b/src/stario/markup/attributes.py
@@ -39,7 +39,7 @@ def styles(declarations: StyleDeclarations) -> Attrs:
                 example='h.Div(styles({"color": "red"}))',
             )
 
-        if any(ch in key for ch in r":;{}\"):
+        if any(ch in key for ch in ":;{}\\"):
             raise StarioError(
                 f"Invalid CSS property name: {key!r}",
                 context={"property": key},

--- a/src/stario/markup/attributes.py
+++ b/src/stario/markup/attributes.py
@@ -39,12 +39,12 @@ def styles(declarations: StyleDeclarations) -> Attrs:
                 example='h.Div(styles({"color": "red"}))',
             )
 
-        if any(ch in key for ch in ":;{}"):
+        if any(ch in key for ch in r":;{}\"):
             raise StarioError(
                 f"Invalid CSS property name: {key!r}",
                 context={"property": key},
                 help_text=(
-                    "CSS property names must not contain ':', ';', '{', or '}' characters."
+                    "CSS property names must not contain ':', ';', '{', '}', or '\\' characters."
                 ),
                 example='h.Div(styles({"background-color": "red"}))',
             )
@@ -65,6 +65,16 @@ def styles(declarations: StyleDeclarations) -> Attrs:
         value_type = type(value)
         if value_type is str:
             rendered_value = escape_attribute_value(cast(str, value))
+            if any(ch in rendered_value for ch in ";{}\\"):
+                raise StarioError(
+                    f"Invalid CSS value for property '{rendered_key}'",
+                    context={"property": rendered_key, "value": rendered_value[:100]},
+                    help_text=(
+                        "CSS values in styles() must not contain ';', '{', '}', "
+                        "or '\\' so they cannot inject extra declarations."
+                    ),
+                    example='h.Div(styles({"color": "red"}))',
+                )
         elif value_type is int or value_type is float:
             rendered_value = str(value)
         else:

--- a/src/stario/routing/urlpath.py
+++ b/src/stario/routing/urlpath.py
@@ -84,7 +84,7 @@ def _format_host_value(
             context={"pattern": pattern, "parameter": name},
             help_text="Pass a non-empty value for each host placeholder.",
         )
-    if any(ch in text for ch in "/:@[]"):
+    if any(ch in text for ch in "/:@[]?#\\ \t\r\n"):
         raise StarioError(
             "UrlPath host parameter contains invalid character",
             context={"pattern": pattern, "parameter": name, "value": text},

--- a/src/stario_cython/exchange.pxd
+++ b/src/stario_cython/exchange.pxd
@@ -26,6 +26,7 @@ cdef enum:
 cdef int _fold_header_name(object name, char* buf, Py_ssize_t* out_n) except -1
 cdef object _intern_name(const char* src, size_t n)
 cdef object _encode_name(str name)
+cdef bint host_value_ok(const char* value, size_t n) noexcept
 
 cdef class Headers:
     cdef list _names
@@ -193,8 +194,11 @@ cdef class RequestExchange:
     cdef Py_ssize_t _h2_head_bytes
     cdef bint _h2_awaiting_headers
     cdef double _h2_header_deadline
+    cdef bint _h2_outbound
     cdef object _h2_date_line
     cdef object _h2_date_bare
+    cdef object _handler_task
+    cdef bint _head_request
     cdef bint _expect_continue
     cdef bint _waiting
     cdef bint _discard_body

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -404,6 +404,30 @@ cdef inline int _hex_nibble(unsigned char c) noexcept:
     return -1
 
 
+cdef bint host_value_ok(const char* value, size_t n) noexcept:
+    """Reject Host / :authority values that can break out of the host form.
+
+    `?` and `#` turn ``//{label}.example.com`` into a different origin.
+    `/`, ``\\``, `@`, and ASCII controls are not valid in a host header.
+    IPv6 literals (``[::1]:port``) still pass.
+    """
+    cdef size_t i
+    cdef unsigned char c
+    for i in range(n):
+        c = <unsigned char>value[i]
+        if (
+            c <= 32
+            or c == 127
+            or c == 35
+            or c == 47
+            or c == 63
+            or c == 64
+            or c == 92
+        ):
+            return False
+    return True
+
+
 cdef object _decode_latin1(const char* s, Py_ssize_t n):
     if n <= 0:
         return ""
@@ -466,6 +490,8 @@ cdef object _unquote_plus_component(const char* s, Py_ssize_t n):
                     h1 = _hex_nibble(<unsigned char>s[i + 1])
                     h2 = _hex_nibble(<unsigned char>s[i + 2])
                     if h1 >= 0 and h2 >= 0:
+                        if ((h1 << 4) | h2) == 0:
+                            raise ValueError("query contains a NUL byte")
                         buf[w] = <char>((h1 << 4) | h2)
                         w += 1
                         i += 3
@@ -474,6 +500,8 @@ cdef object _unquote_plus_component(const char* s, Py_ssize_t n):
                         w += 1
                         i += 1
                 else:
+                    if c == 0:
+                        raise ValueError("query contains a NUL byte")
                     buf[w] = <char>c
                     w += 1
                     i += 1
@@ -505,11 +533,23 @@ cdef inline bint _span_all_ascii(const char* s, Py_ssize_t n) noexcept:
     return True
 
 
+cdef inline bint _span_contains_nul(const char* s, Py_ssize_t n) noexcept:
+    cdef Py_ssize_t i
+    for i in range(n):
+        if s[i] == 0:
+            return True
+    return False
+
+
 cdef object _decode_query_component(const char* s, Py_ssize_t n):
+    cdef Py_ssize_t i
     if n <= 0:
         return ""
     if _span_needs_unquote(s, n):
         return _unquote_plus_component(s, n)
+    for i in range(n):
+        if s[i] == 0:
+            raise ValueError("query contains a NUL byte")
     return _decode_latin1(s, n)
 
 
@@ -820,6 +860,8 @@ cdef class ParsedQuery:
         if buf == NULL:
             return ""
         name = buf + param.name_off
+        if _span_contains_nul(name, nlen):
+            raise ValueError("query contains a NUL byte")
         if param.flags & QUERY_NAME_INPLACE:
             if _span_all_ascii(name, nlen):
                 return _decode_latin1(name, nlen)
@@ -1959,13 +2001,13 @@ cdef class RequestExchange:
                 ]
                 if not h.c_vary_contains(b"accept-encoding"):
                     nva.append((b"vary", b"accept-encoding"))
+                self._status_code = status
+                self._declared_length = nbytes
+                self._bytes_written = nbytes
+                self._completed = True
                 self._connection.h2_respond(self, nva, payload, True, True, True)
             finally:
                 self._free_compressors()
-            self._status_code = status
-            self._declared_length = nbytes
-            self._bytes_written = nbytes
-            self._completed = True
             self._done()
             return
         if existing_cl is not None:
@@ -1979,13 +2021,13 @@ cdef class RequestExchange:
             nva.append((b"content-length", _dec(<size_t>nbytes)))
         if isinstance(payload, (list, tuple)):
             payload = b"".join(payload) if payload else b""
-        self._connection.h2_respond(
-            self, nva, payload if payload is not None else b"", False, True, True
-        )
         self._status_code = status
         self._declared_length = nbytes
         self._bytes_written = nbytes if nbytes > 0 else 0
         self._completed = True
+        self._connection.h2_respond(
+            self, nva, payload if payload is not None else b"", False, True, True
+        )
         self._done()
 
     cdef void _flush(self):
@@ -2272,8 +2314,11 @@ cdef class RequestExchange:
         header.value_offset = <uint32_t>self._req_pending_value_offset
         header.value_length = <uint32_t>value_length
         if name_length == 4 and memcmp(name, "host", 4) == 0:
-            if self._req_host_index < 0:
-                self._req_host_index = self._req_raw_count
+            if not host_value_ok(value, value_length):
+                return -1
+            if self._req_host_index >= 0:
+                return -1
+            self._req_host_index = self._req_raw_count
         elif name_length == 6:
             if memcmp(name, "cookie", 6) == 0:
                 if self._req_cookie_index < 0:
@@ -2453,6 +2498,9 @@ cdef class RequestExchange:
         self._h2_head_bytes = 0
         self._h2_awaiting_headers = False
         self._h2_header_deadline = 0.0
+        self._h2_outbound = False
+        self._handler_task = None
+        self._head_request = False
 
     cdef void bind_http2(self, int32_t stream_id) noexcept:
         self._http2 = True
@@ -2464,6 +2512,9 @@ cdef class RequestExchange:
         self._h2_head_bytes = 0
         self._h2_awaiting_headers = True
         self._h2_header_deadline = 0.0
+        self._h2_outbound = False
+        self._handler_task = None
+        self._head_request = False
 
     cdef void _clear_hot_request_headers(self) noexcept:
         self._req_encoding = ENCODING_NONE
@@ -2542,6 +2593,7 @@ cdef class RequestExchange:
             and self._completed
             and self.handler_done
             and (not self._body_active or self._body_complete)
+            and (not self._http2 or not self._h2_outbound)
         ):
             self._connection.recycle_exchange(self)
 
@@ -2551,6 +2603,8 @@ cdef class RequestExchange:
         self.in_pool = True
         self._cached = None
         self._data_ready = None
+        self._h2_pending = b""
+        self._h2_pending_off = 0
         self._cancel_stall_timer()
         self._clear_body_storage()
         self._body_active = False
@@ -2609,11 +2663,22 @@ cdef class RequestExchange:
                     "then write()/end()."
                 ),
             )
+        try:
+            content_type = _encode_value_bytes(content_type)
+        except ValueError as exc:
+            raise StarioError(
+                "Invalid Content-Type",
+                context={"content_type": repr(content_type)[:120]},
+                help_text="Content-Type must be a header value without CR or LF.",
+            ) from exc
+        self._expect_continue = False
         if not _may_have_body(status):
             body = b""
             nbytes = 0
         else:
             nbytes = self._body_nbytes(body)
+            if self._head_request:
+                body = b""
         self._declared_length = nbytes
         self._bytes_written = 0
         if self._http2:
@@ -2639,18 +2704,30 @@ cdef class RequestExchange:
                     _dec(<size_t>nbytes),
                     CRLF2,
                 ))
-                self._transport.writelines(body)
+                if body and not self._head_request:
+                    self._transport.writelines(body)
             else:
-                self._transport.writelines((
-                    _status_line(status),
-                    self._date_box[0],
-                    CT_PREFIX,
-                    content_type,
-                    CL_PREFIX,
-                    _dec(<size_t>nbytes),
-                    CRLF2,
-                    body,
-                ))
+                if self._head_request or not nbytes:
+                    self._transport.writelines((
+                        _status_line(status),
+                        self._date_box[0],
+                        CT_PREFIX,
+                        content_type,
+                        CL_PREFIX,
+                        _dec(<size_t>nbytes),
+                        CRLF2,
+                    ))
+                else:
+                    self._transport.writelines((
+                        _status_line(status),
+                        self._date_box[0],
+                        CT_PREFIX,
+                        content_type,
+                        CL_PREFIX,
+                        _dec(<size_t>nbytes),
+                        CRLF2,
+                        body,
+                    ))
         else:
             existing_ce = None
             existing_cl = None
@@ -2722,7 +2799,7 @@ cdef class RequestExchange:
             self._buf_bytes(CRLF2)
             self._flush()
             self._status_code = status
-            if nbytes:
+            if nbytes and not self._head_request:
                 if isinstance(body, (list, tuple)):
                     self._transport.writelines(body)
                 else:
@@ -2765,6 +2842,26 @@ cdef class RequestExchange:
             headers.c_set(b"content-length", b"0")
             self._declared_length = 0
             self._bytes_written = 0
+        elif self._head_request:
+            headers.c_remove(b"transfer-encoding")
+            if headers.c_get(b"content-length") is not None:
+                raw_length = headers.c_get(b"content-length")
+                try:
+                    parsed_length = int(raw_length)
+                    if parsed_length < 0:
+                        raise ValueError()
+                    self._declared_length = parsed_length
+                    self._bytes_written = 0
+                except (TypeError, ValueError, OverflowError) as exc:
+                    raise StarioError(
+                        "Invalid Content-Length header",
+                        context={"content-length": raw_length},
+                        help_text="Set Content-Length to a non-negative integer before write_headers().",
+                    ) from exc
+            else:
+                self._declared_length = 0
+                self._bytes_written = 0
+                headers.c_set(b"content-length", b"0")
         elif headers.c_get(b"content-length") is not None:
             headers.c_remove(b"transfer-encoding")
             raw_length = headers.c_get(b"content-length")
@@ -2795,6 +2892,7 @@ cdef class RequestExchange:
                         self._ensure_gzip()
                     headers.c_set(b"content-encoding", encoding)
                     headers.c_merge_vary(b"accept-encoding")
+        self._expect_continue = False
         if self._http2:
             nva = [
                 (b":status", _dec(<size_t>status_code)),
@@ -2843,6 +2941,8 @@ cdef class RequestExchange:
                     "204/304 and 1xx responses must not include a message body."
                 ),
             )
+        if self._head_request:
+            return self
         n = self._body_nbytes(data)
         if n == 0:
             return self
@@ -2898,8 +2998,9 @@ cdef class RequestExchange:
             self.write_headers(200 if data is not None else 204)
         if data:
             self.write(data)
-        if self._http2:
-            self._connection.h2_end(self)
+        if self._head_request:
+            if self._http2:
+                self._connection.h2_end(self)
             self._completed = True
             self._done()
             return
@@ -2912,6 +3013,11 @@ cdef class RequestExchange:
                     "before w.end()."
                 ),
             )
+        if self._http2:
+            self._connection.h2_end(self)
+            self._completed = True
+            self._done()
+            return
         if self._declared_length < 0:
             if self._brotli != NULL or self._gzip != NULL:
                 self._finish(&native_out, &native_len)
@@ -3018,6 +3124,8 @@ cdef class RequestExchange:
             and received_before == 0
         ):
             cap = self._expected_size
+            if cap > STREAM_CHUNK_CL:
+                cap = STREAM_CHUNK_CL
         elif self._consumed_as != CONSUMED_STREAM:
             cap = DEFAULT_STREAM_CHUNK
         if self._expected_size >= 0:
@@ -3047,6 +3155,8 @@ cdef class RequestExchange:
         if self._expected_size <= 0 or self._consumed_as == CONSUMED_STREAM:
             return 0
         if self._body_complete:
+            return 0
+        if self._expected_size > STREAM_CHUNK_CL:
             return 0
         have = self._buffered + self._tail_used
         if have > self._expected_size:
@@ -3172,14 +3282,18 @@ cdef class RequestExchange:
         self._wake()
 
     cdef void _maybe_continue(self):
-        if self._expect_continue:
+        if not self._expect_continue:
+            return
+        if self._status_code >= 0 or self._completed:
             self._expect_continue = False
-            if self._transport is None or self._transport.is_closing():
-                return
-            if self._http2:
-                self._connection.h2_write_headers(self, [(b":status", b"100")], True, True, True, True)
-                return
-            self._transport.write(b"HTTP/1.1 100 Continue\r\n\r\n")
+            return
+        self._expect_continue = False
+        if self._transport is None or self._transport.is_closing():
+            return
+        if self._http2:
+            self._connection.h2_write_headers(self, [(b":status", b"100")], True, True, True, True)
+            return
+        self._transport.write(b"HTTP/1.1 100 Continue\r\n\r\n")
 
     cdef void _maybe_pause(self):
         if self._consumed_as == CONSUMED_STREAM:

--- a/src/stario_cython/headers.pxi
+++ b/src/stario_cython/headers.pxi
@@ -225,12 +225,14 @@ cdef object _intern_name(const char* src, size_t n):
 
 
 cdef object _intern_wire_name(const char* src, size_t n):
+    cdef char buf[NAME_STACK]
     cdef int index
     if n >= NAME_STACK - 2:
         raise ValueError("Invalid header name: too long")
-    index = _intern_lookup(src, n)
+    _lower_copy(buf, src, n)
+    index = _intern_lookup(buf, n)
     if index < 0:
-        return _make_wire_name(src, n)
+        return _make_wire_name(buf, n)
     return _INTERN_WIRE[index]
 
 
@@ -299,6 +301,18 @@ cdef object _encode_value(str value):
     return raw
 
 
+cdef object _encode_value_bytes(object value):
+    cdef bytes raw
+    if isinstance(value, str):
+        return _encode_value(value)
+    if not isinstance(value, bytes):
+        raise ValueError("Invalid header value")
+    raw = <bytes>value
+    if raw.translate(None, _VALID_VALUE):
+        raise ValueError("Invalid header value")
+    return raw
+
+
 def encode_header_value(str value):
     """Validate and return wire bytes for a header value."""
     return _encode_value(value)
@@ -321,17 +335,25 @@ cdef class Headers:
                     self.c_set(key, value)
 
     cdef Py_ssize_t _find_n(self, const char* name, Py_ssize_t n) noexcept:
+        cdef char buf[NAME_STACK]
         cdef Py_ssize_t i
+        if n >= NAME_STACK:
+            return -1
+        _lower_copy(buf, name, <size_t>n)
         for i in range(self._n):
-            if _wire_is(self._names[i], name, n):
+            if _wire_is(self._names[i], buf, n):
                 return i
         return -1
 
     cdef Py_ssize_t _compact_except(self, const char* name, Py_ssize_t n) noexcept:
+        cdef char buf[NAME_STACK]
         cdef Py_ssize_t i
         cdef Py_ssize_t w = 0
+        if n >= NAME_STACK:
+            return self._n
+        _lower_copy(buf, name, <size_t>n)
         for i in range(self._n):
-            if _wire_is(self._names[i], name, n):
+            if _wire_is(self._names[i], buf, n):
                 continue
             if w != i:
                 self._names[w] = self._names[i]
@@ -605,12 +627,16 @@ cdef class Headers:
 
     def unsafe_getlist(self, name):
         cdef bytes key = <bytes>name
+        cdef char buf[NAME_STACK]
         cdef const char* src = PyBytes_AS_STRING(key)
         cdef Py_ssize_t n = PyBytes_GET_SIZE(key)
         cdef list result = []
         cdef Py_ssize_t i
+        if n >= NAME_STACK:
+            return result
+        _lower_copy(buf, src, <size_t>n)
         for i in range(self._n):
-            if _wire_is(self._names[i], src, n):
+            if _wire_is(self._names[i], buf, n):
                 result.append(_bare_bytes(self._values[i], 2))
         return result
 

--- a/src/stario_cython/protocol.pyx
+++ b/src/stario_cython/protocol.pyx
@@ -50,6 +50,7 @@ from stario_cython.exchange cimport (
     Request,
     RequestExchange,
     acquire_exchange,
+    host_value_ok,
     _status_line,
 )
 from stario_cython.llhttp cimport *
@@ -60,6 +61,7 @@ from stario_cython.nghttp2 cimport (
     NGHTTP2_DATA_FLAG_NO_COPY,
     NGHTTP2_ERR_CALLBACK_FAILURE,
     NGHTTP2_ERR_DEFERRED,
+    NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE,
     NGHTTP2_FLAG_END_STREAM,
     NGHTTP2_FLAG_NONE,
     NGHTTP2_HEADERS,
@@ -157,9 +159,6 @@ cdef Py_ssize_t _UC_QLEN[256]
 cdef list _UC_PATH = None
 cdef object PATH_EMPTY = ""
 cdef bytes H2_PREFACE = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
-cdef uint8_t H2_NV_NOCOPY = (
-    NGHTTP2_NV_FLAG_NO_COPY_NAME | NGHTTP2_NV_FLAG_NO_COPY_VALUE
-)
 
 
 cdef uint32_t _url_hash(const char* s, Py_ssize_t n) noexcept:
@@ -354,9 +353,9 @@ cdef bint _trailing_slash_redirect(
         return False
     start[0] = 0
     end[0] = path_end[0]
-    while start[0] < end[0] and url[start[0]] == 47:
+    while start[0] < end[0] and (url[start[0]] == 47 or url[start[0]] == 92):
         start[0] += 1
-    while end[0] > start[0] and url[end[0] - 1] == 47:
+    while end[0] > start[0] and (url[end[0] - 1] == 47 or url[end[0] - 1] == 92):
         end[0] -= 1
     return True
 
@@ -476,6 +475,8 @@ cdef void _bind_settings():
         return
     _url_cache_init()
     _SETTINGS = stario_settings_new()
+    if _SETTINGS == NULL:
+        raise MemoryError()
     _SETTINGS.on_message_begin = _cb_message_begin
     _SETTINGS.on_url = _cb_url
     _SETTINGS.on_header_field = _cb_header_field
@@ -627,7 +628,7 @@ cdef ssize_t _h2_data_source_read(
     cdef RequestExchange ex
     if source != NULL and source.ptr != NULL:
         ex = <RequestExchange>source.ptr
-        return proto._h2_read_data(ex, buf, length, data_flags)
+        return proto._h2_read_data(ex, stream_id, buf, length, data_flags)
     return NGHTTP2_ERR_CALLBACK_FAILURE
 
 
@@ -850,8 +851,17 @@ cdef class HttpProtocol:
         ssl_object = transport.get_extra_info("ssl_object")
         if ssl_object is not None:
             selected = ssl_object.selected_alpn_protocol()
+            if isinstance(selected, bytes):
+                try:
+                    selected = selected.decode("ascii")
+                except UnicodeDecodeError:
+                    selected = None
             if selected == "h2":
                 self._start_h2()
+            else:
+                # RFC 9113: ALPN is authoritative over TLS. Do not sniff
+                # the cleartext preface after negotiating http/1.1.
+                self.parse_mode = PARSE_H1
         # First request: header deadline only. Keep-alive stores a
         # deadline; the sweeper compares it. No TimerHandle per request.
         self._arm_timeout(TIMEOUT_HEADER, self.header_timeout)
@@ -924,10 +934,18 @@ cdef class HttpProtocol:
         if self.parse_mode != PARSE_H2 and self.parser == NULL:
             return
         if self.timeout_kind == TIMEOUT_IDLE:
-            # Keep-alive traffic: drop the idle deadline. The sweeper
-            # sees TIMEOUT_NONE on the next wake.
-            self.timeout_kind = TIMEOUT_NONE
-            self.timeout_deadline = 0.0
+            if not (
+                self.parse_mode == PARSE_H1
+                and self.reading_exchange is not None
+                and (
+                    self.reading_exchange._discard_body
+                    or self.h1_headers_too_large
+                )
+            ):
+                # Keep-alive traffic: drop the idle deadline. Bytes that
+                # only drain a leftover body must not refresh it.
+                self.timeout_kind = TIMEOUT_NONE
+                self.timeout_deadline = 0.0
         if self.held_data is not None:
             self._held_append(data)
             return
@@ -1064,10 +1082,10 @@ cdef class HttpProtocol:
                     self._check_body_stall(exchange, now)
 
     cdef void _check_h2_header_timeout(self, RequestExchange ex, double now) noexcept:
-        """Reset one stalled HEADERS stream; other streams keep running."""
+        """Reset a stream that has not dispatched within the header timeout."""
         if (
             ex is None
-            or not ex._h2_awaiting_headers
+            or ex._h2_dispatched
             or self.header_timeout <= 0.0
             or TIMEOUT_MODE == CLEANUP_OFF
         ):
@@ -1077,7 +1095,6 @@ cdef class HttpProtocol:
             return
         if now >= ex._h2_header_deadline:
             ex._h2_awaiting_headers = False
-            # Header block is unfinished — cannot send 408 HEADERS. RST only.
             self._h2_reject_stream(ex._h2_stream_id, NGHTTP2_CANCEL)
             self._h2_send()
 
@@ -1101,13 +1118,28 @@ cdef class HttpProtocol:
                 )
             ):
                 self._arm_timeout(TIMEOUT_HEADER, self.header_timeout)
+        if self.timeout_kind != TIMEOUT_NONE or self.rejected:
+            return
+        if self.parse_mode == PARSE_H2:
+            if not self.h2_streams:
+                self._arm_timeout(TIMEOUT_IDLE, self.keep_alive_timeout)
+            return
         if (
-            self.timeout_kind == TIMEOUT_NONE
-            and self.parse_mode == PARSE_H1
-            and not self.rejected
+            self.parse_mode == PARSE_H1
             and self.reading_exchange is None
             and self.active_exchange is None
             and not self.pending_exchanges
+        ):
+            self._arm_timeout(TIMEOUT_IDLE, self.keep_alive_timeout)
+            return
+        if (
+            self.parse_mode == PARSE_H1
+            and self.reading_exchange is not None
+            and (
+                self.reading_exchange._discard_body
+                or self.h1_headers_too_large
+            )
+            and not self.reading_exchange._body_complete
         ):
             self._arm_timeout(TIMEOUT_IDLE, self.keep_alive_timeout)
 
@@ -1365,11 +1397,18 @@ cdef class HttpProtocol:
         cdef uint16_t flags
         cdef uint64_t content_length
         cdef bint has_body
+        cdef int http_major
+        cdef int http_minor
+        cdef int method
         if self.rejected or self.reading_exchange is None:
             return
         exchange = self.reading_exchange
         flags = stario_parser_flags(self.parser)
         content_length = stario_parser_content_length(self.parser)
+        http_major = <int>llhttp_get_http_major(self.parser)
+        http_minor = <int>llhttp_get_http_minor(self.parser)
+        method = <int>llhttp_get_method(self.parser)
+        exchange._head_request = method == 2
         has_body = (
             (flags & F_CHUNKED) != 0
             or ((flags & F_CONTENT_LENGTH) != 0 and content_length > 0)
@@ -1377,22 +1416,12 @@ cdef class HttpProtocol:
         self.request_keep_alive = (
             llhttp_should_keep_alive(self.parser) != 0
             or (
-                llhttp_get_http_major(self.parser) == 1
-                and llhttp_get_http_minor(self.parser) == 1
+                http_major == 1
+                and http_minor == 1
                 and not exchange._req_connection_close
             )
         )
-        if self.h1_headers_too_large:
-            # Keep-alive only when there is no body to drain. A huge POST
-            # after oversize headers would be a read-DoS if we stayed open.
-            self._h1_protocol_status(
-                431,
-                "Request header fields too large",
-                has_body or not self.request_keep_alive,
-                -1,
-            )
-            return
-        if exchange.finish_request_header() != 0:
+        if http_major != 1:
             self._close_error(400, "Invalid HTTP request")
             return
         if llhttp_get_upgrade(self.parser):
@@ -1402,6 +1431,26 @@ cdef class HttpProtocol:
         # length is undefined. Reject before dispatch (llhttp errors after
         # on_headers_complete, which would otherwise 404 then 400).
         if (flags & F_TRANSFER_ENCODING) and not (flags & F_CHUNKED):
+            self._close_error(400, "Invalid HTTP request")
+            return
+        if self.h1_headers_too_large:
+            # Keep-alive only when there is no body to drain. A huge POST
+            # after oversize headers would be a read-DoS if we stayed open.
+            # Trust llhttp when it says this message cannot be keep-alive
+            # (TE-without-chunked is already rejected above).
+            self._h1_protocol_status(
+                431,
+                "Request header fields too large",
+                has_body
+                or not self.request_keep_alive
+                or llhttp_should_keep_alive(self.parser) == 0,
+                -1,
+            )
+            return
+        if exchange.finish_request_header() != 0:
+            self._close_error(400, "Invalid HTTP request")
+            return
+        if http_minor == 1 and exchange._req_host_index < 0:
             self._close_error(400, "Invalid HTTP request")
             return
         if flags & F_CONTENT_LENGTH and content_length > <uint64_t>self.max_body_bytes:
@@ -1531,6 +1580,8 @@ cdef class HttpProtocol:
                 <int>llhttp_get_http_major(self.parser),
                 <int>llhttp_get_http_minor(self.parser),
             )
+        if method is METH_HEAD:
+            exchange._head_request = True
         request.reset(
             method,
             path,
@@ -1624,6 +1675,7 @@ cdef class HttpProtocol:
             loop=self.loop,
             eager_start=eager_start,
         )
+        exchange._handler_task = task
         if task.done():
             # Skip only a clean NoOp success. Write-then-raise / cancel / an
             # incomplete response must still hit on_handler_done (log + abort).
@@ -1670,16 +1722,8 @@ cdef class HttpProtocol:
         cdef object conn
         cdef RequestExchange next_exchange
         if exchange._http2:
-            self.h2_streams.pop(exchange._h2_stream_id, None)
-            if (
-                transport is not None
-                and not transport.is_closing()
-                and not self.h2_streams
-                and self.reading_exchange is None
-                and not self.pending_exchanges
-                and not self.app.shutdown.done()
-            ):
-                self._arm_timeout(TIMEOUT_IDLE, self.keep_alive_timeout)
+            # Keep the stream mapped until on_stream_close so the DATA
+            # provider cannot be recycled while nghttp2 still holds it.
             return
         if self.active_exchange is not exchange:
             return
@@ -1794,17 +1838,29 @@ cdef class HttpProtocol:
             if close_conn:
                 date = self.date_box[0]
                 if transport is not None and not transport.is_closing():
-                    transport.write(
-                        b"".join((
-                            _status_line(status),
-                            date,
-                            b"content-type: text/plain; charset=utf-8\r\n",
-                            b"content-length: %d\r\n" % len(body),
-                            b"connection: close\r\n",
-                            b"\r\n",
-                            body,
-                        ))
-                    )
+                    if exchange is not None and exchange._head_request:
+                        transport.write(
+                            b"".join((
+                                _status_line(status),
+                                date,
+                                b"content-type: text/plain; charset=utf-8\r\n",
+                                b"content-length: %d\r\n" % len(body),
+                                b"connection: close\r\n",
+                                b"\r\n",
+                            ))
+                        )
+                    else:
+                        transport.write(
+                            b"".join((
+                                _status_line(status),
+                                date,
+                                b"content-type: text/plain; charset=utf-8\r\n",
+                                b"content-length: %d\r\n" % len(body),
+                                b"connection: close\r\n",
+                                b"\r\n",
+                                body,
+                            ))
+                        )
                 self.rejected = True
                 if exchange is not None:
                     exchange._completed = True
@@ -1876,19 +1932,40 @@ cdef class HttpProtocol:
                 self._finish_protocol_span(status, span, method, path)
                 transport.close()
                 return
+            if (
+                self.active_exchange is not None
+                and self.active_exchange._status_code >= 0
+            ):
+                # A response is already on the wire. Do not splice a second
+                # status line into that stream.
+                self._finish_protocol_span(status, span, method, path)
+                transport.close()
+                return
             body = message.encode("utf-8")
             date = self.date_box[0]
-            transport.write(
-                b"".join((
-                    _status_line(status),
-                    date,
-                    b"content-type: text/plain; charset=utf-8\r\n",
-                    b"content-length: %d\r\n" % len(body),
-                    b"connection: close\r\n",
-                    b"\r\n",
-                    body,
-                ))
-            )
+            if exchange is not None and exchange._head_request:
+                transport.write(
+                    b"".join((
+                        _status_line(status),
+                        date,
+                        b"content-type: text/plain; charset=utf-8\r\n",
+                        b"content-length: %d\r\n" % len(body),
+                        b"connection: close\r\n",
+                        b"\r\n",
+                    ))
+                )
+            else:
+                transport.write(
+                    b"".join((
+                        _status_line(status),
+                        date,
+                        b"content-type: text/plain; charset=utf-8\r\n",
+                        b"content-length: %d\r\n" % len(body),
+                        b"connection: close\r\n",
+                        b"\r\n",
+                        body,
+                    ))
+                )
             self._finish_protocol_span(status, span, method, path)
             transport.close()
         except Exception:
@@ -2169,6 +2246,8 @@ cdef class HttpProtocol:
                     return
                 ex._h2_got_method = True
                 ex._h2_method = _method_from_bytes(hv, valuelen)
+                if ex._h2_method is METH_HEAD:
+                    ex._head_request = True
                 return
             if namelen == 5 and memcmp(hn, ":path", 5) == 0:
                 if ex._h2_got_path:
@@ -2180,6 +2259,9 @@ cdef class HttpProtocol:
                 return
             if namelen == 10 and memcmp(hn, ":authority", 10) == 0:
                 if ex._h2_got_authority:
+                    self._h2_reject_stream(stream_id, NGHTTP2_PROTOCOL_ERROR)
+                    return
+                if not host_value_ok(hv, valuelen):
                     self._h2_reject_stream(stream_id, NGHTTP2_PROTOCOL_ERROR)
                     return
                 if ex._req_host_index >= 0:
@@ -2201,6 +2283,9 @@ cdef class HttpProtocol:
             self._h2_reject_stream(stream_id, NGHTTP2_PROTOCOL_ERROR)
             return
         if namelen == 4 and memcmp(hn, "host", 4) == 0:
+            if not host_value_ok(hv, valuelen):
+                self._h2_reject_stream(stream_id, NGHTTP2_PROTOCOL_ERROR)
+                return
             if ex._req_host_index >= 0:
                 if not ex.header_value_equals(ex._req_host_index, hv, valuelen):
                     self._h2_reject_stream(stream_id, NGHTTP2_PROTOCOL_ERROR)
@@ -2312,16 +2397,31 @@ cdef class HttpProtocol:
 
     cdef void _h2_stream_closed(self, int32_t stream_id):
         cdef RequestExchange ex
+        cdef object task
         if self.h2 != NULL:
             nghttp2_session_set_stream_user_data(self.h2, stream_id, NULL)
         ex = self.h2_streams.pop(stream_id, None)
         if ex is None:
+            if not self.h2_streams and not self.rejected:
+                self._arm_timeout(TIMEOUT_IDLE, self.keep_alive_timeout)
             return
-        # Client RST or GOAWAY: stop the handler; recycle if it never started.
+        ex._h2_outbound = False
         if not ex._completed:
+            task = ex._handler_task
             ex.c_abort()
-            if not ex.handler_started:
+            if task is not None and not task.done():
+                # Recycle from on_handler_done after CancelledError so
+                # the handler cannot touch a pooled exchange.
+                task.cancel()
+            elif not ex.handler_started:
                 ex.cancel_before_start()
+            else:
+                ex._completed = True
+                ex.handler_finished()
+        else:
+            ex._maybe_recycle()
+        if not self.h2_streams and not self.rejected:
+            self._arm_timeout(TIMEOUT_IDLE, self.keep_alive_timeout)
 
     cdef void _h2_reject_stream(self, int32_t stream_id, uint32_t error_code) noexcept:
         cdef RequestExchange ex = self.h2_streams.get(stream_id)
@@ -2333,6 +2433,7 @@ cdef class HttpProtocol:
     cdef ssize_t _h2_read_data(
         self,
         RequestExchange ex,
+        int32_t stream_id,
         uint8_t* buf,
         size_t length,
         uint32_t* data_flags,
@@ -2342,9 +2443,8 @@ cdef class HttpProtocol:
         cdef object pending
         cdef const char* src = NULL
         cdef Py_ssize_t n = 0
-        if ex is None:
-            data_flags[0] |= NGHTTP2_DATA_FLAG_EOF
-            return 0
+        if ex is None or ex.in_pool or ex._h2_stream_id != stream_id:
+            return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE
         pending = ex._h2_pending
         if pending is None or pending == b"":
             avail = 0
@@ -2382,6 +2482,10 @@ cdef class HttpProtocol:
         if frame != NULL and frame.data.padlen > 0:
             return NGHTTP2_ERR_CALLBACK_FAILURE
         ex = <RequestExchange>source.ptr
+        if ex.in_pool or (
+            frame != NULL and ex._h2_stream_id != frame.hd.stream_id
+        ):
+            return NGHTTP2_ERR_CALLBACK_FAILURE
         if self._h2_out_append(<const char*>framehd, 9) != 0:
             return NGHTTP2_ERR_CALLBACK_FAILURE
         if length == 0:
@@ -2415,7 +2519,7 @@ cdef class HttpProtocol:
             nvs[i].namelen = <size_t>nn
             nvs[i].value = <uint8_t*>PyBytes_AS_STRING(value)
             nvs[i].valuelen = <size_t>vn
-            nvs[i].flags = H2_NV_NOCOPY
+            nvs[i].flags = NGHTTP2_NV_FLAG_NONE
         return <int>n
 
     cdef int _h2_fill_user_nvs(
@@ -2456,6 +2560,14 @@ cdef class HttpProtocol:
                 continue
             if nl == 19 and memcmp(np, "transfer-encoding: ", 19) == 0:
                 continue
+            if nl == 12 and memcmp(np, "connection: ", 12) == 0:
+                continue
+            if nl == 12 and memcmp(np, "keep-alive: ", 12) == 0:
+                continue
+            if nl == 19 and memcmp(np, "proxy-connection: ", 19) == 0:
+                continue
+            if nl == 9 and memcmp(np, "upgrade: ", 9) == 0:
+                continue
             if nl >= 2:
                 nl -= 2
             if vl >= 2:
@@ -2466,7 +2578,7 @@ cdef class HttpProtocol:
             nvs[filled].namelen = <size_t>nl
             nvs[filled].value = <uint8_t*>vp
             nvs[filled].valuelen = <size_t>vl
-            nvs[filled].flags = H2_NV_NOCOPY
+            nvs[filled].flags = NGHTTP2_NV_FLAG_NONE
             filled += 1
         return filled
 
@@ -2479,41 +2591,67 @@ cdef class HttpProtocol:
         bint skip_cl=True,
         bint skip_ct=True,
     ):
-        cdef nghttp2_nv nvs[64]
+        cdef nghttp2_nv nvs_stack[64]
+        cdef nghttp2_nv* nvs
         cdef int nvlen
+        cdef int cap
+        cdef int heap
         cdef nghttp2_data_provider prd
         cdef object payload
         cdef int rv
         if self.h2 == NULL or ex is None:
             return
-        nvlen = self._h2_fill_nva(nva, nvs, 64)
-        nvlen += self._h2_fill_user_nvs(
-            ex.headers, nvs + nvlen, 64 - nvlen, skip_ce, skip_cl, skip_ct
-        )
-        if body is None:
-            payload = b""
-        elif PyBytes_Check(body) or PyByteArray_Check(body):
-            payload = body
+        cap = <int>len(nva)
+        if ex.headers is not None:
+            cap += <int>ex.headers._n
+        if cap < 8:
+            cap = 8
+        heap = 0
+        if cap <= 64:
+            nvs = nvs_stack
         else:
-            payload = bytes(body)
-        if payload:
-            ex._h2_pending = payload
-            ex._h2_pending_off = 0
-            ex._h2_body_done = True
-            prd.source.ptr = <void*>ex
-            prd.read_callback = _h2_data_source_read
-            rv = nghttp2_submit_response(
-                self.h2, ex._h2_stream_id, nvs, <size_t>nvlen, &prd
+            nvs = <nghttp2_nv*>malloc(sizeof(nghttp2_nv) * <size_t>cap)
+            if nvs == NULL:
+                self._close_error(500, "Internal Server Error")
+                return
+            heap = 1
+        try:
+            nvlen = self._h2_fill_nva(nva, nvs, <size_t>cap)
+            nvlen += self._h2_fill_user_nvs(
+                ex.headers, nvs + nvlen, cap - nvlen, skip_ce, skip_cl, skip_ct
             )
-        else:
-            ex._h2_body_done = True
-            rv = nghttp2_submit_response(
-                self.h2, ex._h2_stream_id, nvs, <size_t>nvlen, NULL
-            )
-        if rv != 0:
-            self._close_error(400, "Invalid HTTP request")
-            return
-        self._h2_send()
+            if body is None:
+                payload = b""
+            elif PyBytes_Check(body) or PyByteArray_Check(body):
+                payload = body
+            else:
+                payload = bytes(body)
+            if ex._head_request:
+                payload = b""
+            ex._h2_outbound = True
+            ex._h2_headers_sent = True
+            if payload:
+                ex._h2_pending = payload
+                ex._h2_pending_off = 0
+                ex._h2_body_done = True
+                prd.source.ptr = <void*>ex
+                prd.read_callback = _h2_data_source_read
+                rv = nghttp2_submit_response(
+                    self.h2, ex._h2_stream_id, nvs, <size_t>nvlen, &prd
+                )
+            else:
+                ex._h2_body_done = True
+                rv = nghttp2_submit_response(
+                    self.h2, ex._h2_stream_id, nvs, <size_t>nvlen, NULL
+                )
+            if rv != 0:
+                ex._h2_outbound = False
+                self._close_error(400, "Invalid HTTP request")
+                return
+            self._h2_send()
+        finally:
+            if heap:
+                free(nvs)
 
     def h2_write_headers(
         self,
@@ -2524,33 +2662,64 @@ cdef class HttpProtocol:
         bint skip_ct=False,
         bint skip_user=False,
     ):
-        cdef nghttp2_nv nvs[64]
+        cdef nghttp2_nv nvs_stack[64]
+        cdef nghttp2_nv* nvs
         cdef int nvlen
+        cdef int cap
+        cdef int heap
         cdef nghttp2_data_provider prd
         cdef int rv
         if self.h2 == NULL or ex is None:
             return
-        nvlen = self._h2_fill_nva(nva, nvs, 64)
-        if not skip_user:
-            nvlen += self._h2_fill_user_nvs(
-                ex.headers, nvs + nvlen, 64 - nvlen, skip_ce, skip_cl, skip_ct
-            )
-        if nva and nva[0][0] == b":status" and nva[0][1] == b"100":
-            nghttp2_submit_headers(
-                self.h2, NGHTTP2_FLAG_NONE, ex._h2_stream_id, NULL, nvs, <size_t>nvlen, NULL
-            )
+        cap = <int>len(nva)
+        if not skip_user and ex.headers is not None:
+            cap += <int>ex.headers._n
+        if cap < 8:
+            cap = 8
+        heap = 0
+        if cap <= 64:
+            nvs = nvs_stack
+        else:
+            nvs = <nghttp2_nv*>malloc(sizeof(nghttp2_nv) * <size_t>cap)
+            if nvs == NULL:
+                self._close_error(500, "Internal Server Error")
+                return
+            heap = 1
+        try:
+            nvlen = self._h2_fill_nva(nva, nvs, <size_t>cap)
+            if not skip_user:
+                nvlen += self._h2_fill_user_nvs(
+                    ex.headers, nvs + nvlen, cap - nvlen, skip_ce, skip_cl, skip_ct
+                )
+            if nva and nva[0][0] == b":status" and nva[0][1] == b"100":
+                nghttp2_submit_headers(
+                    self.h2, NGHTTP2_FLAG_NONE, ex._h2_stream_id, NULL, nvs, <size_t>nvlen, NULL
+                )
+                self._h2_send()
+                return
+            if ex._h2_headers_sent:
+                return
+            ex._h2_headers_sent = True
+            ex._h2_outbound = True
+            if ex._head_request:
+                ex._h2_body_done = True
+                rv = nghttp2_submit_response(
+                    self.h2, ex._h2_stream_id, nvs, <size_t>nvlen, NULL
+                )
+            else:
+                prd.source.ptr = <void*>ex
+                prd.read_callback = _h2_data_source_read
+                rv = nghttp2_submit_response(
+                    self.h2, ex._h2_stream_id, nvs, <size_t>nvlen, &prd
+                )
+            if rv != 0:
+                ex._h2_outbound = False
+                self._close_error(400, "Invalid HTTP request")
+                return
             self._h2_send()
-            return
-        if ex._h2_headers_sent:
-            return
-        ex._h2_headers_sent = True
-        prd.source.ptr = <void*>ex
-        prd.read_callback = _h2_data_source_read
-        rv = nghttp2_submit_response(self.h2, ex._h2_stream_id, nvs, <size_t>nvlen, &prd)
-        if rv != 0:
-            self._close_error(400, "Invalid HTTP request")
-            return
-        self._h2_send()
+        finally:
+            if heap:
+                free(nvs)
 
     cdef void _h2_pending_extend(self, RequestExchange ex, object data) noexcept:
         cdef object pending = ex._h2_pending
@@ -2602,7 +2771,7 @@ cdef class HttpProtocol:
         pending.extend(data)
 
     def h2_write_data(self, RequestExchange ex, object data, bint end):
-        if self.h2 == NULL or ex is None:
+        if self.h2 == NULL or ex is None or ex.in_pool:
             return
         if data:
             self._h2_pending_extend(ex, data)

--- a/tests/cython/test_h2.py
+++ b/tests/cython/test_h2.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from stario_cython.protocol import HttpProtocol
@@ -18,6 +19,7 @@ from stario.routing import UrlPath
 from tests.cython.h2wire import (
     FLAG_END_HEADERS,
     FLAG_END_STREAM,
+    H2_PREFACE,
     NGHTTP2_CANCEL,
     NGHTTP2_PROTOCOL_ERROR,
     SETTINGS_HEADER_TABLE_SIZE,
@@ -26,6 +28,7 @@ from tests.cython.h2wire import (
     TYPE_CONTINUATION,
     TYPE_DATA,
     TYPE_HEADERS,
+    TYPE_SETTINGS,
     collected_settings,
     encode_request,
     h2_handshake,
@@ -41,7 +44,7 @@ from tests.cython.h2wire import (
     stream_ended,
     stream_headers_blob,
 )
-from tests.cython.http import RecordingTransport, free_port, make_protocol
+from tests.cython.http import RecordingTransport, free_port, make_protocol, response_status
 
 
 async def _curl(*args: str) -> subprocess.CompletedProcess[str]:
@@ -1216,4 +1219,170 @@ async def test_h2_host_routing_normalizes_authority() -> None:
     finally:
         server.close()
         await server.wait_closed()
+        await app.drain_tasks()
+
+
+@pytest.mark.asyncio
+async def test_h2_coalesced_posts_keep_bodies_on_correct_streams() -> None:
+    app = App()
+    seen: list[bytes] = []
+
+    async def echo(c, w) -> None:
+        body = await c.req.body()
+        seen.append(body)
+        w.respond(body, b"text/plain; charset=utf-8", 200)
+
+    app.post("/", echo)
+    loop = asyncio.get_running_loop()
+    proto = make_protocol(loop, app)
+    transport = RecordingTransport(proto)
+    proto.connection_made(transport)
+    try:
+        proto.data_received(H2_PREFACE + pack_frame(TYPE_SETTINGS, 0, 0))
+        extra = [(b"content-length", b"3")]
+        proto.data_received(
+            pack_frame(
+                TYPE_HEADERS,
+                FLAG_END_HEADERS,
+                1,
+                encode_request(method="POST", extra=extra),
+            )
+            + pack_frame(TYPE_DATA, FLAG_END_STREAM, 1, b"aaa")
+            + pack_frame(
+                TYPE_HEADERS,
+                FLAG_END_HEADERS,
+                3,
+                encode_request(method="POST", extra=extra),
+            )
+            + pack_frame(TYPE_DATA, FLAG_END_STREAM, 3, b"bbb")
+        )
+        await app.drain_tasks()
+        frames, _rest = parse_frames(b"".join(transport.writes))
+        assert stream_data(frames, 1) == b"aaa"
+        assert stream_data(frames, 3) == b"bbb"
+        assert seen == [b"aaa", b"bbb"]
+    finally:
+        proto.connection_lost(None)
+        await app.drain_tasks()
+
+
+@pytest.mark.asyncio
+async def test_h2_head_omits_data_payload() -> None:
+    app = App()
+
+    async def hello(_c, w) -> None:
+        responses.text(w, "hello")
+
+    app.head("/", hello)
+    loop = asyncio.get_running_loop()
+    proto = make_protocol(loop, app)
+    transport = RecordingTransport(proto)
+    proto.connection_made(transport)
+    try:
+        proto.data_received(H2_PREFACE + pack_frame(TYPE_SETTINGS, 0, 0))
+        proto.data_received(
+            pack_frame(
+                TYPE_HEADERS,
+                FLAG_END_HEADERS | FLAG_END_STREAM,
+                1,
+                encode_request(method="HEAD", path="/"),
+            )
+        )
+        await app.drain_tasks()
+        frames, _rest = parse_frames(b"".join(transport.writes))
+        assert stream_data(frames, 1) == b""
+        assert stream_ended(frames, 1)
+        assert not has_rst(frames, 1)
+    finally:
+        proto.connection_lost(None)
+        await app.drain_tasks()
+
+
+@pytest.mark.asyncio
+async def test_tls_http11_alpn_does_not_sniff_h2_preface() -> None:
+    loop = asyncio.get_running_loop()
+    app = App()
+    proto = make_protocol(loop, app)
+
+    class _AlpnTransport(RecordingTransport):
+        def get_extra_info(self, name, default=None):
+            if name == "ssl_object":
+                return SimpleNamespace(selected_alpn_protocol=lambda: "http/1.1")
+            return default
+
+    transport = _AlpnTransport(proto)
+    proto.connection_made(transport)
+    try:
+        proto.data_received(H2_PREFACE)
+        await app.drain_tasks()
+        assert proto.parse_mode == 1
+        assert response_status(transport.writes) == 400
+    finally:
+        proto.connection_lost(None)
+        await app.drain_tasks()
+
+
+@pytest.mark.asyncio
+async def test_h2_skips_connection_specific_response_headers() -> None:
+    app = App()
+
+    async def hello(_c, w) -> None:
+        w.headers.set("connection", "close")
+        w.headers.set("keep-alive", "timeout=5")
+        responses.text(w, "ok")
+
+    app.get("/", hello)
+    loop = asyncio.get_running_loop()
+    proto = make_protocol(loop, app)
+    transport = RecordingTransport(proto)
+    proto.connection_made(transport)
+    try:
+        proto.data_received(H2_PREFACE + pack_frame(TYPE_SETTINGS, 0, 0))
+        proto.data_received(
+            pack_frame(
+                TYPE_HEADERS,
+                FLAG_END_HEADERS | FLAG_END_STREAM,
+                1,
+                encode_request(path="/"),
+            )
+        )
+        await app.drain_tasks()
+        frames, _rest = parse_frames(b"".join(transport.writes))
+        assert stream_data(frames, 1) == b"ok"
+        blob = stream_headers_blob(frames, 1)
+        assert b"keep-alive" not in blob
+        assert b"connection" not in blob
+    finally:
+        proto.connection_lost(None)
+        await app.drain_tasks()
+
+
+@pytest.mark.asyncio
+async def test_h2_authority_with_question_mark_is_rejected() -> None:
+    app = App()
+
+    async def boom(_c, w) -> None:
+        responses.text(w, "nope")
+
+    app.get("/", boom)
+    loop = asyncio.get_running_loop()
+    proto = make_protocol(loop, app)
+    transport = RecordingTransport(proto)
+    proto.connection_made(transport)
+    try:
+        proto.data_received(H2_PREFACE + pack_frame(TYPE_SETTINGS, 0, 0))
+        proto.data_received(
+            pack_frame(
+                TYPE_HEADERS,
+                FLAG_END_HEADERS | FLAG_END_STREAM,
+                1,
+                encode_request(path="/", authority="evil?.example.com"),
+            )
+        )
+        await app.drain_tasks()
+        frames, _rest = parse_frames(b"".join(transport.writes))
+        assert has_rst(frames, 1) or has_goaway(frames)
+        assert stream_data(frames, 1) != b"nope"
+    finally:
+        proto.connection_lost(None)
         await app.drain_tasks()

--- a/tests/cython/test_hardening.py
+++ b/tests/cython/test_hardening.py
@@ -1052,3 +1052,273 @@ async def test_trailing_slash_308_finishes_span_without_fail() -> None:
             if not transport.is_closing():
                 transport.close()
             await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_head_response_omits_body_and_keeps_pipeline_in_sync() -> None:
+    app = App()
+
+    async def hello(_c, w) -> None:
+        responses.text(w, "hello")
+
+    app.get("/", hello)
+    app.head("/", hello)
+    proto, app, transport = _attach(app)
+    try:
+        proto.data_received(
+            b"HEAD / HTTP/1.1\r\nHost: t\r\n\r\n"
+            b"GET / HTTP/1.1\r\nHost: t\r\n\r\n"
+        )
+        await _drain(app)
+        raw = b"".join(transport.writes)
+        parts = raw.split(b"\r\n\r\n")
+        assert response_statuses(transport.writes) == [200, 200]
+        assert b"content-length: 5" in parts[0]
+        assert parts[1].startswith(b"HTTP/1.1")
+        assert parts[-1] == b"hello"
+        assert b"helloHTTP/1.1" not in raw
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_close_error_does_not_splice_status_into_started_response() -> None:
+    app = App()
+    started = asyncio.get_running_loop().create_future()
+
+    async def hang(_c, w) -> None:
+        w.headers.set("content-type", "text/plain")
+        w.write_headers(200)
+        w.write(b"partial")
+        started.set_result(None)
+        await asyncio.Event().wait()
+
+    app.get("/", hang)
+    proto, app, transport = _attach(app)
+    try:
+        proto.data_received(
+            b"GET / HTTP/1.1\r\nHost: t\r\n\r\n"
+            b"GET / HTTP/2.0\r\nHost: t\r\n\r\n"
+        )
+        await asyncio.wait_for(started, timeout=1)
+        await _drain(app)
+        raw = b"".join(transport.writes)
+        assert response_status(transport.writes) == 200
+        assert b"HTTP/1.1 400" not in raw
+        assert b"partial" in raw
+        assert transport.is_closing()
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_unread_body_trickle_does_not_reset_idle_timeout() -> None:
+    app = App()
+
+    async def ignore_body(_c, w) -> None:
+        responses.text(w, "ok")
+
+    app.post("/", ignore_body)
+    proto, app, transport = _attach(
+        app=app, header_timeout=5.0, keep_alive_timeout=_TIMEOUT
+    )
+    try:
+        proto.data_received(
+            b"POST / HTTP/1.1\r\n"
+            b"Host: t\r\n"
+            b"Content-Length: 10\r\n"
+            b"Expect: 100-continue\r\n"
+            b"\r\n"
+        )
+        await _drain(app)
+        assert response_status(transport.writes) == 200
+        assert not transport.is_closing()
+        proto.data_received(b"x")
+        await asyncio.sleep(_WAIT)
+        assert transport.is_closing()
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_http11_missing_host_returns_400() -> None:
+    proto, app, transport = _attach()
+    try:
+        proto.data_received(b"GET / HTTP/1.1\r\n\r\n")
+        await _drain(app)
+        assert response_status(transport.writes) == 400
+        assert transport.is_closing()
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_duplicate_host_returns_400() -> None:
+    proto, app, transport = _attach()
+    try:
+        proto.data_received(
+            b"GET / HTTP/1.1\r\nHost: a.example\r\nHost: b.example\r\n\r\n"
+        )
+        await _drain(app)
+        assert response_status(transport.writes) == 400
+        assert transport.is_closing()
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"GET / HTTP/0.9\r\nHost: t\r\n\r\n",
+        b"GET / HTTP/2.0\r\nHost: t\r\n\r\n",
+    ],
+    ids=["http09", "http20"],
+)
+async def test_non_http11_version_on_h1_path_returns_400(payload: bytes) -> None:
+    proto, app, transport = _attach()
+    try:
+        proto.data_received(payload)
+        await _drain(app)
+        assert response_status(transport.writes) == 400
+        assert transport.is_closing()
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_respond_before_body_does_not_emit_100_continue() -> None:
+    app = App()
+
+    async def early(c, w) -> None:
+        responses.text(w, "early")
+        await c.req.body()
+
+    app.post("/", early)
+    proto, app, transport = _attach(app)
+    try:
+        proto.data_received(
+            b"POST / HTTP/1.1\r\n"
+            b"Host: t\r\n"
+            b"Content-Length: 5\r\n"
+            b"Expect: 100-continue\r\n"
+            b"\r\n"
+        )
+        await asyncio.sleep(0)
+        assert b"100 Continue" not in b"".join(transport.writes)
+        proto.data_received(b"hello")
+        await _drain(app)
+        assert response_statuses(transport.writes) == [200]
+        assert b"early" in b"".join(transport.writes)
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_oversize_headers_with_upgrade_are_single_400() -> None:
+    limit = 512
+    proto, app, transport = _attach(max_header_bytes=limit)
+    try:
+        pad = b"x" * (limit + 32)
+        proto.data_received(
+            b"GET / HTTP/1.1\r\n"
+            b"Host: t\r\n"
+            b"Connection: Upgrade\r\n"
+            b"Upgrade: websocket\r\n"
+            b"X-Pad: " + pad + b"\r\n\r\n"
+        )
+        await _drain(app)
+        assert response_statuses(transport.writes) == [400]
+        assert transport.is_closing()
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_host_with_question_mark_returns_400() -> None:
+    proto, app, transport = _attach()
+    try:
+        proto.data_received(b"GET / HTTP/1.1\r\nHost: evil?.example.com\r\n\r\n")
+        await _drain(app)
+        assert response_status(transport.writes) == 400
+        assert transport.is_closing()
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_trailing_slash_backslash_is_not_protocol_relative() -> None:
+    proto, app, transport = _attach()
+    try:
+        proto.data_received(b"GET /\\evil.test/ HTTP/1.1\r\nHost: t\r\n\r\n")
+        await _drain(app)
+        raw = b"".join(transport.writes).lower()
+        assert response_status(transport.writes) == 308
+        assert b"location: /evil.test" in raw
+        assert b"location: /\\evil.test" not in raw
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_mixed_case_transfer_encoding_is_rejected_by_respond() -> None:
+    app = App()
+
+    async def bad(_c, w) -> None:
+        w.headers.unsafe_set(b"Transfer-Encoding", b"chunked")
+        responses.text(w, "ok")
+
+    app.get("/", bad)
+    proto, app, transport = _attach(app)
+    try:
+        proto.data_received(b"GET / HTTP/1.1\r\nHost: t\r\n\r\n")
+        await _drain(app)
+        raw = b"".join(transport.writes).lower()
+        assert response_status(transport.writes) == 500
+        assert b"transfer-encoding: chunked" not in raw
+        assert b"ok" not in b"".join(transport.writes)
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)
+
+
+@pytest.mark.asyncio
+async def test_respond_rejects_crlf_in_content_type() -> None:
+    app = App()
+
+    async def bad(_c, w) -> None:
+        w.respond(b"x", b"text/plain\r\nX-Injected: 1")
+
+    app.get("/", bad)
+    proto, app, transport = _attach(app)
+    try:
+        proto.data_received(b"GET / HTTP/1.1\r\nHost: t\r\n\r\n")
+        await _drain(app)
+        raw = b"".join(transport.writes)
+        assert b"X-Injected" not in raw
+        assert response_status(transport.writes) == 500
+    finally:
+        if not transport.is_closing():
+            transport.close()
+        await _drain(app)

--- a/tests/cython/test_hardening.py
+++ b/tests/cython/test_hardening.py
@@ -1103,13 +1103,15 @@ async def test_close_error_does_not_splice_status_into_started_response() -> Non
             b"GET / HTTP/2.0\r\nHost: t\r\n\r\n"
         )
         await asyncio.wait_for(started, timeout=1)
-        await _drain(app)
         raw = b"".join(transport.writes)
         assert response_status(transport.writes) == 200
         assert b"HTTP/1.1 400" not in raw
         assert b"partial" in raw
         assert transport.is_closing()
     finally:
+        for task in list(app.tasks):
+            if not task.done():
+                task.cancel()
         if not transport.is_closing():
             transport.close()
         await _drain(app)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,11 @@ def test_request_policy_rejects_low_pipeline_cap() -> None:
         RequestPolicy(max_pipelined_requests=0)
 
 
+def test_request_policy_rejects_oversized_header_budget() -> None:
+    with pytest.raises(StarioError, match="2\\^31-1"):
+        RequestPolicy(max_header_bytes=2_147_483_648)
+
+
 def test_server_config_rejects_blank_unix_socket() -> None:
     with pytest.raises(StarioError, match="unix_socket must be a non-empty path"):
         ServerConfig(unix_socket="")

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 import pytest
 
 import stario.cookies as cookies
+from stario.exceptions import StarioError
 from stario.testing.harness import TestWriter
 
 
@@ -123,5 +124,23 @@ def test_samesite_none_sets_secure(explicit_secure: bool) -> None:
         combined = b";".join(lines).decode("latin-1").lower()
         assert "samesite=none" in combined
         assert "secure" in combined
+    finally:
+        loop.close()
+
+
+def test_set_cookie_rejects_semicolon_in_path() -> None:
+    w, loop = _writer()
+    try:
+        with pytest.raises(StarioError, match="Invalid cookie path"):
+            cookies.set_cookie(w, "sid", "v", path="/; HttpOnly")
+    finally:
+        loop.close()
+
+
+def test_set_cookie_rejects_comma_in_domain() -> None:
+    w, loop = _writer()
+    try:
+        with pytest.raises(StarioError, match="Invalid cookie domain"):
+            cookies.set_cookie(w, "sid", "v", domain="example.com, evil.test")
     finally:
         loop.close()

--- a/tests/test_datastar.py
+++ b/tests/test_datastar.py
@@ -252,6 +252,19 @@ class TestSseWireFormat:
         finally:
             loop.close()
 
+    def test_bare_cr_in_patch_elements_becomes_data_line(self):
+        w, sink, loop = _make_writer()
+        try:
+            SSE(w).patch_elements("<div>\revil")
+            result = _sse_body(w)
+            assert b"event: datastar-patch-elements\n" in result
+            assert b"\revil" not in result
+            assert b"data: elements <div>\n" in result
+            assert b"data: elements evil" in result
+            assert b"event: evil" not in result
+        finally:
+            loop.close()
+
     def test_patch_signals_rejects_raw_json_text(self):
         w, sink, loop = _make_writer()
         try:
@@ -355,6 +368,14 @@ class TestDatastarAttributeValidation:
     def test_bind_rejects_non_snake_signal_path_segment(self):
         with pytest.raises(StarioError, match="snake_case"):
             data.bind("crane.selectedCrane")
+
+    def test_attr_rejects_quote_breakout_key(self):
+        with pytest.raises(StarioError, match="Invalid attribute name"):
+            data.attr('x" onfocus="alert(1)', "$x")
+
+    def test_on_rejects_breakout_event_name(self):
+        with pytest.raises(StarioError, match="Invalid attribute name"):
+            data.on('click" onfocus="alert(1)', "go()")
 
     @pytest.mark.parametrize(
         "time",

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -340,6 +340,14 @@ class TestAttributeTypes:
         with pytest.raises(StarioError, match="Invalid CSS property name"):
             render(h.Div(styles({"x;background:red": "1"})))
 
+    def test_styles_helper_rejects_css_separators_in_values(self):
+        with pytest.raises(StarioError, match="Invalid CSS value"):
+            render(h.Div(styles({"color": "red;position:fixed"})))
+
+    def test_styles_helper_rejects_backslash_in_values(self):
+        with pytest.raises(StarioError, match="Invalid CSS value"):
+            render(h.Div(styles({"color": r"red\3b color:blue"})))
+
     def test_styles_helper_rejects_non_string_keys(self):
         with pytest.raises(StarioError, match="Invalid CSS property name type"):
             render(h.Div(styles(cast(Any, {1: "red"}))))

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,5 +1,7 @@
 """Unit tests for query string parsing."""
 
+import pytest
+
 from stario.http.query import ParsedQuery
 
 
@@ -17,6 +19,11 @@ def test_repeated_keys() -> None:
 
 def test_percent_decoding() -> None:
     assert ParsedQuery(b"q=100%25").get("q") == "100%"
+
+
+def test_nul_in_query_value_is_rejected() -> None:
+    with pytest.raises(ValueError, match="NUL"):
+        ParsedQuery(b"file=foo%00.txt").get("file")
 
 
 def test_blank_and_bare_keys() -> None:

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -79,6 +79,11 @@ class TestUrlPath:
 
         assert path.href(tenant="ACME", user_id="42") == "//acme.example.com/users/42"
 
+    def test_rejects_question_mark_in_host_parameter(self):
+        path = UrlPath("/dash", host="{tenant}.example.com")
+        with pytest.raises(StarioError, match="invalid character"):
+            path.href(tenant="evil?")
+
     def test_rejects_dot_in_host_wildcard(self):
         path = UrlPath("/users", host="{tenant}.example.com")
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Security audit of Stario’s HTTP/1 (llhttp) and HTTP/2 (nghttp2) paths plus the Python response/markup/Datastar layer. This PR **fixes issues that can desynchronize proxies, leak or swap request data, hold connections open, or inject into HTML/SSE/cookies**, and adds defensive tests (no exploit kits or attack scripts).

Audited in parallel across: Cython protocol/exchange/headers, routing/static/query, Datastar/markup/cookies, TLS/ALPN, and the chat-room example.

Local verification: `481 passed, 1 skipped` in `tests/cython` plus Datastar/cookies/markup/headers/query/urls/config/redirect/invoke, and `114 passed` in server/writer/app/header-writer suites.

## Fixed in this PR

### HTTP/1 — high

- **HEAD responses no longer include a body.** Content-Length still reflects the GET size; the body is omitted so pipelined GET stays in sync behind proxies.
- **`_close_error` no longer splices a 400/429 status line into an in-flight response.** If headers are already on the wire, the connection closes without a second status.
- **HTTP/1.1 requires a single Host.** Missing Host and duplicate Host are 400. Host/` :authority` values with `?`, `#`, `/`, `\`, `@`, or controls are rejected (stops `//{evil?}.example.com` origin breakout).
- **Non-HTTP/1 versions on the H1 path are 400** (`HTTP/0.9`, `HTTP/2.0`).
- **Upgrade / TE-without-chunked are checked before 431**, so oversize headers plus Upgrade is one 400/close, not 431 then 400.
- **`Expect: 100-continue` is not sent after `respond()` / `write_headers()`.**
- **Unread leftover bodies do not refresh the idle timer.** Trickled drain bytes cannot hold a keep-alive connection open.
- **Protocol errors on HEAD omit the error body** (same as success HEAD).
- **Trailing-slash 308 strips `\` as well as `/`**, so `GET /\evil.test/` is not a protocol-relative Location.
- **Incomplete-handler 500 strips `Transfer-Encoding`** so a rejected mixed-case TE cannot block the error response.

### HTTP/2 — high

- **Response header nvs use `NGHTTP2_NV_FLAG_NONE`.** nghttp2 copies at submit; deferred send no longer UAF’s Python `bytes`.
- **Exchange recycle is gated on `_h2_outbound`.** The stream stays mapped until `on_stream_close`, so two HEADERS in one `mem_recv` cannot swap DATA providers.
- **DATA callbacks refuse pooled / wrong-stream exchanges** (`NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE`).
- **`h2_write_data` is a no-op on pooled exchanges** (RST/`finally` cannot enqueue onto a recycled object).
- **RST/stream close cancels the in-flight handler** and recycles only after the task is done or the response completed.
- **Hop-by-hop response headers (`connection`, `keep-alive`, `proxy-connection`, `upgrade`) are not emitted on H2.**
- **More than 64 response headers use a heap `nghttp2_nv` array** (no silent drop of CSP / Set-Cookie).
- **TLS ALPN `http/1.1` is authoritative** — the cleartext H2 preface is not sniffed after `http/1.1`.
- **HEAD on H2 omits DATA.** Incomplete HEADERS and undispatched streams still hit the header timeout.
- **`:authority` / `host` with `?`/`#`/controls is RST PROTOCOL_ERROR.**

### DoS / resource

- **Content-Length preallocation is capped at 256 KiB** (no ×256 concurrent full-CL arenas).
- **`max_header_bytes` / `max_body_bytes` cannot exceed 2³¹−1** (Cython `int` storage).
- **`park()` drops `_h2_pending`** so RST mid-response does not stick a large buffer on the idle exchange.

### Python layer

- **SSE `patch_elements` / `patch_signals` split CR, LF, and CRLF** so a bare CR cannot inject a new `event:` line.
- **Datastar `attr` / `on` / `class_` / `style` / `bind` / `persist` keys go through `validate_attribute_key`.**
- **`styles()` rejects `;`, `{`, `}`, and `\` in values** (blocks CSS hex-escape injection).
- **`set_cookie` rejects `;` / `,` in path, domain, and expires;** `CookieError` becomes `StarioError`.
- **`respond()` validates `Content-Type` (no CR/LF)** and folds mixed-case `unsafe_set` names so `Transfer-Encoding` cannot bypass interned guards.
- **UrlPath host `href()` rejects `?`, `#`, `\`, and whitespace** in host parameters.

## Remaining (not fixed here)

These are real, but either need larger design work or are documented trust boundaries:

| Issue | Impact |
| --- | --- |
| HTTP/2 `_h2_pending` is unbounded; `_h2_send` ignores write backpressure | Memory DoS if a handler streams while the peer stalls the window |
| One H2 stream pausing the body pauses **TCP reads for the connection** | Head-of-line blocking / multiplexed DoS |
| No PING/SETTINGS ACK rate limit (RST is already rate-limited) | CPU/bandwidth DoS |
| Pooled `Request` / `RequestHeaders` are not generation-stamped | If an app retains `req` after the handler returns, the next request can overwrite it (cross-request header leak) |
| `normalized_location` allows `//host` by design | App footgun if user input is passed to `redirect()` without extra checks |
| `STARIO_CYTHON_TIMEOUTS=off` | Profiling hatch; disables header/idle/body-stall cleanup |
| No process-wide connection cap | Relies on OS / reverse proxy |
| Catchall `{path...}` still yields raw `..` | Apps that `os.path.join` catchall params onto a filesystem must normalize; static assets are dict-lookup only |
| Chat-room example: client-asserted identity, unauthenticated DELETE | Example app only |
| `SSE.execute_script` concatenates trusted JS | Documented; `navigate()` JSON-encodes the URL |

Already solid (spot-checked, not “rediscovered”): unmodified llhttp 9.2.1 with no lenient flags; duplicate CL / CL+TE / non-chunked TE rejected; H2 duplicate `:method`/`:path`/`:authority`, `:authority` vs Host mismatch, uppercase names, CONNECT, `:protocol` rejected; RST rate limit and `max_continuations`; push disabled; static assets served from the fingerprint manifest only.

## Tests

Defensive checks only (assert status, framing, and rejected values):

- HEAD + pipelined GET stay in sync; H2 HEAD has empty DATA
- `_close_error` during a started stream does not write a second status
- Unread body trickle does not reset idle timeout
- Missing/duplicate Host, `HTTP/0.9` / `HTTP/2.0` on H1, Host with `?`
- No `100 Continue` after `respond()`; 431+Upgrade is a single 400
- Two POSTs in one H2 `data_received` keep bodies on the correct streams
- ALPN `http/1.1` does not sniff the H2 preface
- SSE CR, Datastar attribute-name XSS, cookie path `;`, `styles()` `;`/`\`, query `%00`, host `href()` `?`

## How to verify

```bash
python setup.py
pytest tests/cython tests/test_datastar.py tests/test_cookies.py tests/test_markup.py tests/test_headers.py tests/test_query.py tests/test_urls.py tests/test_config.py
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3850873-b6c1-4789-b20f-e28cdfc5dd15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3850873-b6c1-4789-b20f-e28cdfc5dd15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

