### PR TITLE
Keep c.alive() on Context; put send-path closing on Writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - The HTTP protocol schedules `find_handler` then `create_task(handler(c, w))`
   instead of `create_task(app(c, w))`. Trailing-slash 308 is written inline in
   the Cython protocol (no handler task).
-- **`Writer.closing` removed.** Request lifetime (client gone or app draining)
-  is on `Context`: `c.alive()`, `c.disconnected`, `c.closing`. `Writer` is the
-  outbound HTTP message (`started` / `completed` / `write`), not the
-  connection. `w.write()` is already a no-op if the transport is gone.
+- **`Context.closing` removed.** `closing` is the send path, so it lives on
+  `Writer`: `w.closing` is true when further writes will not reach an
+  interested client (peer gone or app draining). It is not `w.completed`
+  (keep-alive can still be open after `end()`). Handler lifetime — cancel
+  this task, including work that is not a write — stays `c.alive()` /
+  `c.disconnected`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - The HTTP protocol schedules `find_handler` then `create_task(handler(c, w))`
   instead of `create_task(app(c, w))`. Trailing-slash 308 is written inline in
   the Cython protocol (no handler task).
+- **`Writer.closing` removed.** Request lifetime (client gone or app draining)
+  is on `Context`: `c.alive()`, `c.disconnected`, `c.closing`. `Writer` is the
+  outbound HTTP message (`started` / `completed` / `write`), not the
+  connection. `w.write()` is already a no-op if the transport is gone.
 
 ### Added
 

--- a/examples/hello-world/main.py
+++ b/examples/hello-world/main.py
@@ -16,7 +16,7 @@ from stario import App, AssetManifest, Context, Span, StaticAssets, UrlPath, Wri
 from stario.datastar import SSE, at, data, read_signals
 from stario.markup import html as h
 
-# Core: Context (request + span), Writer (transport), App (routes + assets).
+# Core: Context (request, span, lifetime), Writer (response), App (routes + assets).
 # `stario.markup.html` holds tag constructors; imported as `h` so names like telemetry `Span` stay unambiguous.
 
 # Cheap at import time: scan + fingerprint only. Serving (compression, caching)

--- a/examples/tiles/main.py
+++ b/examples/tiles/main.py
@@ -46,7 +46,7 @@ from stario.debug import debug_inspector
 from stario.markup import HtmlElement, baked, classes, styles
 from stario.markup import html as h
 
-# Stario apps center on: Context (per-request), Writer (transport), and plain Python
+# Stario apps center on: Context (per-request lifetime), Writer (response), and plain Python
 # instead of a template language. HTML tags live under `stario.markup.html`;
 # importing that catalog as `h` keeps tag names (`h.Div`, `h.Span`) separate from framework
 # symbols like telemetry `Span` (same name as <span>, different concept).

--- a/src/stario/exceptions.py
+++ b/src/stario/exceptions.py
@@ -144,8 +144,8 @@ class ClientDisconnected(Exception):
     The peer closed the connection while the request body was still being read.
 
     If the handler does not finish a response, the protocol logs the failure
-    and aborts. For long-lived responses (SSE, chunked), prefer polling
-    `c.disconnected` or using `c.alive()` instead of relying on this exception.
+    and aborts. For long-lived responses (SSE, chunked), prefer `c.alive()` or
+    polling `c.disconnected` / `c.closing` instead of relying on this exception.
     """
 
     def __init__(

--- a/src/stario/exceptions.py
+++ b/src/stario/exceptions.py
@@ -144,8 +144,9 @@ class ClientDisconnected(Exception):
     The peer closed the connection while the request body was still being read.
 
     If the handler does not finish a response, the protocol logs the failure
-    and aborts. For long-lived responses (SSE, chunked), prefer `c.alive()` or
-    polling `c.disconnected` / `c.closing` instead of relying on this exception.
+    and aborts. For long-lived responses (SSE, chunked), prefer `c.alive()`
+    (handler lifetime) or `w.closing` (stop sending) instead of relying on
+    this exception.
     """
 
     def __init__(

--- a/src/stario/http/__init__.py
+++ b/src/stario/http/__init__.py
@@ -5,8 +5,8 @@
 the matched handler as a task.
 
 **Message** — `Request` (on ``Context``) plus ``Writer`` for the outbound
-response. Client disconnect and ``alive()`` are on ``Context``, not
-``Writer``.
+response. ``Writer.closing`` is the send path; ``c.alive()`` is handler
+lifetime (client gone or app draining).
 
 **Process** — import submodules directly for embedding:
 

--- a/src/stario/http/__init__.py
+++ b/src/stario/http/__init__.py
@@ -4,7 +4,9 @@
 `App` subclasses it and tracks tasks. The protocol runs `find_handler` then
 the matched handler as a task.
 
-**Message** — `Request`, `Writer`, `Headers`, `ParsedQuery` for one HTTP exchange.
+**Message** — `Request` (on ``Context``) plus ``Writer`` for the outbound
+response. Client disconnect and ``alive()`` are on ``Context``, not
+``Writer``.
 
 **Process** — import submodules directly for embedding:
 

--- a/src/stario/http/context.py
+++ b/src/stario/http/context.py
@@ -35,7 +35,22 @@ EMPTY_ROUTE_MATCH = RouteMatch(pattern="", params=MappingProxyType({}))
 
 
 class Context(Protocol):
-    """Per-request bundle passed to every handler and middleware."""
+    """Per-request bundle: inbound request, app, span, and this request's lifetime.
+
+    Every handler is ``async def handler(c: Context, w: Writer)``. ``c`` is
+    everything about *this request still being live work*: what they asked
+    (``req``, ``route``), the process (``app``), observability (``span``),
+    request-scoped ``state``, and whether the handler should keep running.
+
+    ``c.alive()`` / ``c.disconnected`` / ``c.closing`` live here — not on
+    ``Writer`` — because they answer “should this handler still run?”, not
+    “what HTTP bytes am I sending?”. That includes the client leaving *and*
+    the app draining. Shutdown is already ``c.app``; the inbound body already
+    surfaces peer-gone as ``ClientDisconnected`` on ``c.req``. ``Writer`` is
+    the outbound message (``started`` / ``completed`` / ``write``). After
+    ``w.end()`` the response is complete even if keep-alive is still open;
+    ``w.write()`` is a no-op if the transport is already gone.
+    """
 
     app: App
     req: Request
@@ -45,12 +60,12 @@ class Context(Protocol):
 
     @property
     def disconnect(self) -> asyncio.Future[None]:
-        """Completes when the client closes this request's connection."""
+        """Completes when the client is gone from this request."""
         ...
 
     @property
     def disconnected(self) -> bool:
-        """``True`` when the client closed this request's connection."""
+        """``True`` when the client is gone from this request."""
         ...
 
     @property
@@ -73,13 +88,23 @@ class Context(Protocol):
         self,
         source: AsyncIterable[T] | None = None,
     ) -> _Alive[T] | _Alive[None]:
-        """Watch client disconnect and app shutdown; cancel this task when either happens."""
+        """Keep this handler running until the client leaves or the app drains.
+
+        ``async with c.alive():`` cancels the current task when either happens,
+        then swallows that cancellation so the block exits normally (code after
+        the ``async with`` still runs). ``async for item in c.alive(source):``
+        does the same around an async iterable.
+
+        This is handler lifetime, not a write method: a long-lived loop can
+        wait here without sending, and ``SSE(w)`` still only needs ``Writer``
+        for the bytes.
+        """
         ...
 
 
 @dataclass(slots=True)
 class _Alive[T]:
-    """Connection lifecycle helper bound to a request context."""
+    """Handler-lifetime helper bound to a request context."""
 
     c: Context
     source: AsyncIterable[T] | None = None

--- a/src/stario/http/context.py
+++ b/src/stario/http/context.py
@@ -35,21 +35,18 @@ EMPTY_ROUTE_MATCH = RouteMatch(pattern="", params=MappingProxyType({}))
 
 
 class Context(Protocol):
-    """Per-request bundle: inbound request, app, span, and this request's lifetime.
+    """Per-request bundle: inbound request, app, span, and handler lifetime.
 
     Every handler is ``async def handler(c: Context, w: Writer)``. ``c`` is
-    everything about *this request still being live work*: what they asked
-    (``req``, ``route``), the process (``app``), observability (``span``),
-    request-scoped ``state``, and whether the handler should keep running.
+    what they asked (``req``, ``route``), the process (``app``),
+    observability (``span``), request-scoped ``state``, and whether this
+    *task* should keep running.
 
-    ``c.alive()`` / ``c.disconnected`` / ``c.closing`` live here — not on
-    ``Writer`` — because they answer “should this handler still run?”, not
-    “what HTTP bytes am I sending?”. That includes the client leaving *and*
-    the app draining. Shutdown is already ``c.app``; the inbound body already
-    surfaces peer-gone as ``ClientDisconnected`` on ``c.req``. ``Writer`` is
-    the outbound message (``started`` / ``completed`` / ``write``). After
-    ``w.end()`` the response is complete even if keep-alive is still open;
-    ``w.write()`` is a no-op if the transport is already gone.
+    ``c.alive()`` lives here because it cancels the handler — including
+    work that is not a write — when the client leaves or the app drains.
+    ``Writer.closing`` is the send path: stop putting bytes on this
+    response. After ``w.end()`` the response is complete even if keep-alive
+    is still open; ``w.closing`` is not a synonym of ``completed``.
     """
 
     app: App
@@ -73,11 +70,6 @@ class Context(Protocol):
         """``True`` when the server is draining this app."""
         ...
 
-    @property
-    def closing(self) -> bool:
-        """``True`` when handler work should stop (client left or app draining)."""
-        ...
-
     @overload
     def alive(self, source: None = None) -> _Alive[None]: ...
 
@@ -95,9 +87,9 @@ class Context(Protocol):
         the ``async with`` still runs). ``async for item in c.alive(source):``
         does the same around an async iterable.
 
-        This is handler lifetime, not a write method: a long-lived loop can
-        wait here without sending, and ``SSE(w)`` still only needs ``Writer``
-        for the bytes.
+        This is handler lifetime, not send-path status. A long-lived loop
+        can wait here without sending. Whether further ``w.write()`` calls
+        are still worth issuing is ``w.closing``.
         """
         ...
 

--- a/src/stario/http/writer.py
+++ b/src/stario/http/writer.py
@@ -18,12 +18,16 @@ class Writer(Protocol):
     Set headers on ``headers``, then ``respond`` for a whole body or
     ``write_headers`` followed by ``write`` / ``end`` for streaming.
 
-    This is the outbound message, not the connection. Client disconnect and
-    process drain live on ``Context`` (``c.alive``, ``c.disconnected``,
-    ``c.closing``). ``started`` / ``completed`` say whether *this response*
-    has been sent, not whether the socket is still open. After ``end()`` the
-    response is done even if keep-alive is still open; ``write()`` is a
-    no-op if the transport is already gone.
+    ``started`` / ``completed`` are this *response*. ``closing`` is the
+    send path: the client is gone, or the app is draining, so further
+    writes will not reach an interested peer. After ``end()`` the
+    response is complete even if keep-alive is still open (``completed``
+    is true, ``closing`` is not). ``write()`` is a no-op if the
+    transport is already gone.
+
+    Waiting until the client leaves or the process drains is
+    ``c.alive()`` — that cancels the handler task, including work that
+    is not a write.
     """
 
     headers: Headers
@@ -41,6 +45,11 @@ class Writer(Protocol):
     @property
     def completed(self) -> bool:
         """``True`` after ``end`` / ``respond`` / ``abort`` finished the response."""
+        ...
+
+    @property
+    def closing(self) -> bool:
+        """``True`` when further writes will not reach an interested client."""
         ...
 
     def respond(self, body: bytes, content_type: bytes, status: int = 200) -> None:

--- a/src/stario/http/writer.py
+++ b/src/stario/http/writer.py
@@ -13,10 +13,17 @@ if TYPE_CHECKING:
 
 
 class Writer(Protocol):
-    """Low-level HTTP response for one request.
+    """HTTP response for one request: status, headers, and body.
 
     Set headers on ``headers``, then ``respond`` for a whole body or
     ``write_headers`` followed by ``write`` / ``end`` for streaming.
+
+    This is the outbound message, not the connection. Client disconnect and
+    process drain live on ``Context`` (``c.alive``, ``c.disconnected``,
+    ``c.closing``). ``started`` / ``completed`` say whether *this response*
+    has been sent, not whether the socket is still open. After ``end()`` the
+    response is done even if keep-alive is still open; ``write()`` is a
+    no-op if the transport is already gone.
     """
 
     headers: Headers
@@ -34,11 +41,6 @@ class Writer(Protocol):
     @property
     def completed(self) -> bool:
         """``True`` after ``end`` / ``respond`` / ``abort`` finished the response."""
-        ...
-
-    @property
-    def closing(self) -> bool:
-        """Whether the connection is closing or closed."""
         ...
 
     def respond(self, body: bytes, content_type: bytes, status: int = 200) -> None:

--- a/src/stario/staticassets.py
+++ b/src/stario/staticassets.py
@@ -665,7 +665,7 @@ class StaticAssets:
                 return
             w.write_headers(206)
             await self._write_file_range(
-                c, w, f.source, byte_range.start, byte_range.length
+                w, f.source, byte_range.start, byte_range.length
             )
             return
 
@@ -675,11 +675,10 @@ class StaticAssets:
             return
 
         w.write_headers(200)
-        await self._write_file_range(c, w, f.source, 0, f.size)
+        await self._write_file_range(w, f.source, 0, f.size)
 
     async def _write_file_range(
         self,
-        c: Context,
         w: Writer,
         path: Path,
         start: int,
@@ -694,7 +693,7 @@ class StaticAssets:
                 if not chunk:
                     break
                 remaining -= len(chunk)
-                if c.closing:
+                if w.closing:
                     return
                 w.write(chunk)
         w.end()

--- a/src/stario/staticassets.py
+++ b/src/stario/staticassets.py
@@ -665,7 +665,7 @@ class StaticAssets:
                 return
             w.write_headers(206)
             await self._write_file_range(
-                w, f.source, byte_range.start, byte_range.length
+                c, w, f.source, byte_range.start, byte_range.length
             )
             return
 
@@ -675,10 +675,11 @@ class StaticAssets:
             return
 
         w.write_headers(200)
-        await self._write_file_range(w, f.source, 0, f.size)
+        await self._write_file_range(c, w, f.source, 0, f.size)
 
     async def _write_file_range(
         self,
+        c: Context,
         w: Writer,
         path: Path,
         start: int,
@@ -693,7 +694,7 @@ class StaticAssets:
                 if not chunk:
                     break
                 remaining -= len(chunk)
-                if w.closing:
+                if c.closing:
                     return
                 w.write(chunk)
         w.end()

--- a/src/stario/testing/dispatch.py
+++ b/src/stario/testing/dispatch.py
@@ -53,7 +53,7 @@ def wire_dispatch(
         headers=phdrs,
         body=pbody,
     )
-    writer = TestWriter()
+    writer = TestWriter(disconnect=disconnect, shutdown=app.shutdown)
     ctx = TestContext(
         app=app,
         req=request,

--- a/src/stario/testing/dispatch.py
+++ b/src/stario/testing/dispatch.py
@@ -53,7 +53,7 @@ def wire_dispatch(
         headers=phdrs,
         body=pbody,
     )
-    writer = TestWriter(disconnect=disconnect)
+    writer = TestWriter()
     ctx = TestContext(
         app=app,
         req=request,

--- a/src/stario/testing/harness.py
+++ b/src/stario/testing/harness.py
@@ -107,11 +107,10 @@ class TestWriter:
 
     __test__ = False
 
-    def __init__(self, disconnect: asyncio.Future[None] | None = None) -> None:
+    def __init__(self) -> None:
         self.headers = Headers()
         self._status_code: int | None = None
         self._completed = False
-        self._disconnect = disconnect
         self._body = GrowingSink()
         self._headers_event = asyncio.Event()
 
@@ -126,12 +125,6 @@ class TestWriter:
     @property
     def completed(self) -> bool:
         return self._completed
-
-    @property
-    def closing(self) -> bool:
-        return self._completed or (
-            self._disconnect is not None and self._disconnect.done()
-        )
 
     @property
     def body(self) -> bytes:

--- a/src/stario/testing/harness.py
+++ b/src/stario/testing/harness.py
@@ -107,10 +107,16 @@ class TestWriter:
 
     __test__ = False
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        disconnect: asyncio.Future[None] | None = None,
+        shutdown: asyncio.Future[None] | None = None,
+    ) -> None:
         self.headers = Headers()
         self._status_code: int | None = None
         self._completed = False
+        self._disconnect = disconnect
+        self._shutdown = shutdown
         self._body = GrowingSink()
         self._headers_event = asyncio.Event()
 
@@ -125,6 +131,12 @@ class TestWriter:
     @property
     def completed(self) -> bool:
         return self._completed
+
+    @property
+    def closing(self) -> bool:
+        return (self._disconnect is not None and self._disconnect.done()) or (
+            self._shutdown is not None and self._shutdown.done()
+        )
 
     @property
     def body(self) -> bytes:
@@ -237,10 +249,6 @@ class TestContext:
     @property
     def shutting_down(self) -> bool:
         return self.app.shutting_down
-
-    @property
-    def closing(self) -> bool:
-        return self.disconnected or self.shutting_down
 
     def alive(
         self,

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -2953,6 +2953,7 @@ cdef class RequestExchange:
 
     @property
     def closing(self):
+        """Context: stop handler work (client gone or app draining)."""
         return self.disconnected or self.shutting_down
 
     def alive(self, source=None):

--- a/src/stario_cython/exchange.pyx
+++ b/src/stario_cython/exchange.pyx
@@ -2953,7 +2953,7 @@ cdef class RequestExchange:
 
     @property
     def closing(self):
-        """Context: stop handler work (client gone or app draining)."""
+        """Writer: further writes will not reach an interested client."""
         return self.disconnected or self.shutting_down
 
     def alive(self, source=None):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -79,6 +79,10 @@ class DummyWriter:
         self.ended = False
         self._completed = True
 
+    @property
+    def closing(self) -> bool:
+        return False
+
 
 def make_request(
     *,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -79,10 +79,6 @@ class DummyWriter:
         self.ended = False
         self._completed = True
 
-    @property
-    def closing(self) -> bool:
-        return self._completed
-
 
 def make_request(
     *,

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -354,10 +354,18 @@ class TestWriterRaw:
 
     async def test_context_closing_combines_disconnect_and_shutdown(self):
         loop = asyncio.get_running_loop()
-        context = _make_context(loop=loop)
+        disconnect = loop.create_future()
+        context = _make_context(loop=loop, disconnect=disconnect)
 
         assert not context.closing
 
+        disconnect.set_result(None)
+
+        assert context.disconnected
+        assert context.closing
+        assert not context.shutting_down
+
+        context = _make_context(loop=loop)
         context.app.shutdown.set_result(None)
 
         assert context.shutting_down
@@ -416,17 +424,6 @@ class TestWriterRaw:
         w.end()
         assert w.status_code == 204
         assert w.body == b""
-
-    def test_closing_follows_disconnect(self):
-        loop = asyncio.new_event_loop()
-        try:
-            disconnect = loop.create_future()
-            w = TestWriter(disconnect=disconnect)
-            assert not w.closing
-            disconnect.set_result(None)
-            assert w.closing
-        finally:
-            loop.close()
 
     def test_write_after_204_raises(self):
         w = TestWriter()

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -352,24 +352,22 @@ class TestWriterRaw:
         await asyncio.wait_for(stopped.wait(), timeout=0.1)
         await task
 
-    async def test_context_closing_combines_disconnect_and_shutdown(self):
+    async def test_context_disconnected_and_shutting_down_are_separate(self):
         loop = asyncio.get_running_loop()
         disconnect = loop.create_future()
         context = _make_context(loop=loop, disconnect=disconnect)
 
-        assert not context.closing
+        assert not context.disconnected
+        assert not context.shutting_down
 
         disconnect.set_result(None)
-
         assert context.disconnected
-        assert context.closing
         assert not context.shutting_down
 
         context = _make_context(loop=loop)
         context.app.shutdown.set_result(None)
-
         assert context.shutting_down
-        assert context.closing
+        assert not context.disconnected
 
     async def test_context_alive_does_not_swallow_unrelated_cancellation(self):
         loop = asyncio.get_running_loop()
@@ -424,6 +422,30 @@ class TestWriterRaw:
         w.end()
         assert w.status_code == 204
         assert w.body == b""
+        assert w.completed
+        assert not w.closing
+
+    def test_closing_follows_disconnect(self):
+        loop = asyncio.new_event_loop()
+        try:
+            disconnect = loop.create_future()
+            w = TestWriter(disconnect=disconnect)
+            assert not w.closing
+            disconnect.set_result(None)
+            assert w.closing
+        finally:
+            loop.close()
+
+    def test_closing_follows_shutdown(self):
+        loop = asyncio.new_event_loop()
+        try:
+            shutdown = loop.create_future()
+            w = TestWriter(shutdown=shutdown)
+            assert not w.closing
+            shutdown.set_result(None)
+            assert w.closing
+        finally:
+            loop.close()
 
     def test_write_after_204_raises(self):
         w = TestWriter()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Decision

Two different questions, two homes:

| Question | API |
| --- | --- |
| Should I still **send**? | `w.closing` |
| Has this **response** been sent? | `w.started` / `w.completed` |
| Should this **handler task** keep running (including work that is not a write)? | `c.alive()` / `c.disconnected` |

`c.alive()` stays on Context. `closing` lives on Writer, not Context.

## Why not put *everything* on Writer

Writer is the send path, so **send-path status belongs there**. That was the hole in the first cut, which moved `closing` onto Context and made Writer mute about the sink.

`alive()` is not send-path status. It cancels the current task when the client leaves **or** the app drains, then swallows that cancellation so cleanup after the `async with` still runs. You can (and tests do) `async with c.alive()` without writing. Shutdown is `c.app`, not a socket. The inbound body already surfaces peer-gone as `ClientDisconnected` on `c.req`.

So:

- **`w.closing`** — further writes will not reach an interested client (peer gone or app draining). Not a synonym of `completed`: after `end()` keep-alive can still be open.
- **`c.alive()`** — keep this *task* running until those same events, including loops that only wait.

File streaming checks `w.closing` (it is writing). SSE loops use `c.alive(live)` (they are waiting, then writing).

## What changed

- Restore `Writer.closing`
- Remove `Context.closing` so the word `closing` is only the send-path word
- StaticAssets file send uses `w.closing` again
- TestWriter.closing follows disconnect/shutdown, **not** `completed`

Production `RequestExchange` still has one `.closing` bit (disconnected or shutting_down). Untyped `c.closing` can still work by accident; the typed Context protocol no longer has it.

HTTP/2 RST_STREAM is still connection-level today. That is a signal bug (this request should complete disconnect), not a reason to hang `alive()` on Writer.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4fb5f0c-7854-48d9-afff-ebf98fb1a39c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4fb5f0c-7854-48d9-afff-ebf98fb1a39c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

