### PR TITLE
Stario-only HTTP bench across asyncio event loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## Unreleased
 
+### Added
+
+- `STARIO_LOOP` — besides `asyncio` and `uvloop`, accept `zuvloop`, `rloop`, `rsloop`, `uringcore`, and `winloop`. The server uses `<loop>.run()` when present, otherwise `new_event_loop()` / `EventLoopPolicy` with `asyncio.run`.
+- `benchmarks/loops/` — Stario-only HTTP suite across those loops (plaintext, JSON, params, validate).
+
 ## 4.1.1 - 2026-08-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -29,14 +29,16 @@ Stario is an asyncio-native HTTP stack: you write async handlers and register ro
 
 Python 3.14 or newer is required. The package tracks current Python and the standard library (including APIs the framework builds on) rather than supporting older runtimes.
 
-**uvloop (optional):** Stario defaults to the stdlib asyncio loop. For a faster event loop on Linux/macOS, install the optional extra and set `STARIO_LOOP=uvloop`:
+**Event loops (optional):** Stario defaults to the stdlib asyncio loop. Drop-in replacements are selected with `STARIO_LOOP` after installing the matching extra:
 
 ```bash
-uv add "stario[uvloop]"
-# or: pip install "stario[uvloop]"
+uv add "stario[uvloop]"      # MagicStack uvloop (libuv / Cython)
+uv add "stario[zuvloop]"     # Kludex zuvloop (libuv / Zig; Python 3.14+)
+uv add "stario[rloop]"       # rloop (Rust / mio; experimental, Unix)
+# also: stario[rsloop], stario[uringcore] (Linux io_uring), stario[winloop] (Windows)
 ```
 
-Then run with `STARIO_LOOP=uvloop stario serve main:bootstrap` (or `stario watch`). uvloop is not supported on Windows.
+Then run with `STARIO_LOOP=uvloop stario serve main:bootstrap` (or `zuvloop` / `rloop` / …). `uvloop`, `rloop`, and `uringcore` are not supported on Windows; `winloop` is Windows-only.
 
 ## Quick start
 
@@ -73,6 +75,7 @@ async def home(c: Context, w: Writer) -> None:
 
 
 HOME = Route.get("/")
+
 
 async def bootstrap(app: App, span: Span):
     span.attr("app.name", "example")

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,11 +1,14 @@
 # Stario benchmarks
 
-Two suites, one per layer we care about:
+Two suites, one per layer we care about, plus an event-loop comparison:
 
 - `html/` — HTML generation speed: stario against other Python renderers, plus
   microbenchmarks for stario's own hot paths.
 - `server/` — end-to-end HTTP throughput: the current Stario checkout against a
   few Python framework/server combinations under `wrk`.
+- `loops/` — Stario 4.1 against itself on the HTTP suite, swapping only the
+  asyncio event loop (`asyncio`, `uvloop`, `zuvloop`, `rloop`, and other
+  drop-in loops that install on the machine).
 
 The goal is repeatable local signal, not lab-grade numbers. Run on a quiet
 machine and compare repeated runs before drawing conclusions.
@@ -153,3 +156,17 @@ wrk.method = "POST"
 wrk.body = '{"name":"Ada","age":42}'
 wrk.headers["Content-Type"] = "application/json"
 ```
+
+## Event loop comparison (`loops/`)
+
+Same Stario checkout and the same four HTTP cases as `server/`, with only
+`STARIO_LOOP` changing. HTML benches are omitted — they do not go through an
+event loop.
+
+```bash
+benchmarks/loops/run.sh
+```
+
+Defaults match the server suite (`DURATION=10s`, `THREADS=2`, `CONNECTIONS=128`)
+plus `RUNS=3` measured samples after one warmup. Results land in
+`benchmarks/loops/results/` and include host/CPU/memory details.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -169,4 +169,6 @@ benchmarks/loops/run.sh
 
 Defaults match the server suite (`DURATION=10s`, `THREADS=2`, `CONNECTIONS=128`)
 plus `RUNS=3` measured samples after one warmup. Results land in
-`benchmarks/loops/results/` and include host/CPU/memory details.
+`benchmarks/loops/results/` and include host/CPU/memory details. A checked-in
+snapshot from this repo's cloud runner is in
+[`loops/RESULTS.md`](loops/RESULTS.md).

--- a/benchmarks/loops/README.md
+++ b/benchmarks/loops/README.md
@@ -19,6 +19,8 @@ Loops this harness tries:
 that does not install or fails to serve is recorded as skipped/failed; the rest
 of the suite still runs.
 
+**Results from this machine:** [RESULTS.md](RESULTS.md)
+
 ```bash
 benchmarks/loops/run.sh
 DURATION=30s RUNS=5 WARMUP=1 THREADS=2 CONNECTIONS=128 benchmarks/loops/run.sh

--- a/benchmarks/loops/README.md
+++ b/benchmarks/loops/README.md
@@ -1,0 +1,26 @@
+# Stario event-loop comparison
+
+Same Stario checkout (`stario` 4.1.x from this tree) and the same HTTP cases as
+`benchmarks/server/` (`/plaintext`, `/json`, `/user/42`, `POST /validate`).
+The only variable is the asyncio loop under `STARIO_LOOP`.
+
+Loops this harness tries:
+
+| Name | Implementation | Notes |
+| --- | --- | --- |
+| `asyncio` | CPython stdlib | Default; `SelectorEventLoop` on Linux |
+| `uvloop` | [MagicStack/uvloop](https://github.com/MagicStack/uvloop) | libuv / Cython; the usual production extra |
+| `zuvloop` | [Kludex/zuvloop](https://github.com/Kludex/zuvloop) | libuv / Zig; Python 3.14+ |
+| `rloop` | [gi0baro/rloop](https://github.com/gi0baro/rloop) | Rust / mio; experimental, Unix |
+| `rsloop` | [RustedBytes/rsloop](https://github.com/RustedBytes/rsloop) | Rust / io_uring on Linux |
+| `uringcore` | [ankitkpandey1/uringcore](https://github.com/ankitkpandey1/uringcore) | Linux io_uring |
+
+`winloop` is accepted by `STARIO_LOOP` but skipped here (Windows-only). A loop
+that does not install or fails to serve is recorded as skipped/failed; the rest
+of the suite still runs.
+
+```bash
+benchmarks/loops/run.sh
+DURATION=30s RUNS=5 WARMUP=1 THREADS=2 CONNECTIONS=128 benchmarks/loops/run.sh
+benchmarks/loops/run.sh asyncio uvloop zuvloop
+```

--- a/benchmarks/loops/RESULTS.md
+++ b/benchmarks/loops/RESULTS.md
@@ -1,0 +1,63 @@
+# Stario 4.1.1 × asyncio event loops
+
+Same Stario checkout, same HTTP app (`benchmarks/server/apps/stario_app.py`),
+same four cases as `benchmarks/server/`. Only `STARIO_LOOP` changes. HTML
+compare/micro are omitted — they never enter an event loop.
+
+Median requests/sec ± sample stdev. `wrk -t 2 -c 128 -d 10s`, 1 warmup + 3
+measured samples. No non-2xx or socket errors in any `wrk` run.
+
+| Loop | Plaintext | JSON | Params | Validate |
+| --- | ---: | ---: | ---: | ---: |
+| asyncio | 47,239 ± 1,219 | 51,822 ± 3,123 | 51,221 ± 1,509 | 47,632 ± 255 |
+| uvloop | 73,650 ± 261 | 71,568 ± 803 | 69,988 ± 1,224 | 55,698 ± 355 |
+| zuvloop | **84,234 ± 849** | **80,414 ± 802** | **77,365 ± 1,314** | **62,533 ± 1,702** |
+| rloop | 55,252 ± 4,749 | 51,855 ± 1,120 | 46,879 ± 1,551 | 39,758 ± 3,864 |
+| rsloop | 53,625 ± 1,655 | 47,575 ± 1,140 | 46,136 ± 468 | 37,686 ± 633 |
+| uringcore | skip | skip | skip | skip |
+
+Relative to stdlib asyncio (median rps):
+
+| Loop | Plaintext | JSON | Params | Validate |
+| --- | ---: | ---: | ---: | ---: |
+| asyncio | 1.00× | 1.00× | 1.00× | 1.00× |
+| uvloop | 1.56× | 1.38× | 1.37× | 1.17× |
+| zuvloop | 1.78× | 1.55× | 1.51× | 1.31× |
+| rloop | 1.17× | 1.00× | 0.92× | 0.83× |
+| rsloop | 1.14× | 0.92× | 0.90× | 0.79× |
+
+## Packages
+
+| Loop | Version | Implementation |
+| --- | --- | --- |
+| asyncio | stdlib | CPython `SelectorEventLoop` |
+| uvloop | 0.22.1 | libuv / Cython ([MagicStack/uvloop](https://github.com/MagicStack/uvloop)) |
+| zuvloop | 0.0.13 | libuv / Zig ([Kludex/zuvloop](https://github.com/Kludex/zuvloop)) |
+| rloop | 0.5.0 | Rust / mio ([gi0baro/rloop](https://github.com/gi0baro/rloop); experimental) |
+| rsloop | 0.1.46 | Rust / io_uring ([RustedBytes/rsloop](https://github.com/RustedBytes/rsloop)) |
+| uringcore | — | Did not install on CPython 3.14 (PyO3 max 3.13 in 0.9.1) |
+
+Also considered, not run here:
+
+- **winloop** — uvloop port for Windows; this host is Linux.
+- **uringcore** — Linux io_uring loop; current PyPI release does not build on 3.14.
+
+## Machine
+
+| | |
+| --- | --- |
+| Host | KVM guest, hostname `cursor` |
+| OS | Ubuntu 24.04.4 LTS (`6.12.94+`, x86_64, glibc 2.39) |
+| CPU | Intel Xeon Processor, 4 cores / 4 threads, 1 socket |
+| Memory | 16 GiB |
+| Python | CPython 3.14.7 (uv build, Clang 22.1.3) |
+| Client | wrk 4.1.0 (`debian/4.1.0-4build2`, epoll) |
+| Stario | 4.1.1 (`04ffa87`) |
+
+Raw run: `benchmarks/loops/results/20260901T161526Z/` (local; gitignored).
+
+Re-run:
+
+```bash
+benchmarks/loops/run.sh
+```

--- a/benchmarks/loops/run.sh
+++ b/benchmarks/loops/run.sh
@@ -1,0 +1,423 @@
+#!/usr/bin/env bash
+# Stario-only HTTP suite across asyncio-compatible event loops.
+set -euo pipefail
+
+export PATH="${HOME}/.local/bin:${PATH}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BENCHMARK_DIR="$ROOT/benchmarks/server"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENVS_DIR="$HERE/.venvs"
+RESULTS_DIR="$HERE/results"
+
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-3200}"
+DURATION="${DURATION:-10s}"
+THREADS="${THREADS:-2}"
+CONNECTIONS="${CONNECTIONS:-128}"
+RUNS="${RUNS:-3}"
+WARMUP="${WARMUP:-1}"
+PYTHON="${PYTHON:-3.14}"
+KEEP_RAW="${KEEP_RAW:-0}"
+WRK="${WRK:-wrk}"
+
+ENV_NAME=stario-loops
+ALL_LOOPS=(asyncio uvloop zuvloop rloop rsloop uringcore)
+LOOP_PACKAGES=(uvloop zuvloop rloop rsloop uringcore)
+ENDPOINTS=(plaintext json params validate)
+
+RUN_DIR=""
+SERVER_PID=""
+SERVER_PORT=""
+SELECTED_LOOPS=()
+
+usage() {
+  cat <<'EOF'
+Usage: benchmarks/loops/run.sh [asyncio|uvloop|zuvloop|rloop|rsloop|uringcore ...]
+
+Environment: DURATION=10s RUNS=3 WARMUP=1 THREADS=2 CONNECTIONS=128
+             HOST=127.0.0.1 PORT=3200 PYTHON=3.14 REFRESH_ENVS=1 KEEP_RAW=1
+EOF
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || { echo "Missing required command: $1" >&2; exit 1; }
+}
+
+python_bin() { echo "$ENVS_DIR/$ENV_NAME/bin/python"; }
+
+path_for() {
+  case "$1" in
+    plaintext) echo /plaintext ;;
+    json) echo /json ;;
+    params) echo /user/42 ;;
+    validate) echo /validate ;;
+  esac
+}
+
+format_int() {
+  local value="$1" out=""
+  while ((${#value} > 3)); do
+    out=",${value:${#value}-3:3}$out"
+    value="${value:0:${#value}-3}"
+  done
+  printf '%s%s' "$value" "$out"
+}
+
+loop_offset() {
+  local index=0 name
+  for name in "${ALL_LOOPS[@]}"; do
+    if [[ "$name" == "$1" ]]; then
+      echo "$index"
+      return 0
+    fi
+    index=$((index + 1))
+  done
+  return 1
+}
+
+port_for() {
+  echo $((PORT + $(loop_offset "$1")))
+}
+
+known_loop() {
+  loop_offset "$1" >/dev/null
+}
+
+require_port_free() {
+  local python="$1" port="$2"
+  if ! "$python" - "$HOST" "$port" <<'PY'
+import socket
+import sys
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+family = socket.AF_INET6 if ":" in host else socket.AF_INET
+with socket.socket(family, socket.SOCK_STREAM) as sock:
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind((host, port))
+PY
+  then
+    echo "Port $HOST:$port is already in use." >&2
+    exit 1
+  fi
+}
+
+ensure_env() {
+  local python
+  python="$(python_bin)"
+  [[ "${REFRESH_ENVS:-0}" == 1 ]] && rm -rf "$ENVS_DIR/$ENV_NAME"
+  if [[ ! -x "$python" ]]; then
+    uv venv "$ENVS_DIR/$ENV_NAME" --python "$PYTHON"
+    uv pip install --python "$python" "stario @ file://$ROOT" ujson
+  fi
+  local pkg
+  for pkg in "${LOOP_PACKAGES[@]}"; do
+    if ! "$python" -c "import $pkg" >/dev/null 2>&1; then
+      uv pip install --python "$python" "$pkg" && continue
+      echo "WARN: could not install $pkg; that loop will be skipped." >&2
+    fi
+  done
+}
+
+loop_available() {
+  local loop="$1" python
+  python="$(python_bin)"
+  if [[ "$loop" == asyncio ]]; then
+    return 0
+  fi
+  "$python" -c "import $loop" >/dev/null 2>&1
+}
+
+pkg_version() {
+  local name="$1" python
+  python="$(python_bin)"
+  if [[ "$name" == asyncio ]]; then
+    "$python" -c "import asyncio; print(getattr(asyncio, '__version__', 'stdlib'))"
+    return
+  fi
+  "$python" - <<PY
+import importlib.metadata as m
+try:
+    print(m.version("$name"))
+except m.PackageNotFoundError:
+    print("missing")
+PY
+}
+
+write_machine_info() {
+  local python out="$1"
+  python="$(python_bin)"
+  {
+    echo "=== machine ==="
+    hostnamectl 2>/dev/null || true
+    echo "hostname=$(hostname)"
+    echo "uname=$(uname -a)"
+    echo "os=$({ . /etc/os-release && echo "$PRETTY_NAME"; } 2>/dev/null || uname -s)"
+    echo "kernel=$(uname -r)"
+    echo "arch=$(uname -m)"
+    echo "cpu_model=$(awk -F: '/model name/ {gsub(/^ /,"",$2); print $2; exit}' /proc/cpuinfo)"
+    echo "cpu_count=$(nproc)"
+    echo "mem_kb=$(awk '/MemTotal/ {print $2}' /proc/meminfo)"
+    lscpu 2>/dev/null | awk '/^Architecture|^CPU\(s\)|^Model name|^Thread|^Core|^Socket|^Hypervisor|^Virtualization|^Flags/{print}'
+    echo
+    echo "=== python ==="
+    "$python" - <<'PY'
+import platform, sys
+print(f"executable={sys.executable}")
+print(f"version={sys.version.replace(chr(10), ' ')}")
+print(f"implementation={platform.python_implementation()}")
+print(f"platform={platform.platform()}")
+PY
+  } >>"$out"
+}
+
+stop_server() {
+  if [[ -n "${SERVER_PID:-}" ]] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    local deadline=$((SECONDS + 5))
+    while kill -0 "$SERVER_PID" >/dev/null 2>&1 && ((SECONDS < deadline)); do
+      sleep 0.1
+    done
+    if kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+      kill -9 "$SERVER_PID" >/dev/null 2>&1 || true
+    fi
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+  SERVER_PID=""
+}
+
+fail_log() {
+  echo "$1 Log: $2" >&2
+  sed -n '1,160p' "$2" >&2 || true
+}
+
+wait_ready() {
+  local url="http://$HOST:$SERVER_PORT/plaintext" deadline=$((SECONDS + 20)) log="$1"
+  until curl -fsS --max-time 1 "$url" >/dev/null 2>&1; do
+    if [[ -n "$SERVER_PID" ]] && ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+      fail_log "Server exited before it was ready." "$log"
+      return 1
+    fi
+    if ((SECONDS >= deadline)); then
+      fail_log "Server did not become ready at $url." "$log"
+      return 1
+    fi
+    sleep 0.1
+  done
+  return 0
+}
+
+start_server() {
+  local loop="$1" log="$RUN_DIR/$loop.server.log" python
+  python="$(python_bin)"
+  export STARIO_HOST="$HOST"
+  export STARIO_PORT="$SERVER_PORT"
+  export STARIO_LOOP="$loop"
+  export STARIO_TRACER=noop
+  export STARIO_COMPRESS_ZSTD_LEVEL=-1
+  export STARIO_COMPRESS_BROTLI_LEVEL=-1
+  export STARIO_COMPRESS_GZIP_LEVEL=-1
+  echo "+ STARIO_LOOP=$loop $python -m stario.cli serve apps.stario_app:bootstrap"
+  (cd "$ROOT" && exec env PYTHONPATH="$BENCHMARK_DIR" "$python" -m stario.cli serve apps.stario_app:bootstrap) >"$log" 2>&1 &
+  SERVER_PID="$!"
+  wait_ready "$log"
+}
+
+aggregate_samples() {
+  local samples_file="$1" stats_file="$2" python
+  python="$(python_bin)"
+  "$python" - "$samples_file" "$stats_file" <<'PY'
+import json, pathlib, statistics, sys
+
+samples_path, stats_path = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+samples = [float(line) for line in samples_path.read_text().splitlines() if line.strip()]
+if not samples:
+    raise SystemExit(f"no samples in {samples_path}")
+stats = {
+    "n": len(samples),
+    "median": statistics.median(samples),
+    "mean": statistics.fmean(samples),
+    "stdev": statistics.stdev(samples) if len(samples) > 1 else 0.0,
+    "min": min(samples),
+    "max": max(samples),
+    "samples": samples,
+}
+stats_path.write_text(json.dumps(stats) + "\n")
+PY
+}
+
+format_cell() {
+  local stats_file="$1" python
+  python="$(python_bin)"
+  "$python" - "$stats_file" <<'PY'
+import json, pathlib, sys
+
+stats = json.loads(pathlib.Path(sys.argv[1]).read_text())
+
+def fmt(value: float) -> str:
+    return f"{value:,.0f}"
+
+cell = fmt(stats["median"])
+if stats["n"] > 1:
+    cell += f" ± {fmt(stats['stdev'])}"
+print(cell)
+PY
+}
+
+run_endpoint() {
+  local loop="$1" endpoint="$2"
+  local url="http://$HOST:$SERVER_PORT$(path_for "$endpoint")"
+  local samples_file="$RUN_DIR/$loop.$endpoint.samples"
+  local stats_file="$RUN_DIR/$loop.$endpoint.stats.json"
+  local cmd=("$WRK" -t "$THREADS" -c "$CONNECTIONS" -d "$DURATION" --latency)
+  [[ "$endpoint" == validate ]] && cmd+=(-s "$BENCHMARK_DIR/validate.lua")
+  : >"$samples_file"
+  local total=$((RUNS + WARMUP)) run_idx sample raw_out
+  echo "  $endpoint ($CONNECTIONS conn, $RUNS measured + $WARMUP warmup)"
+  for ((run_idx = 1; run_idx <= total; run_idx++)); do
+    raw_out="$RUN_DIR/$loop.$endpoint.run${run_idx}.txt"
+    "${cmd[@]}" "$url" >"$raw_out"
+    sample="$(awk '/Requests\/sec:/ {print $2; exit}' "$raw_out")"
+    [[ -n "$sample" ]] || { echo "Failed to parse wrk output: $raw_out" >&2; return 1; }
+    if ((run_idx > WARMUP)); then
+      echo "$sample" >>"$samples_file"
+    fi
+    if [[ "$KEEP_RAW" != 1 ]]; then
+      rm -f "$raw_out"
+    fi
+  done
+  aggregate_samples "$samples_file" "$stats_file"
+}
+
+run_loop() {
+  local loop="$1" endpoint
+  echo
+  echo "== stario + $loop =="
+  if ! loop_available "$loop"; then
+    echo "  skip: package not importable"
+    echo "skip" >"$RUN_DIR/$loop.status"
+    return 0
+  fi
+  SERVER_PORT="$(port_for "$loop")"
+  require_port_free "$(python_bin)" "$SERVER_PORT"
+  echo "  port $SERVER_PORT version=$(pkg_version "$loop")"
+  if ! start_server "$loop"; then
+    echo "fail" >"$RUN_DIR/$loop.status"
+    stop_server
+    return 0
+  fi
+  echo "ok" >"$RUN_DIR/$loop.status"
+  for endpoint in "${ENDPOINTS[@]}"; do
+    if ! run_endpoint "$loop" "$endpoint"; then
+      echo "fail" >"$RUN_DIR/$loop.status"
+      break
+    fi
+  done
+  stop_server
+}
+
+print_summary() {
+    local table="$RUN_DIR/summary.md" loop endpoint stats_file status stario_ver
+    stario_ver="$("$(python_bin)" -c "import importlib.metadata as m; print(m.version('stario'))")"
+    : >"$table"
+    {
+    echo "## Stario event-loop comparison"
+    echo
+    echo "Stario ${stario_ver} only — same checkout, same four HTTP cases, different \`STARIO_LOOP\`."
+    echo "Median requests/sec ± sample stdev after discarding $WARMUP warmup run(s)"
+    echo "across $RUNS measured samples. wrk -t $THREADS -c $CONNECTIONS -d $DURATION."
+    echo
+    echo "| Loop | Plaintext | JSON | Params | Validate |"
+    echo "| --- | ---: | ---: | ---: | ---: |"
+    for loop in "${SELECTED_LOOPS[@]}"; do
+      status="$(cat "$RUN_DIR/$loop.status" 2>/dev/null || echo missing)"
+      printf '| %s ' "$loop"
+      if [[ "$status" != ok ]]; then
+        echo "| $status | $status | $status | $status |"
+        continue
+      fi
+      for endpoint in "${ENDPOINTS[@]}"; do
+        stats_file="$RUN_DIR/$loop.$endpoint.stats.json"
+        if [[ -f "$stats_file" ]]; then
+          printf '| %s ' "$(format_cell "$stats_file")"
+        else
+          printf '| - '
+        fi
+      done
+      echo "|"
+    done
+    echo
+    echo "### Loop packages"
+    echo
+    echo "| Loop | Version |"
+    echo "| --- | --- |"
+    for loop in "${SELECTED_LOOPS[@]}"; do
+      echo "| $loop | $(pkg_version "$loop") |"
+    done
+  } | tee "$table"
+}
+
+cleanup_raw_outputs() {
+  local loop endpoint
+  [[ "$KEEP_RAW" == 1 ]] && return 0
+  for loop in "${SELECTED_LOOPS[@]}"; do
+    [[ -f "$RUN_DIR/$loop.server.log" && "$(cat "$RUN_DIR/$loop.status" 2>/dev/null || true)" == ok ]] && rm -f "$RUN_DIR/$loop.server.log"
+    for endpoint in "${ENDPOINTS[@]}"; do
+      rm -f "$RUN_DIR/$loop.$endpoint.samples"
+    done
+  done
+}
+
+main() {
+  need uv; need curl; need "$WRK"
+  trap stop_server EXIT INT TERM
+
+  local selected=("$@") loop
+  if ((${#selected[@]} == 0)); then selected=("${ALL_LOOPS[@]}"); fi
+  case "${selected[0]}" in -h|--help|help) usage; exit 0 ;; esac
+  for loop in "${selected[@]}"; do
+    known_loop "$loop" || { echo "Unknown loop: $loop" >&2; usage >&2; exit 1; }
+  done
+  SELECTED_LOOPS=("${selected[@]}")
+
+  ensure_env
+
+  RUN_DIR="$RESULTS_DIR/$(date -u +%Y%m%dT%H%M%SZ)"
+  mkdir -p "$RUN_DIR"
+  cat >"$RUN_DIR/config.txt" <<EOF
+host=$HOST
+base_port=$PORT
+duration=$DURATION
+threads=$THREADS
+connections=$CONNECTIONS
+runs=$RUNS
+warmup=$WARMUP
+python=$PYTHON
+client=$WRK
+keep_raw=$KEEP_RAW
+payload_file=benchmarks/server/validate.lua
+stario_root=$ROOT
+stario_sha=$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)
+stario_version=$("$(python_bin)" -c "import importlib.metadata as m; print(m.version('stario'))")
+loops=${SELECTED_LOOPS[*]}
+EOF
+  write_machine_info "$RUN_DIR/config.txt"
+  {
+    echo
+    echo "=== loop versions ==="
+    for loop in "${SELECTED_LOOPS[@]}"; do
+      echo "$loop=$(pkg_version "$loop")"
+    done
+  } >>"$RUN_DIR/config.txt"
+
+  echo "Writing results to ${RUN_DIR#$ROOT/}"
+  for loop in "${SELECTED_LOOPS[@]}"; do run_loop "$loop"; done
+  echo
+  print_summary
+  cleanup_raw_outputs
+  echo
+  echo "Summary: ${RUN_DIR#$ROOT/}/summary.md"
+}
+
+main "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ Issues = "https://github.com/bobowski/stario/issues"
 
 [project.optional-dependencies]
 uvloop = ["uvloop>=0.21.0,<1"]
+zuvloop = ["zuvloop>=0.0.13"]
+rloop = ["rloop>=0.5.0"]
+rsloop = ["rsloop>=0.1.46"]
+uringcore = ["uringcore>=0.9.1"]
+winloop = ["winloop>=0.1.0"]
 
 [project.scripts]
 stario = "stario.cli.main:main"

--- a/src/stario/cli/help.py
+++ b/src/stario/cli/help.py
@@ -6,7 +6,7 @@ Server environment variables (Stario does not load .env files; use your shell or
 Listen:
   STARIO_HOST=127.0.0.1
   STARIO_PORT=8000
-  STARIO_LOOP=asyncio|uvloop
+  STARIO_LOOP=asyncio|uvloop|zuvloop|rloop|rsloop|uringcore|winloop
   STARIO_UNIX_SOCKET=          (empty = TCP)
   STARIO_UNIX_SOCKET_MODE=660  (octal; after bind on unix socket)
   STARIO_BACKLOG=2048

--- a/src/stario/http/config.py
+++ b/src/stario/http/config.py
@@ -35,7 +35,52 @@ DEFAULT_REUSE_ADDR = True
 DEFAULT_MAX_PIPELINED_REQUESTS = 8
 DEFAULT_EVENT_LOOP = "asyncio"
 
-type EventLoopKind = Literal["asyncio", "uvloop"]
+type EventLoopKind = Literal[
+    "asyncio",
+    "uvloop",
+    "zuvloop",
+    "rloop",
+    "rsloop",
+    "uringcore",
+    "winloop",
+]
+
+EVENT_LOOP_KIND_NAMES: tuple[EventLoopKind, ...] = (
+    "asyncio",
+    "uvloop",
+    "zuvloop",
+    "rloop",
+    "rsloop",
+    "uringcore",
+    "winloop",
+)
+
+
+def event_loop_choices_text() -> str:
+    """Quoted loop names for error messages (`'a', 'b', or 'c'`)."""
+    *rest, last = EVENT_LOOP_KIND_NAMES
+    quoted = ", ".join(f"'{name}'" for name in rest)
+    return f"{quoted}, or '{last}'"
+
+
+def parse_event_loop_kind(value: str) -> EventLoopKind:
+    """Parse a loop name; comparison is case-insensitive."""
+    match value.lower():
+        case (
+            "asyncio"
+            | "uvloop"
+            | "zuvloop"
+            | "rloop"
+            | "rsloop"
+            | "uringcore"
+            | "winloop"
+        ) as kind:
+            return kind
+        case _:
+            raise StarioError(
+                f"event_loop must be {event_loop_choices_text()}",
+                help_text="Set STARIO_LOOP or pass event_loop to ServerConfig.",
+            )
 
 
 class RequestPolicy:
@@ -199,12 +244,6 @@ class ServerConfig:
                 "host must be non-empty for TCP listen",
                 help_text="Set STARIO_HOST or pass a non-empty host to ServerConfig.",
             )
-        if event_loop not in ("asyncio", "uvloop"):
-            raise StarioError(
-                "event_loop must be 'asyncio' or 'uvloop'",
-                help_text="Set STARIO_LOOP or pass event_loop to ServerConfig.",
-            )
-
         self.host = host
         self.port = port
         self.unix_socket = unix_socket
@@ -216,17 +255,18 @@ class ServerConfig:
         self.graceful_shutdown_timeout = graceful_shutdown_timeout
         self.backlog = backlog
         self.reuse_addr = reuse_addr
-        self.event_loop: EventLoopKind = event_loop
+        self.event_loop: EventLoopKind = parse_event_loop_kind(event_loop)
 
 
 def _event_loop_from_env() -> EventLoopKind:
-    loop = env_str("STARIO_LOOP", DEFAULT_EVENT_LOOP).lower()
-    if loop not in ("asyncio", "uvloop"):
+    raw = env_str("STARIO_LOOP", DEFAULT_EVENT_LOOP)
+    try:
+        return parse_event_loop_kind(raw)
+    except StarioError as exc:
         raise StarioError(
-            "STARIO_LOOP must be 'asyncio' or 'uvloop'",
-            help_text="Set STARIO_LOOP to asyncio or uvloop.",
-        )
-    return loop
+            f"STARIO_LOOP must be {event_loop_choices_text()}",
+            help_text="Set STARIO_LOOP to a supported event loop name.",
+        ) from exc
 
 
 def server_config_from_env() -> ServerConfig:

--- a/src/stario/http/server.py
+++ b/src/stario/http/server.py
@@ -17,7 +17,7 @@ from contextlib import asynccontextmanager, contextmanager, suppress
 from datetime import UTC, datetime
 from email.utils import format_datetime
 from types import FrameType
-from typing import Any, Literal
+from typing import Any, cast
 
 from stario.exceptions import StarioError
 from stario.telemetry.core import Span, Tracer
@@ -29,7 +29,7 @@ from .bootstrap import (
     ShutdownTrigger,
     bootstrap_run,
 )
-from .config import ServerConfig
+from .config import EventLoopKind, ServerConfig
 from .protocol import HttpProtocol
 
 type SignalHandler = Callable[[int, FrameType | None], object]
@@ -43,30 +43,70 @@ _FORCE_CLOSE_CAP = 1.0
 # Yield to the event loop this many times while waiting for connection_made to register.
 _ACCEPT_REGISTER_YIELDS = 10
 
+_WINDOWS_UNSUPPORTED_LOOPS = frozenset({"uvloop", "rloop", "uringcore"})
 
-def resolve_loop_runner(event_loop: Literal["asyncio", "uvloop"]) -> LoopRun[Any]:
-    """Return `asyncio.run` or `uvloop.run` for the configured event loop."""
+
+def _run_with_loop_factory(
+    factory: Callable[[], asyncio.AbstractEventLoop],
+) -> LoopRun[Any]:
+    def run(coro: Coroutine[Any, Any, Any]) -> Any:
+        return asyncio.run(coro, loop_factory=factory)
+
+    return run
+
+
+def resolve_loop_runner(event_loop: EventLoopKind) -> LoopRun[Any]:
+    """Return a coroutine runner for the configured asyncio-compatible loop.
+
+    Prefers `<loop>.run()`, then `new_event_loop()` as `asyncio.run` loop
+    factory, then `EventLoopPolicy.new_event_loop`.
+    """
     if event_loop == "asyncio":
         return asyncio.run
-    if sys.platform == "win32":
+    if sys.platform == "win32" and event_loop in _WINDOWS_UNSUPPORTED_LOOPS:
         raise StarioError(
-            "uvloop is not supported on Windows",
+            f"{event_loop} is not supported on Windows",
+            help_text="Set event_loop to 'asyncio', 'zuvloop', 'rsloop', or 'winloop'.",
+        )
+    if event_loop == "winloop" and sys.platform != "win32":
+        raise StarioError(
+            "winloop is only supported on Windows",
+            help_text="Set event_loop='asyncio' in ServerConfig.",
+        )
+    if event_loop == "uringcore" and sys.platform != "linux":
+        raise StarioError(
+            "uringcore is only supported on Linux",
             help_text="Set event_loop='asyncio' in ServerConfig.",
         )
     try:
-        uvloop = importlib.import_module("uvloop")
+        module = importlib.import_module(event_loop)
     except ImportError as exc:
         raise StarioError(
-            "uvloop is not installed",
-            help_text="Install uvloop or set event_loop='asyncio' in ServerConfig.",
+            f"{event_loop} is not installed",
+            help_text=(
+                f"Install {event_loop} or set event_loop='asyncio' in ServerConfig."
+            ),
         ) from exc
-    run = getattr(uvloop, "run", None)
-    if run is None:
-        raise StarioError(
-            "uvloop does not expose run()",
-            help_text="Set event_loop='asyncio' in ServerConfig.",
+    run = getattr(module, "run", None)
+    if callable(run):
+        return cast(LoopRun[Any], run)
+    factory = getattr(module, "new_event_loop", None)
+    if callable(factory):
+        return _run_with_loop_factory(
+            cast(Callable[[], asyncio.AbstractEventLoop], factory)
         )
-    return run
+    policy_cls = getattr(module, "EventLoopPolicy", None)
+    if isinstance(policy_cls, type):
+        policy = policy_cls()
+        new_loop = getattr(policy, "new_event_loop", None)
+        if callable(new_loop):
+            return _run_with_loop_factory(
+                cast(Callable[[], asyncio.AbstractEventLoop], new_loop)
+            )
+    raise StarioError(
+        f"{event_loop} does not expose run(), new_event_loop(), or EventLoopPolicy",
+        help_text="Set event_loop='asyncio' in ServerConfig.",
+    )
 
 
 class Server:

--- a/tests/test_cli_env.py
+++ b/tests/test_cli_env.py
@@ -4,6 +4,7 @@ import pytest
 
 from stario.cli.env import server_config_from_env
 from stario.cli.errors import CliError
+from stario.http.config import EVENT_LOOP_KIND_NAMES, parse_event_loop_kind
 
 
 def test_server_config_from_env_reads_overrides(monkeypatch) -> None:
@@ -21,6 +22,13 @@ def test_server_config_from_env_reads_overrides(monkeypatch) -> None:
     assert config.unix_socket == "/tmp/stario.sock"
     assert config.graceful_shutdown_timeout == 12.5
     assert config.reuse_addr is False
+
+
+@pytest.mark.parametrize("loop", EVENT_LOOP_KIND_NAMES)
+def test_server_config_from_env_accepts_event_loops(monkeypatch, loop) -> None:
+    monkeypatch.setenv("STARIO_LOOP", loop)
+    assert server_config_from_env().event_loop == loop
+    assert parse_event_loop_kind(loop.upper()) == loop
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,3 +19,8 @@ def test_server_config_rejects_blank_unix_socket() -> None:
 def test_server_config_rejects_blank_tcp_host() -> None:
     with pytest.raises(StarioError, match="host must be non-empty"):
         ServerConfig(host="   ")
+
+
+def test_server_config_rejects_unknown_event_loop() -> None:
+    with pytest.raises(StarioError, match="event_loop must be"):
+        ServerConfig(event_loop="nope")  # type: ignore[arg-type]

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,0 +1,124 @@
+"""Tests for STARIO_LOOP resolution and third-party asyncio loop adapters."""
+
+import asyncio
+import sys
+import types
+from collections.abc import Coroutine
+from typing import Any
+
+import pytest
+
+from stario.exceptions import StarioError
+from stario.http.server import resolve_loop_runner
+
+
+def test_resolve_loop_runner_asyncio() -> None:
+    assert resolve_loop_runner("asyncio") is asyncio.run
+
+
+def test_resolve_loop_runner_uses_module_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(coro: Coroutine[Any, Any, Any]) -> Any:
+        return coro
+
+    monkeypatch.setattr(
+        "stario.http.server.importlib.import_module",
+        lambda name: types.SimpleNamespace(run=fake_run),
+    )
+    assert resolve_loop_runner("zuvloop") is fake_run
+
+
+def test_resolve_loop_runner_falls_back_to_new_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def factory() -> asyncio.AbstractEventLoop:
+        return asyncio.new_event_loop()
+
+    monkeypatch.setattr(
+        "stario.http.server.importlib.import_module",
+        lambda name: types.SimpleNamespace(new_event_loop=factory),
+    )
+    seen: dict[str, Any] = {}
+
+    def fake_asyncio_run(
+        coro: Coroutine[Any, Any, Any],
+        *,
+        loop_factory: Any = None,
+        **kwargs: Any,
+    ) -> str:
+        seen["factory"] = loop_factory
+        return "ok"
+
+    monkeypatch.setattr("stario.http.server.asyncio.run", fake_asyncio_run)
+    run = resolve_loop_runner("rloop")
+    assert run(None) == "ok"  # type: ignore[arg-type]
+    assert seen["factory"] is factory
+
+
+def test_resolve_loop_runner_falls_back_to_event_loop_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Policy:
+        def new_event_loop(self) -> asyncio.AbstractEventLoop:
+            return asyncio.new_event_loop()
+
+    monkeypatch.setattr(
+        "stario.http.server.importlib.import_module",
+        lambda name: types.SimpleNamespace(EventLoopPolicy=Policy),
+    )
+    seen: dict[str, Any] = {}
+
+    def fake_asyncio_run(
+        coro: Coroutine[Any, Any, Any],
+        *,
+        loop_factory: Any = None,
+        **kwargs: Any,
+    ) -> asyncio.AbstractEventLoop:
+        seen["factory"] = loop_factory
+        return loop_factory()
+
+    monkeypatch.setattr("stario.http.server.asyncio.run", fake_asyncio_run)
+    run = resolve_loop_runner("uringcore")
+    loop = run(None)  # type: ignore[arg-type]
+    assert isinstance(loop, asyncio.AbstractEventLoop)
+    loop.close()
+    assert callable(seen["factory"])
+
+
+def test_resolve_loop_runner_missing_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_import(name: str) -> Any:
+        raise ImportError(name)
+
+    monkeypatch.setattr("stario.http.server.importlib.import_module", fake_import)
+    with pytest.raises(StarioError, match="uvloop is not installed"):
+        resolve_loop_runner("uvloop")
+
+
+def test_resolve_loop_runner_missing_hooks(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "stario.http.server.importlib.import_module",
+        lambda name: types.SimpleNamespace(),
+    )
+    with pytest.raises(StarioError, match="does not expose"):
+        resolve_loop_runner("rloop")
+
+
+def test_resolve_loop_runner_rejects_uvloop_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("stario.http.server.sys.platform", "win32")
+    with pytest.raises(StarioError, match="uvloop is not supported on Windows"):
+        resolve_loop_runner("uvloop")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="winloop is the Windows extra")
+def test_resolve_loop_runner_rejects_winloop_on_posix() -> None:
+    with pytest.raises(StarioError, match="winloop is only supported on Windows"):
+        resolve_loop_runner("winloop")
+
+
+def test_resolve_loop_runner_rejects_uringcore_off_linux(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("stario.http.server.sys.platform", "darwin")
+    with pytest.raises(StarioError, match="uringcore is only supported on Linux"):
+        resolve_loop_runner("uringcore")

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,6 +1,7 @@
 """Tests for STARIO_LOOP resolution and third-party asyncio loop adapters."""
 
 import asyncio
+import importlib
 import sys
 import types
 from collections.abc import Coroutine
@@ -12,6 +13,18 @@ from stario.exceptions import StarioError
 from stario.http.server import resolve_loop_runner
 
 
+def _stub_loop_module(monkeypatch: pytest.MonkeyPatch, name: str, **attrs: Any) -> None:
+    real_import = importlib.import_module
+    stub = types.SimpleNamespace(**attrs)
+
+    def fake_import(module_name: str, package: str | None = None) -> Any:
+        if module_name == name:
+            return stub
+        return real_import(module_name, package)
+
+    monkeypatch.setattr("stario.http.server.importlib.import_module", fake_import)
+
+
 def test_resolve_loop_runner_asyncio() -> None:
     assert resolve_loop_runner("asyncio") is asyncio.run
 
@@ -20,10 +33,7 @@ def test_resolve_loop_runner_uses_module_run(monkeypatch: pytest.MonkeyPatch) ->
     def fake_run(coro: Coroutine[Any, Any, Any]) -> Any:
         return coro
 
-    monkeypatch.setattr(
-        "stario.http.server.importlib.import_module",
-        lambda name: types.SimpleNamespace(run=fake_run),
-    )
+    _stub_loop_module(monkeypatch, "zuvloop", run=fake_run)
     assert resolve_loop_runner("zuvloop") is fake_run
 
 
@@ -33,10 +43,7 @@ def test_resolve_loop_runner_falls_back_to_new_event_loop(
     def factory() -> asyncio.AbstractEventLoop:
         return asyncio.new_event_loop()
 
-    monkeypatch.setattr(
-        "stario.http.server.importlib.import_module",
-        lambda name: types.SimpleNamespace(new_event_loop=factory),
-    )
+    _stub_loop_module(monkeypatch, "rloop", new_event_loop=factory)
     seen: dict[str, Any] = {}
 
     def fake_asyncio_run(
@@ -61,10 +68,7 @@ def test_resolve_loop_runner_falls_back_to_event_loop_policy(
         def new_event_loop(self) -> asyncio.AbstractEventLoop:
             return asyncio.new_event_loop()
 
-    monkeypatch.setattr(
-        "stario.http.server.importlib.import_module",
-        lambda name: types.SimpleNamespace(EventLoopPolicy=Policy),
-    )
+    _stub_loop_module(monkeypatch, "uringcore", EventLoopPolicy=Policy)
     seen: dict[str, Any] = {}
 
     def fake_asyncio_run(
@@ -85,8 +89,10 @@ def test_resolve_loop_runner_falls_back_to_event_loop_policy(
 
 
 def test_resolve_loop_runner_missing_module(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_import(name: str) -> Any:
-        raise ImportError(name)
+    def fake_import(name: str, package: str | None = None) -> Any:
+        if name == "uvloop":
+            raise ImportError(name)
+        return importlib.import_module(name, package)
 
     monkeypatch.setattr("stario.http.server.importlib.import_module", fake_import)
     with pytest.raises(StarioError, match="uvloop is not installed"):
@@ -94,10 +100,7 @@ def test_resolve_loop_runner_missing_module(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_resolve_loop_runner_missing_hooks(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        "stario.http.server.importlib.import_module",
-        lambda name: types.SimpleNamespace(),
-    )
+    _stub_loop_module(monkeypatch, "rloop")
     with pytest.raises(StarioError, match="does not expose"):
         resolve_loop_runner("rloop")
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Compare **Stario 4.1.1** against itself on the existing HTTP suite (`/plaintext`, `/json`, `/user/42`, `POST /validate`), changing only the asyncio event loop.

## Results (this machine)

Median req/s ± stdev. `wrk -t 2 -c 128 -d 10s`, 1 warmup + 3 measured samples. No non-2xx or socket errors.

| Loop | Plaintext | JSON | Params | Validate |
| --- | ---: | ---: | ---: | ---: |
| asyncio | 47,239 ± 1,219 | 51,822 ± 3,123 | 51,221 ± 1,509 | 47,632 ± 255 |
| uvloop 0.22.1 | 73,650 ± 261 | 71,568 ± 803 | 69,988 ± 1,224 | 55,698 ± 355 |
| **zuvloop 0.0.13** | **84,234 ± 849** | **80,414 ± 802** | **77,365 ± 1,314** | **62,533 ± 1,702** |
| rloop 0.5.0 | 55,252 ± 4,749 | 51,855 ± 1,120 | 46,879 ± 1,551 | 39,758 ± 3,864 |
| rsloop 0.1.46 | 53,625 ± 1,655 | 47,575 ± 1,140 | 46,136 ± 468 | 37,686 ± 633 |
| uringcore | skip (no CPython 3.14 wheel; PyO3 max 3.13) | | | |

Relative to stdlib asyncio: zuvloop 1.78× / 1.55× / 1.51× / 1.31×; uvloop 1.56× / 1.38× / 1.37× / 1.17×. rloop and rsloop only beat asyncio on plaintext.

Full write-up: [`benchmarks/loops/RESULTS.md`](benchmarks/loops/RESULTS.md).

## Machine

- Ubuntu 24.04.4 LTS, kernel 6.12.94+, x86_64 KVM guest
- Intel Xeon Processor, 4 cores / 4 threads, 16 GiB RAM
- CPython 3.14.7 (uv, Clang 22.1.3)
- wrk 4.1.0

`winloop` was not run (Windows-only). HTML benches were not run (they do not use an event loop).

## Code

`STARIO_LOOP` now accepts `asyncio`, `uvloop`, `zuvloop`, `rloop`, `rsloop`, `uringcore`, and `winloop`. The server uses `<loop>.run()` when present, otherwise `new_event_loop()` / `EventLoopPolicy` with `asyncio.run`.

```bash
benchmarks/loops/run.sh
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c47ed00-8bf1-47b3-84c8-96d6b4f16d31?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c47ed00-8bf1-47b3-84c8-96d6b4f16d31&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

